### PR TITLE
fix: prevent project tab close button from overlapping scroll arrow

### DIFF
--- a/src/renderer/src/components/project/ProjectTabs.tsx
+++ b/src/renderer/src/components/project/ProjectTabs.tsx
@@ -193,6 +193,7 @@ export const ProjectTabs = ({
               ))}
             </SortableContext>
           </DndContext>
+          {showRightScrollButton && <div className="flex-shrink-0 w-[52px]" />}
         </div>
         {showRightScrollButton && (
           <button


### PR DESCRIPTION
Fixes #848

## What was wrong

When the project toolbar has enough tabs to overflow, scrolling right causes the last tab's close button (X) to overlap with the right scroll arrow (>). This makes it easy to accidentally delete a project when trying to scroll.

## What was changed

Added a 52px spacer element inside the scrollable tabs container, conditionally rendered when the right scroll button is visible. This spacer matches the offset of the scroll arrow button (bsolute right-[52px]), creating a gap between the last tab's close button and the scroll arrow. The spacer scrolls with the tab content, so when scrolled to the rightmost position, the last tab stops before reaching the scroll button.