### PR TITLE
Minor bug fix - update the listener being removed

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -304,7 +304,7 @@ const api: ApplicationAPI = {
   removeInputHistoryUpdatedListener: (listenerId) => {
     const callback = inputHistoryUpdatedListeners[listenerId];
     if (callback) {
-      ipcRenderer.removeListener('tool', callback);
+      ipcRenderer.removeListener('input-history-updated', callback);
       delete inputHistoryUpdatedListeners[listenerId];
     }
   },


### PR DESCRIPTION
Fixes a minor bug where input history listeners were removed from the wrong IPC event - looks like a copy/paste typo.

Updated removeInputHistoryUpdatedListener in src/preload/index.ts to detach the listener from the correct "input-history-updated" event
