### PR TITLE
Increase server request timeout for long prompts

### DIFF
--- a/src/main/server/__tests__/timeouts.test.ts
+++ b/src/main/server/__tests__/timeouts.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+
+import { REQUEST_TIMEOUT_MS } from '../timeouts';
+
+describe('server request timeout', () => {
+  it('allows long-running model/proxy requests for 30 minutes', () => {
+    expect(REQUEST_TIMEOUT_MS).toBe(30 * 60 * 1000);
+  });
+});

--- a/src/main/server/server-controller.ts
+++ b/src/main/server/server-controller.ts
@@ -4,6 +4,8 @@ import { join } from 'path';
 import express, { NextFunction, Request, Response } from 'express';
 import cors from 'cors';
 
+import { REQUEST_TIMEOUT_MS } from './timeouts';
+
 import {
   AgentApi,
   CommandsApi,
@@ -27,8 +29,6 @@ import { ProjectManager } from '@/project';
 import { EventsHandler } from '@/events-handler';
 import { Store } from '@/store';
 import { isDev, isElectron } from '@/app';
-
-const REQUEST_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
 export class ServerController {
   private readonly app = express();

--- a/src/main/server/timeouts.ts
+++ b/src/main/server/timeouts.ts
@@ -1,0 +1,2 @@
+// Keep long-running local/model/proxy requests alive long enough for large-context or multimodal prompts.
+export const REQUEST_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes


### PR DESCRIPTION
## Summary
- increase the local REST server request/response timeout from 5 minutes to 30 minutes
- move the timeout into a small exported constant so it is covered by a focused test

Fixes #858

## Tests
- npm run test:node -- src/main/server/__tests__/timeouts.test.ts
- npx eslint src/main/server/server-controller.ts src/main/server/timeouts.ts src/main/server/__tests__/timeouts.test.ts

## Notes
- npm run typecheck:node currently fails on main with src/main/models/providers/claude-agent-sdk.ts(243,14): Property 'aiSdkTools' does not exist on type 'ClaudeCodeSettings'.