### PR TITLE
feat: allow monkey patching of models missing in aider

### DIFF
--- a/resources/connector/connector.py
+++ b/resources/connector/connector.py
@@ -22,6 +22,8 @@ from concurrent.futures import ThreadPoolExecutor, Future
 import nest_asyncio
 import litellm
 import types
+from monkeypatch import monkey_patch_model_settings
+from logger import log_info, log_error, log_warning, log_debug
 
 class PromptContext:
   def __init__(self, id: str, group=None):
@@ -597,9 +599,16 @@ def clone_coder(connector, coder, prompt_context=None, messages=None, files=None
   return coder
 
 def create_base_coder(connector):
+  log_info("Initializing aider with monkey patches...")
+  monkey_patch_model_settings()
+  
+  log_info("Creating aider coder instance...")
   coder = cli_main(return_coder=True)
   if not isinstance(coder, Coder):
     raise ValueError(coder)
+
+  for line in coder.get_announcements():
+    log_info(f"AIDER: {line}")
 
   return coder
 

--- a/resources/connector/logger.py
+++ b/resources/connector/logger.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+import sys
+
+def log_info(message):
+    """Log informational messages to stderr."""
+    sys.stderr.write(f"CONNECTOR INFO: {message}\n")
+    sys.stderr.flush()
+
+def log_warning(message):
+    """Log warning messages to stderr."""
+    sys.stderr.write(f"CONNECTOR WARNING: {message}\n")
+    sys.stderr.flush()
+
+def log_error(message):
+    """Log error messages to stderr."""
+    sys.stderr.write(f"CONNECTOR ERROR: {message}\n")
+    sys.stderr.flush()
+
+def log_debug(message):
+    """Log debug messages to stderr."""
+    sys.stderr.write(f"CONNECTOR DEBUG: {message}\n")
+    sys.stderr.flush()

--- a/resources/connector/monkey_patch_models.yaml
+++ b/resources/connector/monkey_patch_models.yaml
@@ -1,0 +1,31 @@
+# Configuration file for models that need to be monkey patched into aider's MODEL_SETTINGS
+# This allows adding support for newer models that aren't yet in aider's official model list
+
+models:
+  - name: anthropic/claude-sonnet-4-5-20250929
+    edit_format: diff
+    weak_model_name: anthropic/claude-haiku-4-5-20251001
+    use_repo_map: true
+    examples_as_sys_msg: false
+    extra_params:
+      extra_headers:
+        anthropic-beta: prompt-caching-2024-07-31,pdfs-2024-09-25,output-128k-2025-02-19
+      max_tokens: 64000
+    cache_control: true
+    editor_model_name: anthropic/claude-sonnet-4-5-20250929
+    editor_edit_format: editor-diff
+    accepts_settings: ["thinking_tokens"]
+
+  - name: anthropic/claude-haiku-4-5-20251001
+    edit_format: diff
+    weak_model_name: anthropic/claude-3-5-haiku-20241022
+    use_repo_map: true
+    examples_as_sys_msg: false
+    extra_params:
+      extra_headers:
+        anthropic-beta: prompt-caching-2024-07-31,pdfs-2024-09-25,output-128k-2025-02-19
+      max_tokens: 64000
+    cache_control: true
+    editor_model_name: anthropic/claude-haiku-4-5-20251001
+    editor_edit_format: editor-diff
+    accepts_settings: ["thinking_tokens"]

--- a/resources/connector/monkeypatch.py
+++ b/resources/connector/monkeypatch.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+
+import yaml
+from pathlib import Path
+from aider import models
+from logger import log_info, log_error
+
+def load_monkey_patch_models():
+    """Load models to monkey patch from YAML configuration file."""
+    config_path = Path(__file__).parent / "monkey_patch_models.yaml"
+    
+    if not config_path.exists():
+        log_error(f"Monkey patch config file not found: {config_path}")
+        return []
+    
+    try:
+        with open(config_path, 'r') as f:
+            config = yaml.safe_load(f)
+            return config.get('models', [])
+    except Exception as e:
+        log_error(f"Error loading monkey patch config: {e}")
+        return []
+
+def monkey_patch_model_settings():
+    """Add missing models to aider's MODEL_SETTINGS."""
+    
+    # Load models to patch from YAML config
+    models_to_patch = load_monkey_patch_models()
+    
+    if not models_to_patch:
+        log_info("No models to monkey patch")
+        return
+    
+    # Check if models already exist and add them if they don't
+    existing_model_names = {model_settings.name for model_settings in models.MODEL_SETTINGS}
+    
+    for model_config in models_to_patch:
+        model_name = model_config['name']
+        
+        if model_name not in existing_model_names:
+            try:
+                # Try to create using the dataclass if available
+                if hasattr(models, 'ModelSettings') and callable(models.ModelSettings):
+                    model_settings = models.ModelSettings(**model_config)
+                    log_info(f"Created model using ModelSettings constructor: {model_name}")
+                else:
+                    # Fallback: create a simple object and copy methods from existing model
+                    model_settings = type('ModelSettings', (), model_config)()
+                    
+                    # Copy methods from an existing ModelSettings object
+                    if models.MODEL_SETTINGS:
+                        existing_model = models.MODEL_SETTINGS[0]
+                        for attr_name in dir(existing_model):
+                            if callable(getattr(existing_model, attr_name)) and not attr_name.startswith('_'):
+                                setattr(model_settings, attr_name, getattr(existing_model, attr_name))
+                    
+                    log_info(f"Created model using fallback method: {model_name}")
+                
+                # Add it to the MODEL_SETTINGS list
+                models.MODEL_SETTINGS.append(model_settings)
+                log_info(f"Added model: {model_name}")
+                
+            except Exception as e:
+                log_error(f"Failed to create model settings for {model_name}: {e}")
+        else:
+            # Model exists, check if it has cache_control enabled
+            for existing_model in models.MODEL_SETTINGS:
+                if existing_model.name == model_name:
+                    if 'cache_control' in model_config and (not hasattr(existing_model, 'cache_control') or not existing_model.cache_control):
+                        # Enable cache_control for existing model
+                        existing_model.cache_control = model_config['cache_control']
+                        log_info(f"Enabled caching for existing model: {model_name}")
+                    break

--- a/src/main/start-up.ts
+++ b/src/main/start-up.ts
@@ -55,10 +55,18 @@ const setupAiderConnector = async (cleanInstall: boolean, updateProgress?: Updat
     fs.mkdirSync(AIDER_DESK_CONNECTOR_DIR, { recursive: true });
   }
 
-  // Copy connector.py from resources
-  const sourceConnectorPath = path.join(RESOURCES_DIR, 'connector/connector.py');
-  const destConnectorPath = path.join(AIDER_DESK_CONNECTOR_DIR, 'connector.py');
-  fs.copyFileSync(sourceConnectorPath, destConnectorPath);
+  const sourceConnectorDir = path.join(RESOURCES_DIR, 'connector');
+
+  if (fs.existsSync(sourceConnectorDir)) {
+    fs.cpSync(sourceConnectorDir, AIDER_DESK_CONNECTOR_DIR, {
+      recursive: true,
+      force: true,
+    });
+    logger.info(`Copied connector directory from ${sourceConnectorDir} to ${AIDER_DESK_CONNECTOR_DIR}`);
+  } else {
+    logger.error(`Connector directory not found: ${sourceConnectorDir}`);
+    throw new Error(`Connector directory not found: ${sourceConnectorDir}`);
+  }
 
   await installAiderConnectorRequirements(cleanInstall, updateProgress);
 };


### PR DESCRIPTION
I was using claude-sonnet-4-5 and I thought it was getting expensive and started to investigate why it seemed to cost me more than with claude-sonnet-4. I found that aider doesn't support prompt caching yet for sonnet and haiku on 4.5 so I thought that maybe I could fix it.

The changes proposed here allow for monkey patching the model settings list in aider at runtime. I'm not even sure this is a feature that is wanted for this application, maybe it should be targeted at the aider repo directly instead to update model_settings.yaml. But I thought this could be food for thought.

The logging is a bit ugly since it outputs directly to stderr, but I couldn't figure out a good way of using the logger in the typescript project.
