### PR TITLE
Bugfix - Subagents do not include base rules

### DIFF
--- a/resources/prompts/rules-block.hbs
+++ b/resources/prompts/rules-block.hbs
@@ -1,0 +1,5 @@
+<Knowledge>
+  <Rules>
+{{{rulesFiles}}}
+  </Rules>
+</Knowledge>

--- a/src/common/agent.ts
+++ b/src/common/agent.ts
@@ -424,6 +424,7 @@ export const DEFAULT_AGENT_PROFILE: AgentProfile = {
     color: '#3368a8',
     description: '',
     contextMemory: ContextMemoryMode.Off,
+    includeRules: false,
   },
   ruleFiles: [],
 };

--- a/src/common/locales/en.json
+++ b/src/common/locales/en.json
@@ -644,6 +644,8 @@
         "descriptionPlaceholder": "Describe this subagent's purpose, capabilities, and specialization and when this subagent should be invoked",
         "systemPrompt": "System Prompt",
         "systemPromptPlaceholder": "Your subagent's system prompt goes here. This can be multiple paragraphs and should clearly define the subagent's role, capabilities, and approach to solving problems.",
+        "includeRules": "Include project rules",
+        "includeRulesInformation": "When enabled, the subagent will include project rules (AGENTS.md, .aider-desk/rules/*.md) at the start of its system prompt. This is useful when the subagent needs to follow specific project guidelines.",
         "invocationMode": "Invocation",
         "invocationModeOnDemand": "On demand",
         "invocationModeOnDemandInformation": "Subagent is only used when explicitly requested by the user.",

--- a/src/common/locales/zh.json
+++ b/src/common/locales/zh.json
@@ -642,6 +642,8 @@
         "descriptionPlaceholder": "描述此子代理的目的、能力和专长...",
         "systemPrompt": "系统提示",
         "systemPromptPlaceholder": "输入此配置用作子代理时的自定义系统提示指令...",
+        "includeRules": "包含项目规则",
+        "includeRulesInformation": "启用后，子代理将在其系统提示开头包含项目规则（AGENTS.md、.aider-desk/rules/*.md）。当子代理需要遵循特定项目指南时，此选项非常有用。",
         "invocationMode": "调用方式",
         "invocationModeOnDemand": "按需",
         "invocationModeOnDemandInformation": "子代理仅在父代理明确请求时才使用。",

--- a/src/common/types/common.ts
+++ b/src/common/types/common.ts
@@ -368,6 +368,7 @@ export interface SubagentConfig {
   invocationMode: InvocationMode;
   color: string;
   description: string;
+  includeRules: boolean;
 }
 
 export interface BashToolSettings {

--- a/src/main/__tests__/mocks/agent-profile.ts
+++ b/src/main/__tests__/mocks/agent-profile.ts
@@ -25,6 +25,7 @@ export const createMockAgentProfile = (overrides: Partial<AgentProfile> = {}): A
       invocationMode: InvocationMode.Automatic,
       color: 'blue',
       description: '',
+      includeRules: false,
     },
     isSubagent: false,
   } as AgentProfile;

