### PR TITLE
fix: prevent cmd window popups on Windows

### DIFF
--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -14,7 +14,7 @@ export const RESOURCES_DIR = is.dev ? path.join(__dirname, '..', '..', 'resource
 export const LOGS_DIR = path.join(AIDER_DESK_DIR, 'logs');
 export const SETUP_COMPLETE_FILENAME = path.join(AIDER_DESK_DIR, 'setup-complete');
 export const PYTHON_VENV_DIR = path.join(AIDER_DESK_DIR, 'python-venv');
-export const PYTHON_COMMAND = process.platform === 'win32' ? path.join(PYTHON_VENV_DIR, 'Scripts', 'pythonw.exe') : path.join(PYTHON_VENV_DIR, 'bin', 'python');
+export const PYTHON_COMMAND = process.platform === 'win32' ? path.join(PYTHON_VENV_DIR, 'Scripts', 'python.exe') : path.join(PYTHON_VENV_DIR, 'bin', 'python');
 export const AIDER_DESK_CONNECTOR_DIR = path.join(AIDER_DESK_DIR, 'aider-connector');
 export const AIDER_DESK_MCP_SERVER_DIR = path.join(AIDER_DESK_DIR, 'mcp-server');
 export const SERVER_PORT = process.env.AIDER_DESK_PORT ? parseInt(process.env.AIDER_DESK_PORT) : 24337;


### PR DESCRIPTION
## Problem

  On Windows, terminal windows briefly appear and steal focus periodically when
  AiderDesk is running. This happens because:

  1. pythonw.exe was being used instead of python.exe for Python operations
  2. pythonw.exe is the "windowless" Python executable intended for GUI applications that don't need a console, where as python.exe is the standard console Python executable that properly handles CLI operations without spawning additional windows
  3. This causes Windows to spawn visible console windows when running pip commands

  ## Solution

  This PR fixes the issue by:

  Changing PYTHON_COMMAND to use python.exe instead of pythonw.exe on Windows

 ## Testing

  - Launch AiderDesk on Windows
  - Keep it running for at least 10-15 minutes to verify no terminal windows pop up periodically
  - Test creating a new project to ensure the setup process doesn't show terminal windows
  - Verify that Aider functionality still works correctly

  This change is Windows-specific (the constant already uses the correct Python binary on other platforms), so it
  shouldn't affect Linux or macOS users.