### PR TITLE
fix: improve API key handling and error messages in agent mode

### DIFF
--- a/src/main/models/providers/cerebras.ts
+++ b/src/main/models/providers/cerebras.ts
@@ -95,9 +95,17 @@ export const getCerebrasAiderMapping = (provider: ProviderProfile, modelId: stri
 };
 
 // === LLM Creation Functions ===
-export const createCerebrasLlm = (profile: ProviderProfile, model: Model, env: Record<string, string | undefined> = {}): LanguageModelV2 => {
+export const createCerebrasLlm = (profile: ProviderProfile, model: Model, settings: SettingsData, projectDir: string): LanguageModelV2 => {
   const provider = profile.provider as CerebrasProvider;
-  const apiKey = provider.apiKey || env['CEREBRAS_API_KEY'];
+  let apiKey = provider.apiKey;
+
+  if (!apiKey) {
+    const effectiveVar = getEffectiveEnvironmentVariable('CEREBRAS_API_KEY', settings, projectDir);
+    if (effectiveVar) {
+      apiKey = effectiveVar.value;
+      logger.debug(`Loaded CEREBRAS_API_KEY from ${effectiveVar.source}`);
+    }
+  }
 
   if (!apiKey) {
     throw new Error('Cerebras API key is required in Providers settings or Aider environment variables (CEREBRAS_API_KEY)');

--- a/src/main/models/providers/deepseek.ts
+++ b/src/main/models/providers/deepseek.ts
@@ -76,9 +76,17 @@ export const getDeepseekAiderMapping = (provider: ProviderProfile, modelId: stri
 };
 
 // === LLM Creation Functions ===
-export const createDeepseekLlm = (profile: ProviderProfile, model: Model, env: Record<string, string | undefined> = {}): LanguageModelV2 => {
+export const createDeepseekLlm = (profile: ProviderProfile, model: Model, settings: SettingsData, projectDir: string): LanguageModelV2 => {
   const provider = profile.provider as DeepseekProvider;
-  const apiKey = provider.apiKey || env['DEEPSEEK_API_KEY'];
+  let apiKey = provider.apiKey;
+
+  if (!apiKey) {
+    const effectiveVar = getEffectiveEnvironmentVariable('DEEPSEEK_API_KEY', settings, projectDir);
+    if (effectiveVar) {
+      apiKey = effectiveVar.value;
+      logger.debug(`Loaded DEEPSEEK_API_KEY from ${effectiveVar.source}`);
+    }
+  }
 
   if (!apiKey) {
     throw new Error('Deepseek API key is required in Providers settings or Aider environment variables (DEEPSEEK_API_KEY)');

--- a/src/main/models/providers/groq.ts
+++ b/src/main/models/providers/groq.ts
@@ -92,9 +92,17 @@ export const getGroqAiderMapping = (provider: ProviderProfile, modelId: string):
 };
 
 // === LLM Creation Functions ===
-export const createGroqLlm = (profile: ProviderProfile, model: Model, env: Record<string, string | undefined> = {}): LanguageModelV2 => {
+export const createGroqLlm = (profile: ProviderProfile, model: Model, settings: SettingsData, projectDir: string): LanguageModelV2 => {
   const provider = profile.provider as GroqProvider;
-  const apiKey = provider.apiKey || env['GROQ_API_KEY'];
+  let apiKey = provider.apiKey;
+
+  if (!apiKey) {
+    const effectiveVar = getEffectiveEnvironmentVariable('GROQ_API_KEY', settings, projectDir);
+    if (effectiveVar) {
+      apiKey = effectiveVar.value;
+      logger.debug(`Loaded GROQ_API_KEY from ${effectiveVar.source}`);
+    }
+  }
 
   if (!apiKey) {
     throw new Error('Groq API key is required in Providers settings or Aider environment variables (GROQ_API_KEY)');

--- a/src/main/models/providers/lm-studio.ts
+++ b/src/main/models/providers/lm-studio.ts
@@ -82,9 +82,17 @@ export const getLmStudioAiderMapping = (provider: ProviderProfile, modelId: stri
 };
 
 // === LLM Creation Functions ===
-export const createLmStudioLlm = (profile: ProviderProfile, model: Model, env: Record<string, string | undefined> = {}): LanguageModelV2 => {
+export const createLmStudioLlm = (profile: ProviderProfile, model: Model, settings: SettingsData, projectDir: string): LanguageModelV2 => {
   const provider = profile.provider as LmStudioProvider;
-  const baseUrl = provider.baseUrl || env['LMSTUDIO_API_BASE'];
+  let baseUrl = provider.baseUrl;
+
+  if (!baseUrl) {
+    const effectiveVar = getEffectiveEnvironmentVariable('LMSTUDIO_API_BASE', settings, projectDir);
+    if (effectiveVar) {
+      baseUrl = effectiveVar.value;
+      logger.debug(`Loaded LMSTUDIO_API_BASE from ${effectiveVar.source}`);
+    }
+  }
 
   if (!baseUrl) {
     throw new Error('Base URL is required for LMStudio provider. Set it in Providers settings or via the LMSTUDIO_API_BASE environment variable.');

--- a/src/main/models/providers/ollama.ts
+++ b/src/main/models/providers/ollama.ts
@@ -81,9 +81,17 @@ export const getOllamaAiderMapping = (provider: ProviderProfile, modelId: string
 };
 
 // === LLM Creation Functions ===
-export const createOllamaLlm = (profile: ProviderProfile, model: Model, env: Record<string, string | undefined> = {}): LanguageModelV2 => {
+export const createOllamaLlm = (profile: ProviderProfile, model: Model, settings: SettingsData, projectDir: string): LanguageModelV2 => {
   const provider = profile.provider as OllamaProvider;
-  const baseUrl = provider.baseUrl || env['OLLAMA_API_BASE'];
+  let baseUrl = provider.baseUrl;
+
+  if (!baseUrl) {
+    const effectiveVar = getEffectiveEnvironmentVariable('OLLAMA_API_BASE', settings, projectDir);
+    if (effectiveVar) {
+      baseUrl = effectiveVar.value;
+      logger.debug(`Loaded OLLAMA_API_BASE from ${effectiveVar.source}`);
+    }
+  }
 
   if (!baseUrl) {
     throw new Error('Base URL is required for Ollama provider. Set it in Providers settings or via the OLLAMA_API_BASE environment variable.');

--- a/src/main/models/providers/openai-compatible.ts
+++ b/src/main/models/providers/openai-compatible.ts
@@ -88,13 +88,31 @@ export const getOpenAiCompatibleAiderMapping = (provider: ProviderProfile, model
 };
 
 // === LLM Creation Functions ===
-export const createOpenAiCompatibleLlm = (profile: ProviderProfile, model: Model, env: Record<string, string | undefined> = {}): LanguageModelV2 => {
+export const createOpenAiCompatibleLlm = (profile: ProviderProfile, model: Model, settings: SettingsData, projectDir: string): LanguageModelV2 => {
   const provider = profile.provider as OpenAiCompatibleProvider;
-  const apiKey = provider.apiKey || env['OPENAI_API_KEY'];
+  let apiKey = provider.apiKey;
+  let baseUrl = provider.baseUrl;
+
+  if (!apiKey) {
+    const effectiveVar = getEffectiveEnvironmentVariable('OPENAI_API_KEY', settings, projectDir);
+    if (effectiveVar) {
+      apiKey = effectiveVar.value;
+      logger.debug(`Loaded OPENAI_API_KEY from ${effectiveVar.source}`);
+    }
+  }
+
   if (!apiKey) {
     throw new Error(`API key is required for ${provider.name}. Check Providers settings or Aider environment variables (OPENAI_API_KEY).`);
   }
-  const baseUrl = provider.baseUrl || env['OPENAI_API_BASE'];
+
+  if (!baseUrl) {
+    const effectiveVar = getEffectiveEnvironmentVariable('OPENAI_API_BASE', settings, projectDir);
+    if (effectiveVar) {
+      baseUrl = effectiveVar.value;
+      logger.debug(`Loaded OPENAI_API_BASE from ${effectiveVar.source}`);
+    }
+  }
+
   if (!baseUrl) {
     throw new Error(`Base URL is required for ${provider.name} provider. Set it in Providers settings or via the OPENAI_API_BASE environment variable.`);
   }

--- a/src/main/models/providers/openai.ts
+++ b/src/main/models/providers/openai.ts
@@ -102,9 +102,17 @@ export const getOpenAiAiderMapping = (provider: ProviderProfile, modelId: string
 };
 
 // === LLM Creation Functions ===
-export const createOpenAiLlm = (profile: ProviderProfile, model: Model, env: Record<string, string | undefined> = {}): LanguageModelV2 => {
+export const createOpenAiLlm = (profile: ProviderProfile, model: Model, settings: SettingsData, projectDir: string): LanguageModelV2 => {
   const provider = profile.provider as OpenAiProvider;
-  const apiKey = provider.apiKey || env['OPENAI_API_KEY'];
+  let apiKey = provider.apiKey;
+
+  if (!apiKey) {
+    const effectiveVar = getEffectiveEnvironmentVariable('OPENAI_API_KEY', settings, projectDir);
+    if (effectiveVar) {
+      apiKey = effectiveVar.value;
+      logger.debug(`Loaded OPENAI_API_KEY from ${effectiveVar.source}`);
+    }
+  }
 
   if (!apiKey) {
     throw new Error('OpenAI API key is required in Providers settings or Aider environment variables (OPENAI_API_KEY)');

--- a/src/main/models/providers/openrouter.ts
+++ b/src/main/models/providers/openrouter.ts
@@ -111,9 +111,17 @@ export const getOpenRouterAiderMapping = (provider: ProviderProfile, modelId: st
 };
 
 // === LLM Creation Functions ===
-export const createOpenRouterLlm = (profile: ProviderProfile, model: Model, env: Record<string, string | undefined> = {}): LanguageModelV2 => {
+export const createOpenRouterLlm = (profile: ProviderProfile, model: Model, settings: SettingsData, projectDir: string): LanguageModelV2 => {
   const provider = profile.provider as OpenRouterProvider;
-  const apiKey = provider.apiKey || env['OPENROUTER_API_KEY'];
+  let apiKey = provider.apiKey;
+
+  if (!apiKey) {
+    const effectiveVar = getEffectiveEnvironmentVariable('OPENROUTER_API_KEY', settings, projectDir);
+    if (effectiveVar) {
+      apiKey = effectiveVar.value;
+      logger.debug(`Loaded OPENROUTER_API_KEY from ${effectiveVar.source}`);
+    }
+  }
 
   if (!apiKey) {
     throw new Error('OpenRouter API key is required in Providers settings or Aider environment variables (OPENROUTER_API_KEY)');

--- a/src/main/models/providers/requesty.ts
+++ b/src/main/models/providers/requesty.ts
@@ -107,9 +107,17 @@ export const getRequestyAiderMapping = (provider: ProviderProfile, modelId: stri
 };
 
 // === LLM Creation Functions ===
-export const createRequestyLlm = (profile: ProviderProfile, model: Model, env: Record<string, string | undefined> = {}): LanguageModelV2 => {
+export const createRequestyLlm = (profile: ProviderProfile, model: Model, settings: SettingsData, projectDir: string): LanguageModelV2 => {
   const provider = profile.provider as RequestyProvider;
-  const apiKey = provider.apiKey || env['REQUESTY_API_KEY'];
+  let apiKey = provider.apiKey;
+
+  if (!apiKey) {
+    const effectiveVar = getEffectiveEnvironmentVariable('REQUESTY_API_KEY', settings, projectDir);
+    if (effectiveVar) {
+      apiKey = effectiveVar.value;
+      logger.debug(`Loaded REQUESTY_API_KEY from ${effectiveVar.source}`);
+    }
+  }
 
   if (!apiKey) {
     throw new Error('Requesty API key is required in Providers settings or Aider environment variables (REQUESTY_API_KEY)');

--- a/src/main/models/providers/zai-plan.ts
+++ b/src/main/models/providers/zai-plan.ts
@@ -78,9 +78,18 @@ const getZaiPlanAiderMapping = (provider: ProviderProfile, modelId: string): Aid
 };
 
 // === LLM Creation Functions ===
-const createZaiPlanLlm = (profile: ProviderProfile, model: Model, env: Record<string, string | undefined> = {}): LanguageModelV2 => {
+const createZaiPlanLlm = (profile: ProviderProfile, model: Model, settings: SettingsData, projectDir: string): LanguageModelV2 => {
   const provider = profile.provider as ZaiPlanProvider;
-  const apiKey = provider.apiKey || env['ZAI_API_KEY'];
+  let apiKey = provider.apiKey;
+
+  if (!apiKey) {
+    const effectiveVar = getEffectiveEnvironmentVariable('ZAI_API_KEY', settings, projectDir);
+    if (effectiveVar) {
+      apiKey = effectiveVar.value;
+      logger.debug(`Loaded ZAI_API_KEY from ${effectiveVar.source}`);
+    }
+  }
+
   if (!apiKey) {
     throw new Error(`API key is required for ${provider.name}. Check Providers settings or Aider environment variables (ZAI_API_KEY).`);
   }

--- a/src/main/models/types.ts
+++ b/src/main/models/types.ts
@@ -32,8 +32,9 @@ export interface LlmProviderStrategy {
   // === LLM Creation and Usage Functions ===
   /**
    * Creates a LanguageModel instance for the given provider and model
+   * Each provider is responsible for loading its own credentials using getEffectiveEnvironmentVariable
    */
-  createLlm: (profile: ProviderProfile, model: Model, env: Record<string, string | undefined>) => LanguageModelV2;
+  createLlm: (profile: ProviderProfile, model: Model, settings: SettingsData, projectDir: string) => LanguageModelV2;
 
   /**
    * Generates usage reports with provider-specific metadata and calculates cost internally


### PR DESCRIPTION
## Motivation
I hade some issues when using `.aider.conf.yaml` in agent mode. When I switched to agent mode and tried to send a prompt I just received an error:

`Anthropic API key is required in Providers settings or Aider environment variables (ANTHROPIC_API_KEY). Configure credentials in the Settings -> Providers.`

## Claude 4.5 Summary of Changes

1. **Added support for api-key property in `.aider.conf.yml`** (`environment.ts`)
   - Added `readApiKeyFromConfFile()` function that parses the api-key property
   - Handles both single string format: `api-key: gemini=<key>`
   - Handles array format: `api-key: [gemini=<key>, openai=<key>]`
   - Maps provider names correctly (e.g., GOOGLE_API_KEY → gemini)
   - Integrated into the precedence order at steps 5 and 9

2. **Updated agent.ts to use `getEffectiveEnvironmentVariable`**
   - Replaced manual `.env` file loading with `getEffectiveEnvironmentVariable`
   - Now properly loads API keys from all 11 sources including `.aider.conf.yml` files
   - Added proper TypeScript typing for the environment object
   - Removed the cached aiderEnv approach in favor of direct calls

3. **Improved API key validation**
   - Validates API keys before attempting to create the LLM
   - Checks both provider-specific keys and environment variables
   - Provides clear error messages indicating where to configure credentials