### PR TITLE
implement reset command

### DIFF
--- a/resources/connector/connector.py
+++ b/resources/connector/connector.py
@@ -686,6 +686,10 @@ class Connector:
         self.thinking_tokens = None
       await asyncio.sleep(0.1)
       await self.send_current_models()
+    elif command.startswith("/reset"):
+      await self.send_update_context_files()
+      await self.send_autocompletion()
+      await self.send_tokens_info()
 
   async def send_autocompletion(self):
     try:

--- a/src/main/project.ts
+++ b/src/main/project.ts
@@ -623,6 +623,12 @@ export class Project {
     }
 
     logger.info('Running command:', { command });
+
+    if (command.trim() === 'reset') {
+      this.sessionManager.clearMessages();
+      this.mainWindow.webContents.send('clear-project', this.baseDir, true, false);
+    }
+
     if (addToHistory) {
       void this.addToInputHistory(`/${command}`);
     }

--- a/src/renderer/src/components/PromptField.tsx
+++ b/src/renderer/src/components/PromptField.tsx
@@ -12,7 +12,20 @@ import { showErrorNotification } from '@/utils/notifications';
 import { ModeSelector } from '@/components/ModeSelector';
 
 const COMMANDS = ['/code', '/context', '/agent', '/ask', '/architect', '/add', '/model', '/read-only'];
-const CONFIRM_COMMANDS = ['/clear', '/web', '/undo', '/test', '/map-refresh', '/map', '/run', '/reasoning-effort', '/think-tokens', '/copy-context', '/tokens'];
+const CONFIRM_COMMANDS = [
+  '/clear',
+  '/web',
+  '/undo',
+  '/test',
+  '/map-refresh',
+  '/map',
+  '/run',
+  '/reasoning-effort',
+  '/think-tokens',
+  '/copy-context',
+  '/tokens',
+  '/reset',
+];
 
 const ANSWERS = ['y', 'n', 'a', 'd'];
 


### PR DESCRIPTION
Not so sure about this, but I wanted to at least send something concrete for discussion.

There have been several issues (#65 and #85 ) posted about being able to drop files, and specifically about dropping _all_ files. So it seems like implementing /reset would be a straightforward way to accomplish this.

So the idea in this PR to implement the /reset command, to a) clear the messages, and b) drop all files from context.

Two things - 

1. The code does indeed work, and updates the file list and the new token bar in the lower right, but it somehow "feels" gross, like we're adding special-case code to somewhere it doesn't belong. That said, better options weren't entirely obvious, so I thought you might be able to either a) agree this is the way to do it, or b) point me in a better direction.

2. As has been mentioned (#84 ), dropping a lot of files at once in Aider seems to be _very_ slow. I tried adding most of the files in the aider-desk repo, then reset, and the Aider python process went to 100% for like a minute or so getting this done. It did work in the end - but there wasn't feedback about it. Not sure that's really our problem here, but I wanted to mention it...

Thanks!