### PR TITLE
Feature - Open terminal in worktree by default

### DIFF
--- a/src/main/events-handler.ts
+++ b/src/main/events-handler.ts
@@ -373,7 +373,7 @@ export class EventsHandler {
 
   async createTerminal(baseDir: string, taskId: string, cols?: number, rows?: number): Promise<string> {
     try {
-      return this.terminalManager.createTerminal(baseDir, taskId, cols, rows);
+      return await this.terminalManager.createTerminal(baseDir, taskId, cols, rows);
     } catch (error) {
       logger.error('Failed to create terminal:', { baseDir, error });
       throw error;
@@ -397,14 +397,14 @@ export class EventsHandler {
     return terminal ? terminal.id : null;
   }
 
-  getTerminalsForTask(baseDir: string): {
+  getTerminalsForTask(taskId: string): {
     id: string;
     taskId: string;
     baseDir: string;
     cols: number;
     rows: number;
   }[] {
-    const terminals = this.terminalManager.getTerminalsForTask(baseDir);
+    const terminals = this.terminalManager.getTerminalsForTask(taskId);
     return terminals.map((terminal) => ({
       id: terminal.id,
       baseDir: terminal.baseDir,

--- a/src/main/managers.ts
+++ b/src/main/managers.ts
@@ -55,7 +55,7 @@ export const initManagers = async (store: Store, mainWindow: BrowserWindow | nul
   const projectManager = new ProjectManager(store, mcpManager, telemetryManager, dataManager, eventManager, modelManager, worktreeManager, agentProfileManager);
 
   // Initialize terminal manager
-  const terminalManager = new TerminalManager(eventManager, telemetryManager);
+  const terminalManager = new TerminalManager(eventManager, worktreeManager, telemetryManager);
 
   // Initialize Versions Manager
   const versionsManager = new VersionsManager(eventManager, store);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -522,12 +522,12 @@ const api: ApplicationAPI = {
 
   // Terminal operations
   isTerminalSupported: () => true,
-  createTerminal: (baseDir, cols, rows) => ipcRenderer.invoke('terminal-create', baseDir, cols, rows),
+  createTerminal: (baseDir, taskId, cols, rows) => ipcRenderer.invoke('terminal-create', baseDir, taskId, cols, rows),
   writeToTerminal: (terminalId, data) => ipcRenderer.invoke('terminal-write', terminalId, data),
   resizeTerminal: (terminalId, cols, rows) => ipcRenderer.invoke('terminal-resize', terminalId, cols, rows),
   closeTerminal: (terminalId) => ipcRenderer.invoke('terminal-close', terminalId),
-  getTerminalForTask: (baseDir) => ipcRenderer.invoke('terminal-get-for-task', baseDir),
-  getAllTerminalsForTask: (baseDir) => ipcRenderer.invoke('terminal-get-all-for-task', baseDir),
+  getTerminalForTask: (taskId) => ipcRenderer.invoke('terminal-get-for-task', taskId),
+  getAllTerminalsForTask: (taskId) => ipcRenderer.invoke('terminal-get-all-for-task', taskId),
 
   // Worktree merge operations
   mergeWorktreeToMain: (baseDir, taskId, squash) => ipcRenderer.invoke('merge-worktree-to-main', baseDir, taskId, squash),

--- a/src/renderer/src/api/browser-api.ts
+++ b/src/renderer/src/api/browser-api.ts
@@ -695,8 +695,8 @@ export class BrowserApi implements ApplicationAPI {
     void terminalId;
     throw new UnsupportedError('closeTerminal not supported yet.');
   }
-  getTerminalForTask(baseDir: string): Promise<string | null> {
-    void baseDir;
+  getTerminalForTask(taskId: string): Promise<string | null> {
+    void taskId;
     throw new UnsupportedError('getTerminalForTask not supported yet.');
   }
   getAllTerminalsForTask(taskId: string): Promise<Array<{ id: string; taskId: string; cols: number; rows: number }>> {


### PR DESCRIPTION
If aider desk is running in a worktree mode, open the terminal in the worktree directory by default. It's easier to go back to root if necessary than to find the worktree from the root.