--- a/src/main/agent/__tests__/agent.test.ts
+++ b/src/main/agent/__tests__/agent.test.ts
@@ -840,6 +840,8 @@ describe('Agent - getContextFilesAsToolCallMessages', () => {
   describe('systemPrompt merging', () => {
     // Variables for systemPrompt merging tests
     let mockPromptsManagerGetSystemPrompt: ReturnType<typeof vi.fn>;
+    let mockPromptsManagerGetRulesContent: ReturnType<typeof vi.fn>;
+    let mockPromptsManagerGetRulesBlock: ReturnType<typeof vi.fn>;
     let mockModelManagerCreateLlm: ReturnType<typeof vi.fn>;
     let mockProvider: any;
     let mockTaskWithRun: any;
@@ -849,10 +851,14 @@ describe('Agent - getContextFilesAsToolCallMessages', () => {
 
       // Create mock for getSystemPrompt
       mockPromptsManagerGetSystemPrompt = vi.fn();
+      mockPromptsManagerGetRulesContent = vi.fn();
+      mockPromptsManagerGetRulesBlock = vi.fn();
 
       // Update the mockPromptsManager with the getSystemPrompt mock
       mockPromptsManager = {
         getSystemPrompt: mockPromptsManagerGetSystemPrompt,
+        getRulesContent: mockPromptsManagerGetRulesContent,
+        getRulesBlock: mockPromptsManagerGetRulesBlock,
       };
 
       // Add missing methods to agentProfileManager mock
@@ -883,7 +889,7 @@ describe('Agent - getContextFilesAsToolCallMessages', () => {
         doWrite: vi.fn(),
       });
       mockModelManager.createLlm = mockModelManagerCreateLlm;
-      mockModelManager.normalizeMessages = vi.fn().mockImplementation((provider, model, messages) => messages);
+      mockModelManager.normalizeMessages = vi.fn().mockImplementation((_provider, _model, messages) => messages);
 
       // Mock fs.readdir to return empty array to avoid skills loading issues
       mockFsReadFile.mockResolvedValue(Buffer.from('file content'));
@@ -955,40 +961,6 @@ describe('Agent - getContextFilesAsToolCallMessages', () => {
       expect(mockPromptsManagerGetSystemPrompt).toHaveBeenCalled();
     });
 
-    it('should merge custom systemPrompt with base prompt (both appear in result)', async () => {
-      // Arrange
-      const basePrompt = 'BASE_PROMPT_FROM_RULES';
-      const customPrompt = 'CUSTOM_PROMPT';
-
-      mockPromptsManagerGetSystemPrompt.mockResolvedValue(basePrompt);
-
-      const profile = createMockAgentProfile({
-        provider: 'anthropic',
-      });
-
-      // Act
-      await agent.runAgent(
-        mockTaskWithRun,
-        profile,
-        'test prompt',
-        undefined,
-        [],
-        [],
-        customPrompt, // custom systemPrompt parameter
-      );
-
-      // Assert - verify the systemPrompt passed to createLlm contains both
-      expect(mockModelManagerCreateLlm).toHaveBeenCalled();
-      const callArgs = mockModelManagerCreateLlm.mock.calls[0];
-      const systemPromptPassedToModel = callArgs[5]; // systemPrompt is the 6th argument
-
-      // Should contain base prompt first, then custom prompt
-      expect(systemPromptPassedToModel).toContain(basePrompt);
-      expect(systemPromptPassedToModel).toContain(customPrompt);
-      // Verify order: base first, then custom (separated by newlines)
-      expect(systemPromptPassedToModel.indexOf(basePrompt)).toBeLessThan(systemPromptPassedToModel.indexOf(customPrompt));
-    });
-
     it('should use base prompt when no custom systemPrompt is provided', async () => {
       // Arrange
       const basePrompt = 'BASE_PROMPT_FROM_RULES_ONLY';
@@ -1030,15 +1002,7 @@ describe('Agent - getContextFilesAsToolCallMessages', () => {
       });
 
       // Act
-      await agent.runAgent(
-        mockTaskWithRun,
-        profile,
-        'test prompt',
-        undefined,
-        [],
-        [],
-        customPrompt,
-      );
+      await agent.runAgent(mockTaskWithRun, profile, 'test prompt', undefined, [], [], customPrompt);
 
       // Assert
       expect(mockModelManagerCreateLlm).toHaveBeenCalled();
@@ -1047,6 +1011,210 @@ describe('Agent - getContextFilesAsToolCallMessages', () => {
 
       // Should just be the custom prompt when base is empty
       expect(systemPromptPassedToModel).toBe(customPrompt);
+    });
+  });
+
+  describe('includeRules toggle behavior for subagents', () => {
+    // Variables for includeRules tests
+    let mockPromptsManagerGetSystemPrompt: ReturnType<typeof vi.fn>;
+    let mockPromptsManagerGetRulesContent: ReturnType<typeof vi.fn>;
+    let mockPromptsManagerGetRulesBlock: ReturnType<typeof vi.fn>;
+    let mockModelManagerCreateLlm: ReturnType<typeof vi.fn>;
+    let mockProvider: any;
+    let mockTaskWithRun: any;
+
+    beforeEach(async () => {
+      vi.clearAllMocks();
+
+      // Create mocks for getSystemPrompt and getRulesContent
+      mockPromptsManagerGetSystemPrompt = vi.fn();
+      mockPromptsManagerGetRulesContent = vi.fn();
+      mockPromptsManagerGetRulesBlock = vi.fn();
+
+      mockPromptsManager = {
+        getSystemPrompt: mockPromptsManagerGetSystemPrompt,
+        getRulesContent: mockPromptsManagerGetRulesContent,
+        getRulesBlock: mockPromptsManagerGetRulesBlock,
+      };
+
+      // Add missing methods to agentProfileManager mock
+      mockAgentProfileManager = {
+        getProjectProfiles: vi.fn().mockReturnValue([]),
+        getProfile: vi.fn(),
+      };
+
+      // Re-create agent with updated mocks
+      agent = new AgentClass(
+        mockStore as any,
+        mockAgentProfileManager as any,
+        mockMcpManager as any,
+        mockModelManager as any,
+        mockTelemetryManager as any,
+        mockMemoryManager as any,
+        mockPromptsManager as any,
+      );
+
+      // Spy on the private method for testing
+      originalGetContextFilesMessages = agent['getContextFilesMessages'];
+      agent['getContextFilesMessages'] = vi.fn();
+
+      // Create mock for createLlm to capture what systemPrompt is passed
+      mockModelManagerCreateLlm = vi.fn().mockReturnValue({
+        modelId: 'test-model',
+        doStream: vi.fn(),
+        doWrite: vi.fn(),
+      });
+      mockModelManager.createLlm = mockModelManagerCreateLlm;
+      mockModelManager.normalizeMessages = vi.fn().mockImplementation((_provider, _model, messages) => messages);
+
+      // Mock fs.readdir to return empty array to avoid skills loading issues
+      mockFsReadFile.mockResolvedValue(Buffer.from('file content'));
+      vi.mocked(fs.readdir).mockResolvedValue([]);
+      vi.mocked(fs.stat).mockRejectedValue(new Error('not found'));
+
+      // Setup provider mock
+      mockProvider = {
+        id: 'anthropic',
+        provider: {
+          name: 'Anthropic',
+          languageModel: vi.fn().mockReturnValue({}),
+        },
+      };
+
+      // Update store mock to return our provider
+      mockStore.getProviders = vi.fn(() => [mockProvider]);
+      mockStore.getSettings = vi.fn(() => ({}));
+
+      // Create a task mock with all required methods
+      mockTaskWithRun = {
+        ...mockTask,
+        getContextMessages: vi.fn().mockResolvedValue([]),
+        getContextFiles: vi.fn().mockResolvedValue([]),
+        addContextMessage: vi.fn(),
+        addLogMessage: vi.fn(),
+        hookManager: {
+          trigger: vi.fn().mockResolvedValue({ blocked: false, event: { prompt: 'test prompt' } }),
+        },
+        getProjectDir: vi.fn().mockReturnValue('/test/project'),
+        getTaskDir: vi.fn().mockReturnValue('/test/project'),
+        task: {
+          ...mockTask.task,
+          autoApprove: false,
+        },
+      };
+    });
+
+    afterEach(() => {
+      // Restore original method
+      if (originalGetContextFilesMessages) {
+        agent['getContextFilesMessages'] = originalGetContextFilesMessages;
+      }
+    });
+
+    it('should use custom systemPrompt as-is when includeRules is false (default)', async () => {
+      // Arrange
+      const customSystemPrompt = 'This is the custom subagent system prompt.';
+
+      mockPromptsManagerGetSystemPrompt.mockResolvedValue('base prompt');
+      mockPromptsManagerGetRulesContent.mockResolvedValue('rules content');
+
+      const profile = createMockAgentProfile({
+        provider: 'anthropic',
+        isSubagent: true,
+        subagent: {
+          enabled: true,
+          systemPrompt: customSystemPrompt,
+          includeRules: false, // explicitly set to false
+          invocationMode: 'automatic' as any,
+          contextMemory: 'lastMessage' as any,
+          color: '#3368a8',
+          description: 'Test subagent',
+        },
+      });
+
+      // Act
+      await agent.runAgent(mockTaskWithRun, profile, 'test prompt', undefined, [], [], customSystemPrompt);
+
+      // Assert
+      expect(mockModelManagerCreateLlm).toHaveBeenCalled();
+      const callArgs = mockModelManagerCreateLlm.mock.calls[0];
+      const systemPromptPassedToModel = callArgs[5];
+
+      // Should use ONLY the custom systemPrompt (no rules, no base prompt)
+      expect(systemPromptPassedToModel).toBe(customSystemPrompt);
+      // getRulesContent should NOT be called when includeRules is false
+      expect(mockPromptsManagerGetRulesContent).not.toHaveBeenCalled();
+    });
+
+    it('should prepend rules content to custom systemPrompt when includeRules is true', async () => {
+      // Arrange
+      const rulesContent = 'RULES_CONTENT_HERE';
+      const customSystemPrompt = 'CUSTOM_SYSTEM_PROMPT_HERE';
+      const wrappedRules = `<Knowledge>\n  <Rules>\n${rulesContent}\n  </Rules>\n</Knowledge>`;
+
+      mockPromptsManagerGetSystemPrompt.mockResolvedValue('base prompt');
+      mockPromptsManagerGetRulesBlock.mockResolvedValue(wrappedRules);
+
+      const profile = createMockAgentProfile({
+        provider: 'anthropic',
+        isSubagent: true,
+        subagent: {
+          enabled: true,
+          systemPrompt: customSystemPrompt,
+          includeRules: true,
+          invocationMode: 'automatic' as any,
+          contextMemory: 'lastMessage' as any,
+          color: '#3368a8',
+          description: 'Test subagent',
+        },
+      });
+
+      // Act
+      await agent.runAgent(mockTaskWithRun, profile, 'test prompt', undefined, [], [], customSystemPrompt);
+
+      // Assert
+      expect(mockModelManagerCreateLlm).toHaveBeenCalled();
+      const callArgs = mockModelManagerCreateLlm.mock.calls[0];
+      const systemPromptPassedToModel = callArgs[5];
+
+      // Should have wrapped rules in <Knowledge><Rules> tags + '\n\n' + customSystemPrompt
+      const expected = `${wrappedRules}\n\n${customSystemPrompt}`;
+      expect(systemPromptPassedToModel).toBe(expected);
+    });
+
+    it('should behave same as false when includeRules is undefined', async () => {
+      // Arrange
+      const customSystemPrompt = 'This is the custom subagent system prompt.';
+
+      mockPromptsManagerGetSystemPrompt.mockResolvedValue('base prompt');
+      mockPromptsManagerGetRulesContent.mockResolvedValue('rules content');
+
+      const profile = createMockAgentProfile({
+        provider: 'anthropic',
+        isSubagent: true,
+        subagent: {
+          enabled: true,
+          systemPrompt: customSystemPrompt,
+          includeRules: false,
+          invocationMode: 'automatic' as any,
+          contextMemory: 'lastMessage' as any,
+          color: '#3368a8',
+          description: 'Test subagent',
+        },
+      });
+
+      // Act
+      await agent.runAgent(mockTaskWithRun, profile, 'test prompt', undefined, [], [], customSystemPrompt);
+
+      // Assert
+      expect(mockModelManagerCreateLlm).toHaveBeenCalled();
+      const callArgs = mockModelManagerCreateLlm.mock.calls[0];
+      const systemPromptPassedToModel = callArgs[5];
+
+      // Should use ONLY the custom systemPrompt (same as when includeRules is false)
+      expect(systemPromptPassedToModel).toBe(customSystemPrompt);
+      // getRulesContent should NOT be called when includeRules is undefined
+      expect(mockPromptsManagerGetRulesContent).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/main/agent/__tests__/agent.test.ts
+++ b/src/main/agent/__tests__/agent.test.ts
@@ -838,15 +838,215 @@ describe('Agent - getContextFilesAsToolCallMessages', () => {
   });
 
   describe('systemPrompt merging', () => {
-    it('should verify promptsManager.getSystemPrompt is called in agent', () => {
-      // This test verifies that the promptsManager is properly injected into the agent
-      // and has the getSystemPrompt method available
-      expect(mockPromptsManager).toBeDefined();
+    // Variables for systemPrompt merging tests
+    let mockPromptsManagerGetSystemPrompt: ReturnType<typeof vi.fn>;
+    let mockModelManagerCreateLlm: ReturnType<typeof vi.fn>;
+    let mockProvider: any;
+    let mockTaskWithRun: any;
+
+    beforeEach(async () => {
+      vi.clearAllMocks();
+
+      // Create mock for getSystemPrompt
+      mockPromptsManagerGetSystemPrompt = vi.fn();
+
+      // Update the mockPromptsManager with the getSystemPrompt mock
+      mockPromptsManager = {
+        getSystemPrompt: mockPromptsManagerGetSystemPrompt,
+      };
+
+      // Add missing methods to agentProfileManager mock
+      mockAgentProfileManager = {
+        getProjectProfiles: vi.fn().mockReturnValue([]),
+        getProfile: vi.fn(),
+      };
+
+      // Re-create agent with updated mocks
+      agent = new AgentClass(
+        mockStore as any,
+        mockAgentProfileManager as any,
+        mockMcpManager as any,
+        mockModelManager as any,
+        mockTelemetryManager as any,
+        mockMemoryManager as any,
+        mockPromptsManager as any,
+      );
+
+      // Spy on the private method for testing
+      originalGetContextFilesMessages = agent['getContextFilesMessages'];
+      agent['getContextFilesMessages'] = vi.fn();
+
+      // Create mock for createLlm to capture what systemPrompt is passed
+      mockModelManagerCreateLlm = vi.fn().mockReturnValue({
+        modelId: 'test-model',
+        doStream: vi.fn(),
+        doWrite: vi.fn(),
+      });
+      mockModelManager.createLlm = mockModelManagerCreateLlm;
+      mockModelManager.normalizeMessages = vi.fn().mockImplementation((provider, model, messages) => messages);
+
+      // Mock fs.readdir to return empty array to avoid skills loading issues
+      mockFsReadFile.mockResolvedValue(Buffer.from('file content'));
+      vi.mocked(fs.readdir).mockResolvedValue([]);
+      vi.mocked(fs.stat).mockRejectedValue(new Error('not found'));
+
+      // Setup provider mock
+      mockProvider = {
+        id: 'anthropic',
+        provider: {
+          name: 'Anthropic',
+          languageModel: vi.fn().mockReturnValue({}),
+        },
+      };
+
+      // Update store mock to return our provider
+      mockStore.getProviders = vi.fn(() => [mockProvider]);
+      mockStore.getSettings = vi.fn(() => ({}));
+
+      // Create a task mock with all required methods
+      mockTaskWithRun = {
+        ...mockTask,
+        getContextMessages: vi.fn().mockResolvedValue([]),
+        getContextFiles: vi.fn().mockResolvedValue([]),
+        addContextMessage: vi.fn(),
+        addLogMessage: vi.fn(),
+        hookManager: {
+          trigger: vi.fn().mockResolvedValue({ blocked: false, event: { prompt: 'test prompt' } }),
+        },
+        getProjectDir: vi.fn().mockReturnValue('/test/project'),
+        getTaskDir: vi.fn().mockReturnValue('/test/project'),
+        task: {
+          ...mockTask.task,
+          autoApprove: false,
+        },
+      };
     });
 
-    it('should verify agent has access to promptsManager', () => {
-      // Verify the agent has access to the promptsManager
-      expect(agent['promptsManager']).toBeDefined();
+    afterEach(() => {
+      // Restore original method
+      if (originalGetContextFilesMessages) {
+        agent['getContextFilesMessages'] = originalGetContextFilesMessages;
+      }
+    });
+
+    it('should call getSystemPrompt to fetch base prompt when custom systemPrompt is provided', async () => {
+      // Arrange
+      const basePrompt = 'This is the base system prompt from project rules.';
+      const customPrompt = 'This is a custom system prompt.';
+
+      mockPromptsManagerGetSystemPrompt.mockResolvedValue(basePrompt);
+
+      const profile = createMockAgentProfile({
+        provider: 'anthropic',
+      });
+
+      // Act
+      await agent.runAgent(
+        mockTaskWithRun,
+        profile,
+        'test prompt',
+        undefined,
+        [],
+        [],
+        customPrompt, // custom systemPrompt parameter
+      );
+
+      // Assert - getSystemPrompt should have been called
+      expect(mockPromptsManagerGetSystemPrompt).toHaveBeenCalled();
+    });
+
+    it('should merge custom systemPrompt with base prompt (both appear in result)', async () => {
+      // Arrange
+      const basePrompt = 'BASE_PROMPT_FROM_RULES';
+      const customPrompt = 'CUSTOM_PROMPT';
+
+      mockPromptsManagerGetSystemPrompt.mockResolvedValue(basePrompt);
+
+      const profile = createMockAgentProfile({
+        provider: 'anthropic',
+      });
+
+      // Act
+      await agent.runAgent(
+        mockTaskWithRun,
+        profile,
+        'test prompt',
+        undefined,
+        [],
+        [],
+        customPrompt, // custom systemPrompt parameter
+      );
+
+      // Assert - verify the systemPrompt passed to createLlm contains both
+      expect(mockModelManagerCreateLlm).toHaveBeenCalled();
+      const callArgs = mockModelManagerCreateLlm.mock.calls[0];
+      const systemPromptPassedToModel = callArgs[5]; // systemPrompt is the 6th argument
+
+      // Should contain base prompt first, then custom prompt
+      expect(systemPromptPassedToModel).toContain(basePrompt);
+      expect(systemPromptPassedToModel).toContain(customPrompt);
+      // Verify order: base first, then custom (separated by newlines)
+      expect(systemPromptPassedToModel.indexOf(basePrompt)).toBeLessThan(systemPromptPassedToModel.indexOf(customPrompt));
+    });
+
+    it('should use base prompt when no custom systemPrompt is provided', async () => {
+      // Arrange
+      const basePrompt = 'BASE_PROMPT_FROM_RULES_ONLY';
+
+      mockPromptsManagerGetSystemPrompt.mockResolvedValue(basePrompt);
+
+      const profile = createMockAgentProfile({
+        provider: 'anthropic',
+      });
+
+      // Act - call without custom systemPrompt parameter
+      await agent.runAgent(
+        mockTaskWithRun,
+        profile,
+        'test prompt',
+        undefined,
+        [],
+        [],
+        undefined, // no custom systemPrompt
+      );
+
+      // Assert - verify only base prompt is passed to createLlm
+      expect(mockModelManagerCreateLlm).toHaveBeenCalled();
+      const callArgs = mockModelManagerCreateLlm.mock.calls[0];
+      const systemPromptPassedToModel = callArgs[5];
+
+      // Should contain base prompt and NOT contain any custom additions
+      expect(systemPromptPassedToModel).toBe(basePrompt);
+    });
+
+    it('should handle empty base prompt gracefully', async () => {
+      // Arrange
+      const customPrompt = 'CUSTOM_ONLY_PROMPT';
+
+      mockPromptsManagerGetSystemPrompt.mockResolvedValue(''); // empty base prompt
+
+      const profile = createMockAgentProfile({
+        provider: 'anthropic',
+      });
+
+      // Act
+      await agent.runAgent(
+        mockTaskWithRun,
+        profile,
+        'test prompt',
+        undefined,
+        [],
+        [],
+        customPrompt,
+      );
+
+      // Assert
+      expect(mockModelManagerCreateLlm).toHaveBeenCalled();
+      const callArgs = mockModelManagerCreateLlm.mock.calls[0];
+      const systemPromptPassedToModel = callArgs[5];
+
+      // Should just be the custom prompt when base is empty
+      expect(systemPromptPassedToModel).toBe(customPrompt);
     });
   });
 });

--- a/src/main/agent/__tests__/agent.test.ts
+++ b/src/main/agent/__tests__/agent.test.ts
@@ -68,6 +68,7 @@ describe('Agent - getContextFilesAsToolCallMessages', () => {
   let mockTelemetryManager: any;
   let mockMemoryManager: any;
   let mockPromptsManager: any;
+  let mockExtensionManager: any;
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -114,9 +115,10 @@ describe('Agent - getContextFilesAsToolCallMessages', () => {
     };
     mockMemoryManager = {};
     mockPromptsManager = {};
-    const mockExtensionManager = {
+    mockExtensionManager = {
       isInitialized: vi.fn(() => false),
       createExtensionToolset: vi.fn(() => ({})),
+      dispatchEvent: vi.fn().mockImplementation((_eventName, data) => data),
     };
 
     agent = new AgentClass(
@@ -876,6 +878,7 @@ describe('Agent - getContextFilesAsToolCallMessages', () => {
         mockTelemetryManager as any,
         mockMemoryManager as any,
         mockPromptsManager as any,
+        mockExtensionManager as any,
       );
 
       // Spy on the private method for testing
@@ -952,6 +955,7 @@ describe('Agent - getContextFilesAsToolCallMessages', () => {
         profile,
         'test prompt',
         undefined,
+        { id: 'test-context-id' },
         [],
         [],
         customPrompt, // custom systemPrompt parameter
@@ -977,6 +981,7 @@ describe('Agent - getContextFilesAsToolCallMessages', () => {
         profile,
         'test prompt',
         undefined,
+        { id: 'test-context-id' },
         [],
         [],
         undefined, // no custom systemPrompt
@@ -1002,7 +1007,7 @@ describe('Agent - getContextFilesAsToolCallMessages', () => {
       });
 
       // Act
-      await agent.runAgent(mockTaskWithRun, profile, 'test prompt', undefined, [], [], customPrompt);
+      await agent.runAgent(mockTaskWithRun, profile, 'test prompt', undefined, { id: 'test-context-id' }, [], [], customPrompt);
 
       // Assert
       expect(mockModelManagerCreateLlm).toHaveBeenCalled();
@@ -1052,6 +1057,7 @@ describe('Agent - getContextFilesAsToolCallMessages', () => {
         mockTelemetryManager as any,
         mockMemoryManager as any,
         mockPromptsManager as any,
+        mockExtensionManager as any,
       );
 
       // Spy on the private method for testing
@@ -1133,7 +1139,7 @@ describe('Agent - getContextFilesAsToolCallMessages', () => {
       });
 
       // Act
-      await agent.runAgent(mockTaskWithRun, profile, 'test prompt', undefined, [], [], customSystemPrompt);
+      await agent.runAgent(mockTaskWithRun, profile, 'test prompt', undefined, { id: 'test-context-id' }, [], [], customSystemPrompt);
 
       // Assert
       expect(mockModelManagerCreateLlm).toHaveBeenCalled();
@@ -1170,7 +1176,7 @@ describe('Agent - getContextFilesAsToolCallMessages', () => {
       });
 
       // Act
-      await agent.runAgent(mockTaskWithRun, profile, 'test prompt', undefined, [], [], customSystemPrompt);
+      await agent.runAgent(mockTaskWithRun, profile, 'test prompt', undefined, { id: 'test-context-id' }, [], [], customSystemPrompt);
 
       // Assert
       expect(mockModelManagerCreateLlm).toHaveBeenCalled();
@@ -1204,7 +1210,7 @@ describe('Agent - getContextFilesAsToolCallMessages', () => {
       });
 
       // Act
-      await agent.runAgent(mockTaskWithRun, profile, 'test prompt', undefined, [], [], customSystemPrompt);
+      await agent.runAgent(mockTaskWithRun, profile, 'test prompt', undefined, { id: 'test-context-id' }, [], [], customSystemPrompt);
 
       // Assert
       expect(mockModelManagerCreateLlm).toHaveBeenCalled();

--- a/src/main/agent/__tests__/agent.test.ts
+++ b/src/main/agent/__tests__/agent.test.ts
@@ -60,6 +60,15 @@ describe('Agent - getContextFilesAsToolCallMessages', () => {
   // Store original implementation
   let originalGetContextFilesMessages: any;
 
+  // Mocks that need to be accessible to all tests
+  let mockStore: any;
+  let mockAgentProfileManager: any;
+  let mockMcpManager: any;
+  let mockModelManager: any;
+  let mockTelemetryManager: any;
+  let mockMemoryManager: any;
+  let mockPromptsManager: any;
+
   beforeEach(async () => {
     vi.clearAllMocks();
 
@@ -83,15 +92,15 @@ describe('Agent - getContextFilesAsToolCallMessages', () => {
     mockFileTypeFromBuffer.mockResolvedValue(undefined);
     mockFsReadFile.mockResolvedValue(Buffer.from('file content') as any);
 
-    // Create minimal mocks for Agent constructor dependencies
-    const mockStore = {
+    // Create minimal mocks for Agent constructor dependencies - make them accessible
+    mockStore = {
       getSettings: vi.fn(() => ({})),
     };
-    const mockAgentProfileManager = {};
-    const mockMcpManager = {
+    mockAgentProfileManager = {};
+    mockMcpManager = {
       getConnectors: vi.fn(() => []),
     };
-    const mockModelManager = {
+    mockModelManager = {
       createLlm: vi.fn(),
       getProviderOptions: vi.fn(() => ({})),
       getProviderParameters: vi.fn(() => ({})),
@@ -100,11 +109,11 @@ describe('Agent - getContextFilesAsToolCallMessages', () => {
       getProviderTools: vi.fn(() => Promise.resolve({})),
       isStreamingDisabled: vi.fn(() => false),
     };
-    const mockTelemetryManager = {
+    mockTelemetryManager = {
       captureAgentRun: vi.fn(),
     };
-    const mockMemoryManager = {};
-    const mockPromptsManager = {};
+    mockMemoryManager = {};
+    mockPromptsManager = {};
     const mockExtensionManager = {
       isInitialized: vi.fn(() => false),
       createExtensionToolset: vi.fn(() => ({})),
@@ -825,6 +834,19 @@ describe('Agent - getContextFilesAsToolCallMessages', () => {
       // Verify unique IDs were generated
       expect(new Set(toolCallIds).size).toBe(toolCallIds.length);
       expect(mockUuidv4).toHaveBeenCalled();
+    });
+  });
+
+  describe('systemPrompt merging', () => {
+    it('should verify promptsManager.getSystemPrompt is called in agent', () => {
+      // This test verifies that the promptsManager is properly injected into the agent
+      // and has the getSystemPrompt method available
+      expect(mockPromptsManager).toBeDefined();
+    });
+
+    it('should verify agent has access to promptsManager', () => {
+      // Verify the agent has access to the promptsManager
+      expect(agent['promptsManager']).toBeDefined();
     });
   });
 });

--- a/src/main/agent/agent.ts
+++ b/src/main/agent/agent.ts
@@ -870,6 +870,16 @@ export class Agent {
       return resultMessages;
     }
 
+    // Get the base system prompt (project rules)
+    const baseSystemPrompt = await this.promptsManager.getSystemPrompt(this.store.getSettings(), task, profile);
+
+    // Merge base prompt with custom systemPrompt if provided
+    if (systemPrompt && baseSystemPrompt) {
+      systemPrompt = `${baseSystemPrompt}\n\n${systemPrompt}`;
+    } else if (!systemPrompt) {
+      systemPrompt = baseSystemPrompt;
+    }
+
     const toolSet = await this.getAvailableTools(
       task,
       mode,

--- a/src/main/agent/agent.ts
+++ b/src/main/agent/agent.ts
@@ -873,12 +873,25 @@ export class Agent {
     // Get the base system prompt (project rules)
     const baseSystemPrompt = await this.promptsManager.getSystemPrompt(this.store.getSettings(), task, profile);
 
-    // Merge base prompt with custom systemPrompt if provided
-    if (systemPrompt && baseSystemPrompt) {
-      systemPrompt = `${baseSystemPrompt}\n\n${systemPrompt}`;
+    // Check if this is a subagent with includeRules enabled
+    const isSubagent = profile.isSubagent;
+    const includeRules = isSubagent && profile.subagent.includeRules;
+
+    if (includeRules) {
+      // When includeRules is true: prepend ONLY rules content to custom systemPrompt
+      // (not the entire base system prompt template)
+      // Use rules-block template to wrap rules in <Knowledge><Rules> tags
+      const wrappedRules = await this.promptsManager.getRulesBlock(task, profile);
+      if (systemPrompt && wrappedRules) {
+        systemPrompt = `${wrappedRules}\n\n${systemPrompt}`;
+      } else if (!systemPrompt) {
+        systemPrompt = wrappedRules || '';
+      }
     } else if (!systemPrompt) {
+      // No custom systemPrompt provided, use base system prompt (main agent default)
       systemPrompt = baseSystemPrompt;
     }
+    // When includeRules is false and systemPrompt is provided, use it as-is (no merging)
 
     const toolSet = await this.getAvailableTools(
       task,
@@ -1700,8 +1713,40 @@ export class Agent {
       }
 
       const messages = await this.prepareMessages(task, profile, await task.getContextMessages(), await task.getContextFiles());
+<<<<<<< HEAD
       const toolSet = await this.getAvailableTools(task, 'agent', profile, provider, profile.model);
       const systemPrompt = await this.promptsManager.getSystemPrompt(this.store.getSettings(), task, profile);
+=======
+      const toolSet = await this.getAvailableTools(task, profile, provider);
+
+      // Get the base system prompt (project rules)
+      const baseSystemPrompt = await this.promptsManager.getSystemPrompt(this.store.getSettings(), task, profile);
+
+      // Check if this is a subagent with includeRules enabled
+      const isSubagent = profile.isSubagent;
+      const includeRules = isSubagent && profile.subagent.includeRules;
+
+      // Get custom systemPrompt from subagent profile (if this is a subagent)
+      const customSystemPrompt = isSubagent ? profile.subagent.systemPrompt : undefined;
+
+      let systemPrompt: string | undefined;
+      if (includeRules) {
+        // When includeRules is true: prepend ONLY rules content to custom systemPrompt
+        // Use rules-block template to wrap rules in <Knowledge><Rules> tags
+        const wrappedRules = await this.promptsManager.getRulesBlock(task, profile);
+        if (customSystemPrompt && wrappedRules) {
+          systemPrompt = `${wrappedRules}\n\n${customSystemPrompt}`;
+        } else if (!customSystemPrompt) {
+          systemPrompt = wrappedRules || '';
+        }
+      } else if (customSystemPrompt) {
+        // When includeRules is false and custom systemPrompt provided, use it as-is
+        systemPrompt = customSystemPrompt;
+      } else {
+        // No custom systemPrompt provided, use base system prompt
+        systemPrompt = baseSystemPrompt;
+      }
+>>>>>>> ce12d694 (feat: add includeRules option for subagents)
 
       const cacheControl = this.modelManager.getCacheControl(profile, provider.provider);
 
@@ -1730,7 +1775,7 @@ export class Agent {
         role: 'system',
         content: toolDefinitionsString,
       });
-      optimizedMessages.unshift({ role: 'system', content: systemPrompt });
+      optimizedMessages.unshift({ role: 'system', content: systemPrompt || '' });
 
       const chatMessages = optimizedMessages.map((msg) => ({
         role: msg.role === 'tool' ? 'user' : msg.role, // Map 'tool' role to user message as gpt-tokenizer does not support tool messages

--- a/src/main/agent/agent.ts
+++ b/src/main/agent/agent.ts
@@ -883,7 +883,9 @@ export class Agent {
       // Use rules-block template to wrap rules in <Knowledge><Rules> tags
       const wrappedRules = await this.promptsManager.getRulesBlock(task, profile);
       if (systemPrompt && wrappedRules) {
-        systemPrompt = `${wrappedRules}\n\n${systemPrompt}`;
+        systemPrompt = `${wrappedRules}
+
+${systemPrompt}`;
       } else if (!systemPrompt) {
         systemPrompt = wrappedRules || '';
       }
@@ -1731,7 +1733,9 @@ export class Agent {
         // Use rules-block template to wrap rules in <Knowledge><Rules> tags
         const wrappedRules = await this.promptsManager.getRulesBlock(task, profile);
         if (customSystemPrompt && wrappedRules) {
-          systemPrompt = `${wrappedRules}\n\n${customSystemPrompt}`;
+          systemPrompt = `${wrappedRules}
+
+${customSystemPrompt}`;
         } else if (!customSystemPrompt) {
           systemPrompt = wrappedRules || '';
         }

--- a/src/main/agent/agent.ts
+++ b/src/main/agent/agent.ts
@@ -1713,11 +1713,7 @@ export class Agent {
       }
 
       const messages = await this.prepareMessages(task, profile, await task.getContextMessages(), await task.getContextFiles());
-<<<<<<< HEAD
       const toolSet = await this.getAvailableTools(task, 'agent', profile, provider, profile.model);
-      const systemPrompt = await this.promptsManager.getSystemPrompt(this.store.getSettings(), task, profile);
-=======
-      const toolSet = await this.getAvailableTools(task, profile, provider);
 
       // Get the base system prompt (project rules)
       const baseSystemPrompt = await this.promptsManager.getSystemPrompt(this.store.getSettings(), task, profile);
@@ -1746,7 +1742,6 @@ export class Agent {
         // No custom systemPrompt provided, use base system prompt
         systemPrompt = baseSystemPrompt;
       }
->>>>>>> ce12d694 (feat: add includeRules option for subagents)
 
       const cacheControl = this.modelManager.getCacheControl(profile, provider.provider);
 

--- a/src/main/extensions/__tests__/agent-integration.test.ts
+++ b/src/main/extensions/__tests__/agent-integration.test.ts
@@ -138,6 +138,7 @@ const createMockProfile = (): AgentProfile => ({
     invocationMode: 'on-demand' as InvocationMode,
     color: '#000',
     description: '',
+    includeRules: false,
   },
 });
 

--- a/src/main/prompts/prompts-manager.ts
+++ b/src/main/prompts/prompts-manager.ts
@@ -123,6 +123,7 @@ export class PromptsManager {
       'update-task-state',
       'handoff',
       'code-inline-request',
+      'rules-block',
     ];
   }
 
@@ -382,7 +383,7 @@ export class PromptsManager {
     return await this.render('system-prompt', data, projectDir, task);
   };
 
-  private getRulesContent = async (task: Task, agentProfile?: AgentProfile) => {
+  public getRulesContent = async (task: Task, agentProfile?: AgentProfile) => {
     const ruleFiles = await task.getRuleFilesAsContextFiles(agentProfile);
 
     const ruleFilesContent = await Promise.all(
@@ -409,6 +410,14 @@ export class PromptsManager {
     );
 
     return ruleFilesContent.filter(Boolean).join('\n');
+  };
+
+  public getRulesBlock = async (task: Task, agentProfile?: AgentProfile): Promise<string> => {
+    const rulesFiles = await this.getRulesContent(task, agentProfile);
+    if (!rulesFiles) {
+      return '';
+    }
+    return this.render('rules-block', { rulesFiles }, task.getProjectDir());
   };
 
   public getInitProjectPrompt = async (task: Task) => {

--- a/src/main/prompts/types.ts
+++ b/src/main/prompts/types.ts
@@ -102,4 +102,5 @@ export type PromptTemplateName =
   | 'conflict-resolution-system'
   | 'update-task-state'
   | 'handoff'
-  | 'code-inline-request';
+  | 'code-inline-request'
+  | 'rules-block';

--- a/src/renderer/src/components/settings/agent/AgentSettings.tsx
+++ b/src/renderer/src/components/settings/agent/AgentSettings.tsx
@@ -1274,6 +1274,19 @@ export const AgentSettings = ({
                           placeholder={t('settings.agent.subagent.systemPromptPlaceholder')}
                         />
 
+                        <div className="flex items-center justify-between mb-1">
+                          <Checkbox
+                            label={
+                              <div className="flex items-center">
+                                <span>{t('settings.agent.subagent.includeRules')}</span>
+                                <InfoIcon className="ml-2" tooltip={t('settings.agent.subagent.includeRulesInformation')} />
+                              </div>
+                            }
+                            checked={selectedProfile.subagent.includeRules}
+                            onChange={(checked) => handleProfileSettingChange('subagent', { ...selectedProfile.subagent, includeRules: checked })}
+                          />
+                        </div>
+
                         <div className="flex items-center gap-4 mb-1">
                           <Select
                             label={<label className="text-xs font-medium text-text-primary">{t('settings.agent.subagent.invocationMode')}</label>}


### PR DESCRIPTION
As per my investigation, subagents do not receive AGENTS.md and `.aider-desk/rules/` files when they have a custom `systemPrompt` configured. The bug was in `agent.ts` where `getSystemPrompt()` was only called when `systemPrompt` was undefined - but subagents pass their custom prompt, causing the base prompt with rules to be skipped entirely.