### PR TITLE
Add popup menu for command history

### DIFF
--- a/src/renderer/src/components/InputHistoryMenu.tsx
+++ b/src/renderer/src/components/InputHistoryMenu.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useRef } from 'react';
+import { useClickOutside } from '@/hooks/useClickOutside';
+
+interface Props {
+  items: string[];
+  highlightedIndex: number;
+  setHighlightedIndex: (index: number) => void;
+  onSelect: (item: string) => void;
+  onClose: () => void;
+}
+
+export const InputHistoryMenu = ({
+  items,
+  highlightedIndex,
+  setHighlightedIndex,
+  onSelect,
+  onClose,
+}: Props) => {
+  const menuRef = useRef<HTMLDivElement>(null);
+  useClickOutside(menuRef, onClose);
+
+  useEffect(() => {
+    if (menuRef.current) {
+      menuRef.current.scrollTop = menuRef.current.scrollHeight;
+    }
+  }, []);
+
+  return (
+    <div
+      ref={menuRef}
+      className="absolute bottom-full mb-1 bg-neutral-900 border border-neutral-700 rounded-md shadow-lg z-10 max-h-48 overflow-y-auto scrollbar-thin scrollbar-track-neutral-800 scrollbar-thumb-neutral-700 hover:scrollbar-thumb-neutral-600"
+    >
+      {items.map((item, index) => (
+        <div
+          key={index}
+          ref={index === highlightedIndex ? (el) => el?.scrollIntoView({ block: 'nearest' }) : null}
+          className={`px-3 py-1 text-left text-xs cursor-pointer hover:bg-neutral-700 ${index === highlightedIndex ? 'bg-neutral-700' : ''}`}
+          onMouseEnter={() => setHighlightedIndex(index)}
+          onClick={() => onSelect(item)}
+        >
+          {item}
+        </div>
+      ))}
+    </div>
+  );
+};
+


### PR DESCRIPTION
Adds a popup menu when you press the up arrow, showing your most recent commands. You can move up and down with the arrows, or scroll with the mouse. Selecting an item copies it into the prompt field, but does _not_ auto-submit.

- add InputHistoryMenu component for command history
- show popup menu instead of cycling history with arrow keys
- menu initially scrolled to bottom, and keeps selection visible

Screenshot:

<img width="1045" alt="image" src="https://github.com/user-attachments/assets/484a1972-6b74-4077-85d6-14c555851067" />

Addresses #121, I believe.