### PR TITLE
add /copy-context command pass-through to aider

### DIFF
--- a/src/renderer/src/components/PromptField.tsx
+++ b/src/renderer/src/components/PromptField.tsx
@@ -12,7 +12,7 @@ import { showErrorNotification } from '@/utils/notifications';
 import { ModeSelector } from '@/components/ModeSelector';
 
 const COMMANDS = ['/code', '/context', '/agent', '/ask', '/architect', '/add', '/model', '/read-only'];
-const CONFIRM_COMMANDS = ['/clear', '/web', '/undo', '/test', '/map-refresh', '/map', '/run', '/reasoning-effort', '/think-tokens'];
+const CONFIRM_COMMANDS = ['/clear', '/web', '/undo', '/test', '/map-refresh', '/map', '/run', '/reasoning-effort', '/think-tokens', '/copy-context'];
 
 const ANSWERS = ['y', 'n', 'a', 'd'];
 


### PR DESCRIPTION
This lets you type /copy-context into aider-desk, and it passes the command through to aider and copies the context to the clipboard. 

This is usually used when copying/pasting to a web chat interface as described at
https://aider.chat/docs/usage/copypaste.html

My first PR to this project - hopefully I didn't miss anything here! :)

Implements #73 
