### PR TITLE
Fix add-file handling for existing context files.

### DIFF
--- a/src/main/task/context-manager.ts
+++ b/src/main/task/context-manager.ts
@@ -110,7 +110,15 @@ export class ContextManager {
       return [];
     }
 
-    if (this.isContextFileAlreadyAdded(absolutePath)) {
+    const existingContextFile = this.findExistingContextFile(absolutePath);
+    if (existingContextFile) {
+      const readOnly = contextFile.readOnly ?? false;
+      if (existingContextFile.readOnly !== readOnly) {
+        existingContextFile.readOnly = readOnly;
+        this.autosave();
+        return [existingContextFile];
+      }
+
       return [];
     }
 
@@ -177,8 +185,8 @@ export class ContextManager {
    * Checks whether a resolved absolute path matches any already-added context file.
    * Accounts for files that may have been resolved from either taskDir or projectDir.
    */
-  private isContextFileAlreadyAdded(absolutePath: string): boolean {
-    return this.files.some((file) => {
+  private findExistingContextFile(absolutePath: string): ContextFile | undefined {
+    return this.files.find((file) => {
       const taskDirResolved = path.resolve(this.task.getTaskDir(), file.path);
       const projectDirResolved = path.resolve(this.task.getProjectDir(), file.path);
       return taskDirResolved === absolutePath || projectDirResolved === absolutePath;

--- a/src/main/task/context-manager.ts
+++ b/src/main/task/context-manager.ts
@@ -110,7 +110,15 @@ export class ContextManager {
       return [];
     }
 
-    if (this.isContextFileAlreadyAdded(absolutePath)) {
+    const existingContextFile = this.findExistingContextFile(absolutePath);
+    if (existingContextFile) {
+      const readOnly = contextFile.readOnly ?? false;
+      if (existingContextFile.readOnly !== readOnly) {
+        existingContextFile.readOnly = readOnly;
+        this.autosave();
+        return [existingContextFile];
+      }
+
       return [];
     }
 
@@ -174,11 +182,11 @@ export class ContextManager {
   }
 
   /**
-   * Checks whether a resolved absolute path matches any already-added context file.
+   * Finds an already-added context file matching the given resolved absolute path, if any.
    * Accounts for files that may have been resolved from either taskDir or projectDir.
    */
-  private isContextFileAlreadyAdded(absolutePath: string): boolean {
-    return this.files.some((file) => {
+  private findExistingContextFile(absolutePath: string): ContextFile | undefined {
+    return this.files.find((file) => {
       const taskDirResolved = path.resolve(this.task.getTaskDir(), file.path);
       const projectDirResolved = path.resolve(this.task.getProjectDir(), file.path);
       return taskDirResolved === absolutePath || projectDirResolved === absolutePath;


### PR DESCRIPTION
Fix add-file handling for existing context files.

Previously, `ContextManager.addContextFile` returned an empty array whenever the resolved file path was already present in the task context. This caused `Task.addFiles` to treat the operation as a no-op, so an existing readonly context file could not be updated when a later `add-file` message provided a different `readOnly` value.

The fix changes `addContextFile` to update the existing context file metadata when the file is already present but the incoming `readOnly` value differs. The method signature remains unchanged and it still returns the list of changed files. This allows `Task.addFiles` to reuse its existing update flow and notify connectors/UI/context-info when the readonly state changes.