### PR TITLE
Fix MCP server import paths to resolve build errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "start": "electron-vite preview",
     "dev": "electron-vite dev",
     "dev:no-hmr": "NO_HMR=true electron-vite dev",
-    "build:mcp": "esbuild src/mcp-server/aider-desk-mcp-server.ts --bundle --platform=node --outdir=out/mcp-server",
+    "build:mcp": "esbuild src/mcp-server/aider-desk-mcp-server.ts --bundle --platform=node --outdir=out/mcp-server --external:@modelcontextprotocol/sdk --external:axios --external:zod",
     "build": "npm run typecheck && electron-vite build && npm run build:mcp",
     "postinstall": "electron-builder install-app-deps && node scripts/download-uv.mjs && node scripts/download-probe.mjs && patch-package",
     "build:unpack": "npm run build && electron-builder --dir",

--- a/src/mcp-server/aider-desk-mcp-server.ts
+++ b/src/mcp-server/aider-desk-mcp-server.ts
@@ -1,8 +1,8 @@
 /* eslint-disable func-style,@typescript-eslint/no-explicit-any */
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio';
 import axios from 'axios';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 
 // Get project directory from command line arguments or use default
 const projectDir = process.argv[2] || '.';


### PR DESCRIPTION
- Remove .js extensions from SDK imports
- Change zod/v3 to zod
- Add --external flags to build script to bypass parent Yarn PnP interference

Fixes build failures caused by incorrect module resolution and parent directory Yarn PnP manifest blocking dependency access. Build failures affected all platforms (Windows, macOS, Linux).