### PR TITLE
fix: prevent Claude Agent SDK session leakage on task fork/duplicate

### DIFF
--- a/src/main/project/project.ts
+++ b/src/main/project/project.ts
@@ -421,6 +421,7 @@ export class Project {
 
     const newTask = await this.prepareTask(undefined, {
       ...sourceTask.task,
+      lastAgentProviderMetadata: undefined,
       state: sourceTask.task.state === DefaultTaskState.InProgress ? DefaultTaskState.Todo : sourceTask.task.state,
     });
     await newTask.init();
@@ -438,6 +439,7 @@ export class Project {
 
     const newTask = await this.prepareTask(undefined, {
       ...sourceTask.task,
+      lastAgentProviderMetadata: undefined,
       parentId: sourceTask.task.parentId || sourceTask.task.id,
       state: sourceTask.task.state === DefaultTaskState.InProgress ? DefaultTaskState.Todo : sourceTask.task.state,
     });

--- a/src/main/task/task.ts
+++ b/src/main/task/task.ts
@@ -3987,6 +3987,7 @@ ${error.stderr}`,
     const sourceData = sourceTask.task;
     await this.saveTask({
       name: `${sourceData.name} (Copy)`,
+      lastAgentProviderMetadata: undefined,
     });
 
     // Copy context files
@@ -4018,6 +4019,7 @@ ${error.stderr}`,
     const sourceData = sourceTask.task;
     await this.saveTask({
       name: `${sourceData.name} (Fork)`,
+      lastAgentProviderMetadata: undefined,
     });
 
     // Copy ALL context files from source task (not just up to fork point)


### PR DESCRIPTION
## Problem

When forking or duplicating a task while using the **Claude Agent SDK** provider, the new task inherits the original task's conversation session. This causes **context contamination** — the new task's agent retains full knowledge of the original task's conversation history, and the conversation in the new task doesn't flow naturally.

This issue only affects the Claude Agent SDK provider. Other providers are stateless (they send the full message history each time) and are unaffected.

## Root Cause

In both `duplicateTask` and `forkTask` (`project.ts`), the source task's data is spread into the new task:

```ts
const newTask = await this.prepareTask(undefined, {
  ...sourceTask.task,  // copies ALL TaskData fields
  state: ...
});
```

This copies `lastAgentProviderMetadata`, which contains the Claude Agent SDK's `sessionId`. When the new task's agent runs, it resumes the original session via:

```ts
// claude-agent-sdk.ts
settings.resume = metadata.sessionId;
```

The patched `convertToClaudeCodeMessages` then only sends the last user message (since the session already has the full history), causing the new task to behave as a continuation of the original.

## Fix

Explicitly set `lastAgentProviderMetadata: undefined` in **4 locations** across 2 files:

| File | Method | Role |
|------|--------|------|
| `project.ts` | `duplicateTask` | Override in spread to prevent sessionId propagation |
| `project.ts` | `forkTask` | Same override |
| `task.ts` | `duplicateFrom` | Defensive safeguard in `saveTask` call |
| `task.ts` | `forkFrom` | Same defensive safeguard |

This ensures new tasks always start with a fresh Claude session while preserving the copied `contextMessages` as the initial prompt (matching the behavior of other providers).

## Verification

- TypeScript type check passes (`tsc --noEmit -p tsconfig.node.json`)
- All 730 existing tests pass (`vitest run --config vitest.config.node.ts`)
- No impact on other providers (they don't use `lastAgentProviderMetadata`)