### PR TITLE
feat: add includeContext to custom commands

### DIFF
--- a/docs/custom-commands.md
+++ b/docs/custom-commands.md
@@ -44,6 +44,7 @@ Any line starting with `!` will be treated as a shell command.
 *   `arguments` (array of objects, optional): An array defining the expected arguments for the command. Each argument object can have:
     *   `description` (string, **required**): A description of what the argument represents.
     *   `required` (boolean, optional): Set to `true` if the argument is mandatory, `false` otherwise. Defaults to `true`.
+*   `includeContext` (boolean, optional): Determines whether the current conversation context (chat history and context files) should be included when the command is run. Defaults to `true`. If set to `false`, the agent will receive an empty list of messages. This is useful for commands that should operate independently of the current chat session.
 
 ### Command Template:
 
@@ -113,3 +114,19 @@ To use it, you could type:
 *   `/generate-commit` (for the entire staged diff)
 *   `/generate-commit HEAD~1` (for the diff from the previous commit)
 *   `/generate-commit src/main/project.ts` (for changes in a specific file)
+
+### Example 3: Command without Context
+
+This command will list files in the root of the project, without including the current chat history or context files.
+
+Create a file named `~/.aider-desk/commands/list-root.md`:
+
+```markdown
+---
+description: Lists files in the project root directory, ignoring current context.
+includeContext: false
+---
+!ls -la ./
+```
+
+To use it, type `/list-root` in the prompt field and press Enter. The agent will only receive the `!ls -la ./` instruction and no prior conversation.

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -388,4 +388,5 @@ export interface CustomCommand {
   description: string;
   arguments: CustomCommandArgument[];
   template: string;
+  includeContext?: boolean;
 }

--- a/src/main/custom-commands/custom-command-manager.ts
+++ b/src/main/custom-commands/custom-command-manager.ts
@@ -114,7 +114,14 @@ export class CustomCommandManager {
       const name = path.basename(filePath, '.md');
       const args = Array.isArray(parsed.arguments) ? parsed.arguments : [];
       const template = parsed.__content?.trim() || '';
-      commands.set(name, { name, description: parsed.description || 'Not specified', arguments: args, template });
+      const includeContext = typeof parsed.includeContext === 'boolean' ? parsed.includeContext : true;
+      commands.set(name, {
+        name,
+        description: parsed.description || 'Not specified',
+        arguments: args,
+        template,
+        includeContext,
+      });
     } catch (err) {
       logger.error(`Failed to parse command file ${filePath}: ${err}`);
       // Optionally: send error to chat window via IPC or callback

--- a/src/main/project/project.ts
+++ b/src/main/project/project.ts
@@ -1645,6 +1645,7 @@ export class Project {
     this.addUserMessage(prompt, 'agent');
     this.addLogMessage('loading');
 
-    await this.runAgent(profile, prompt, systemPrompt);
+    const messages = command.includeContext === false ? [] : undefined;
+    await this.agent.runAgent(this, profile, prompt, messages, undefined, systemPrompt);
   }
 }


### PR DESCRIPTION
Adds an optional `includeContext` property to custom commands.

- If `includeContext` is set to `false` in a custom command's front matter, the agent will receive an empty list of messages (i.e., no chat history or context files will be passed).
- Defaults to `true` if not specified.
- Updated documentation to reflect this new feature.