### PR TITLE
fix: prevent crash from circular references in error logging

### DIFF
--- a/src/main/logger/log-buffer.ts
+++ b/src/main/logger/log-buffer.ts
@@ -5,6 +5,23 @@ import { SystemLogEntry, SystemLogsResponse, SystemLogLevel } from '@common/type
 const DEFAULT_PAGE_SIZE = 100;
 
 /**
+ * JSON.stringify replacement that handles circular references.
+ * Returns a string representation with "[Circular]" markers instead of throwing.
+ */
+const safeStringify = (obj: unknown): string => {
+  const seen = new WeakSet();
+  return JSON.stringify(obj, (_key, value) => {
+    if (typeof value === 'object' && value !== null) {
+      if (seen.has(value)) {
+        return '[Circular]';
+      }
+      seen.add(value);
+    }
+    return value;
+  });
+};
+
+/**
  * SQLite-backed storage for system logs.
  * This is session-only storage that clears on app startup.
  */
@@ -50,7 +67,7 @@ export class LogBuffer {
     `;
 
     const stmt = this.db.prepare(sql);
-    const result = stmt.run(entry.timestamp, entry.level, entry.message, entry.extension || null, entry.metadata ? JSON.stringify(entry.metadata) : null);
+    const result = stmt.run(entry.timestamp, entry.level, entry.message, entry.extension || null, entry.metadata ? safeStringify(entry.metadata) : null);
     return result.lastInsertRowid as number;
   }
 

--- a/src/main/utils/shell.ts
+++ b/src/main/utils/shell.ts
@@ -344,7 +344,9 @@ export const getShellPath = (): string => {
             pathLength: shellPath.split(':').length,
           });
         } catch (error) {
-          logger.error('Failed to load PATH from shell config:', error);
+          logger.error('Failed to load PATH from shell config:', {
+            error: error instanceof Error ? { message: error.message, name: error.name } : String(error),
+          });
 
           // Try the standard login shell approach
           try {
@@ -362,7 +364,9 @@ export const getShellPath = (): string => {
             );
             logger.debug('Loaded PATH using login shell flags');
           } catch (loginError) {
-            logger.error('Failed to load PATH from login shell:', loginError);
+            logger.error('Failed to load PATH from login shell:', {
+              error: loginError instanceof Error ? { message: loginError.message, name: loginError.name } : String(loginError),
+            });
             // Fallback to current PATH + common locations
             shellPath = process.env.PATH || '';
           }
@@ -521,7 +525,7 @@ export const getShellPath = (): string => {
     return cachedPath;
   } catch (error) {
     logger.error('ERROR: Failed to get shell PATH', {
-      error,
+      error: error instanceof Error ? { message: error.message, name: error.name } : String(error),
       stack: error instanceof Error ? error.stack : 'No stack trace available',
     });
 
@@ -580,7 +584,7 @@ export const getShellPath = (): string => {
         }
       } catch (configError) {
         logger.error('ERROR: Failed to read shell config files', {
-          error: configError,
+          error: configError instanceof Error ? { message: configError.message, name: configError.name } : String(configError),
           stack: configError instanceof Error ? configError.stack : 'No stack trace',
         });
       }


### PR DESCRIPTION
Fixes #873

## Problem

When xecSync or other child process operations fail during shell PATH detection, the thrown error objects can contain circular references (e.g., \rror.error\ pointing back to the error itself). When these error objects are logged via \logger.error()\, the \LogBuffer.add\ method calls \JSON.stringify\ on the metadata, which throws \TypeError: Converting circular structure to JSON\.

This causes the log entry to be corrupted and the actual error information to be lost, making debugging impossible.

## Fix

**log-buffer.ts**: Added a \safeStringify\ helper that uses a \WeakSet\ to detect circular references and replaces them with \[Circular]\ markers instead of throwing.

**shell.ts**: Sanitized all error logging calls in the PATH detection code to extract only \{ message, name }\ from Error objects instead of passing raw Error instances that may contain circular references.