### PR TITLE
fix: Correct placement of --init flag for Docker MCP server execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [UNRELEASED]
+
+- correct placement of --init flag for Docker MCP server execution
+
 ## [0.11.1]
 
 - using Aider's --env and --env-file options for Agent LLM providers

--- a/src/main/agent/mcp-client.ts
+++ b/src/main/agent/mcp-client.ts
@@ -88,12 +88,12 @@ export const initMcpClient = async (serverName: string, originalServerConfig: Mc
       if (!args.includes('--init')) {
         // Insert '--init' immediately after the 'run' subcommand
         args.splice(runSubcommandIndex + 1, 0, '--init');
-        logger.debug("Added '--init' flag after 'run' for docker command.");
+        logger.debug(`Added '--init' flag after 'run' for server ${serverName} docker command.`);
       }
     } else {
       // Log a warning if we couldn't confidently find the 'run' command
       // This might happen with unusual docker commands defined in the config
-      logger.warn("Could not find 'run' subcommand at the expected position in docker args. '--init' flag not added automatically.");
+      logger.warn(`Could not find 'run' subcommand at the expected position in docker args for server ${serverName} from config.`);
     }
   }
 

--- a/src/main/agent/mcp-client.ts
+++ b/src/main/agent/mcp-client.ts
@@ -66,10 +66,34 @@ export const initMcpClient = async (serverName: string, originalServerConfig: Mc
     args = ['/c', 'npx', ...args];
   }
 
-  // If command is 'docker', ensure '--init' is present so the container properly handles SIGINT and SIGTERM
+  // If command is 'docker', ensure '--init' is present after 'run'
+  // so the container properly handles SIGINT and SIGTERM
   if (command === 'docker') {
-    if (!args.includes('--init')) {
-      args = ['--init', ...args];
+    let runSubcommandIndex = -1;
+
+    // Find the index of 'run'. This handles both 'docker run' and 'docker container run'.
+    const runIndex = args.indexOf('run');
+
+    if (runIndex !== -1) {
+      // Verify it's likely the actual 'run' subcommand
+      // e.g., 'run' is the first arg, or it follows 'container'
+      if (runIndex === 0 || (runIndex === 1 && args[0] === 'container')) {
+        runSubcommandIndex = runIndex;
+      }
+    }
+
+    if (runSubcommandIndex !== -1) {
+      // Check if '--init' already exists anywhere in the arguments
+      // (Docker might tolerate duplicates, but it's cleaner not to add it if present)
+      if (!args.includes('--init')) {
+        // Insert '--init' immediately after the 'run' subcommand
+        args.splice(runSubcommandIndex + 1, 0, '--init');
+        logger.debug("Added '--init' flag after 'run' for docker command.");
+      }
+    } else {
+      // Log a warning if we couldn't confidently find the 'run' command
+      // This might happen with unusual docker commands defined in the config
+      logger.warn("Could not find 'run' subcommand at the expected position in docker args. '--init' flag not added automatically.");
     }
   }
 


### PR DESCRIPTION
### Description:

This PR corrects the automatic insertion of the `--init` flag when launching Docker-based MCP servers.

### Previous Behavior: 
The `--init` flag was incorrectly added before the run subcommand in the arguments array (e.g., `docker --init run ...`). This is not valid Docker syntax and caused command execution failures.

### New Behavior: 
The code now identifies the run subcommand (handling docker run and docker container run) and inserts the `--init` flag directly after it, if not already present. This generates the correct command (e.g., `docker run --init ...`), allowing the container to launch properly with an init process for better signal handling.

Adds logging about inserting `--init` flag to debug level.
