### PR TITLE
fix: discover project rule files on refresh

### DIFF
--- a/src/main/__tests__/utils/file-system.getAllFiles.test.ts
+++ b/src/main/__tests__/utils/file-system.getAllFiles.test.ts
@@ -1,0 +1,62 @@
+import { execFile } from 'child_process';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { promisify } from 'util';
+
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+vi.unmock('fs');
+vi.unmock('path');
+
+const execFileAsync = promisify(execFile);
+
+let getAllFiles: typeof import('@/utils/file-system').getAllFiles;
+let AIDER_DESK_PROJECT_RULES_DIR: typeof import('@/constants').AIDER_DESK_PROJECT_RULES_DIR;
+
+const tempDirs: string[] = [];
+
+const createProject = async () => {
+  const projectDir = await fs.mkdtemp(path.join(os.tmpdir(), 'aider-desk-files-'));
+  tempDirs.push(projectDir);
+
+  await fs.writeFile(path.join(projectDir, '.gitignore'), '.aider-desk/\n');
+  await fs.mkdir(path.join(projectDir, 'src'), { recursive: true });
+  await fs.writeFile(path.join(projectDir, 'src', 'tracked.ts'), 'export {};\n');
+  await fs.mkdir(path.join(projectDir, AIDER_DESK_PROJECT_RULES_DIR), { recursive: true });
+  await fs.writeFile(path.join(projectDir, AIDER_DESK_PROJECT_RULES_DIR, 'copied.md'), '# Rule\n');
+
+  await execFileAsync('git', ['init'], { cwd: projectDir });
+  await execFileAsync('git', ['add', '.gitignore', 'src/tracked.ts'], { cwd: projectDir });
+
+  return projectDir;
+};
+
+describe('getAllFiles', () => {
+  beforeAll(async () => {
+    ({ getAllFiles } = await import('@/utils/file-system'));
+    ({ AIDER_DESK_PROJECT_RULES_DIR } = await import('@/constants'));
+  });
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  });
+
+  it('includes copied project rule files when using git-backed file discovery', async () => {
+    const projectDir = await createProject();
+
+    const files = await getAllFiles(projectDir, true);
+
+    expect(files).toContain('src/tracked.ts');
+    expect(files).toContain('.aider-desk/rules/copied.md');
+  });
+
+  it('includes copied project rule files when filesystem discovery filters gitignored files', async () => {
+    const projectDir = await createProject();
+
+    const files = await getAllFiles(projectDir, false);
+
+    expect(files).toContain('src/tracked.ts');
+    expect(files).toContain('.aider-desk/rules/copied.md');
+  });
+});

--- a/src/main/utils/file-system.ts
+++ b/src/main/utils/file-system.ts
@@ -7,6 +7,7 @@ import slugify from 'slugify';
 import { glob } from 'glob';
 
 import logger from '@/logger';
+import { AIDER_DESK_PROJECT_RULES_DIR } from '@/constants';
 // @ts-expect-error filenamify is not typed properly
 const filenamify = filenamifyImport.default;
 
@@ -168,6 +169,31 @@ const getAllFilesFromFS = async (baseDir: string, ignore: string[] = []): Promis
   }
 };
 
+const getProjectRuleFiles = async (baseDir: string): Promise<string[]> => {
+  try {
+    const rulesDir = path.join(baseDir, AIDER_DESK_PROJECT_RULES_DIR);
+    const entries = await fs.promises.readdir(rulesDir, { withFileTypes: true });
+
+    return entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
+      .map((entry) => path.relative(baseDir, path.join(rulesDir, entry.name)).replace(/\\/g, '/'))
+      .sort((a, b) => a.localeCompare(b));
+  } catch (error) {
+    logger.debug('Could not read project rules directory while listing files', { error, baseDir });
+    return [];
+  }
+};
+
+const includeProjectRuleFiles = async (baseDir: string, files: string[]): Promise<string[]> => {
+  const allFiles = new Set(files.map((file) => file.replace(/\\/g, '/')));
+
+  for (const ruleFile of await getProjectRuleFiles(baseDir)) {
+    allFiles.add(ruleFile);
+  }
+
+  return Array.from(allFiles);
+};
+
 const getIgnoreGlobPatterns = async (gitignorePath: string): Promise<string[]> => {
   const ignore: string[] = [];
 
@@ -219,7 +245,7 @@ export const getAllFiles = async (baseDir: string, useGit = true): Promise<strin
         const result = await git.raw(['ls-files', '-z']);
         const files = result.split('\0').filter(Boolean);
         logger.debug('Retrieved tracked files from Git', { count: files.length, baseDir });
-        return files;
+        return await includeProjectRuleFiles(baseDir, files);
       } catch (gitError) {
         logger.warn('Failed to get tracked files from Git, falling back to filesystem', { error: gitError, baseDir });
       }
@@ -237,10 +263,10 @@ export const getAllFiles = async (baseDir: string, useGit = true): Promise<strin
         filtered: filteredFiles.length,
         baseDir,
       });
-      return filteredFiles;
+      return await includeProjectRuleFiles(baseDir, filteredFiles);
     }
 
-    return files;
+    return await includeProjectRuleFiles(baseDir, files);
   } catch (error) {
     logger.error('Failed to get files', { error, baseDir, useGit });
     return [];


### PR DESCRIPTION
## Summary
Fixes #840

Ensure Project Files refresh includes project rule markdown files from `.aider-desk/rules`, even when file discovery is git-backed or gitignore-filtered.

## Changes
- Merge direct `.md` files from the project rules directory into `getAllFiles()` results.
- Preserve discovery for both git (`git ls-files`) and filesystem modes.
- Add node tests covering copied/gitignored project rule files in both modes.

## Test Plan
- `npx vitest run --config vitest.config.node.ts src/main/__tests__/utils/file-system.getAllFiles.test.ts`
- `npm run typecheck:node`
- `npm run lint:check -- --no-cache src/main/utils/file-system.ts src/main/__tests__/utils/file-system.getAllFiles.test.ts`