### PR TITLE
fix: uppress mermaid error rendering

### DIFF
--- a/src/renderer/src/components/common/MermaidDiagram.tsx
+++ b/src/renderer/src/components/common/MermaidDiagram.tsx
@@ -6,6 +6,7 @@ mermaid.initialize({
   startOnLoad: false,
   theme: 'neutral',
   securityLevel: 'loose',
+  suppressErrorRendering: true,
 });
 
 type Props = {


### PR DESCRIPTION
Fixes a bug where if agents produce enough incorrect mermaid diagrams, the errors appear visually and overflow:
<img width="2032" height="1244" alt="Screenshot 2026-03-11 at 12 35 47" src="https://github.com/user-attachments/assets/b31b8fdc-f213-4b96-a0a7-6d5e1e564660" />
<img width="499" height="259" alt="Screenshot 2026-03-11 at 12 34 48" src="https://github.com/user-attachments/assets/91db34e0-977d-454b-927b-63620bb5913b" />
