### PR TITLE
fix: clarify missing API key warning

### DIFF
--- a/resources/connector/connector.py
+++ b/resources/connector/connector.py
@@ -1448,7 +1448,12 @@ class Connector:
     info = self.coder.main_model.info
 
     if self.coder.main_model.missing_keys:
-      error = "Missing keys for the model: " + ", ".join(self.coder.main_model.missing_keys)
+      error = (
+        "Missing keys for the model: "
+        + ", ".join(self.coder.main_model.missing_keys)
+        + ". If you are using a local OpenAI-compatible server such as llama.cpp, "
+        + "configure any dummy API key for the model/provider."
+      )
 
     await self.send_action({
       "action": "set-models",


### PR DESCRIPTION
## Summary
Fixes #826

Clarifies the missing API key warning returned for Aider models so users running local OpenAI-compatible servers, such as llama.cpp, know they can configure a dummy API key when the local server ignores authentication.

## Changes
- Expand the missing model keys message with guidance for local OpenAI-compatible providers

## Verification
- `python3 -m py_compile resources/connector/connector.py`
- `git diff --check`
- `npm run lint:check -- --quiet`

Note: `npm ci` was attempted first, but its postinstall Electron native rebuild failed because `make` is not installed in the environment. Dependencies were still available for the scoped lint check.