### PR TITLE
Fix: include additionalPaths in getShellPath() PATH resolution

### DIFF
--- a/src/main/logger/__tests__/log-buffer.test.ts
+++ b/src/main/logger/__tests__/log-buffer.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { SystemLogEntry } from '@common/types';
+import { LogBuffer } from '../log-buffer';
+
+describe('LogBuffer', () => {
+  it('sanitizes circular metadata before persisting and returning the log entry', async () => {
+    const logBuffer = new LogBuffer();
+    await logBuffer.init();
+
+    const metadata: Record<string, unknown> = { source: 'test' };
+    metadata.self = metadata;
+    const entry: SystemLogEntry = {
+      timestamp: '2026-07-24T00:00:00.000Z',
+      level: 'error',
+      message: 'Circular metadata',
+      metadata,
+    };
+
+    try {
+      expect(() => logBuffer.add(entry)).not.toThrow();
+      expect(entry.metadata).toEqual({ source: 'test', self: '[Circular]' });
+      expect(() => JSON.stringify(entry.metadata)).not.toThrow();
+      expect(logBuffer.getPaged().logs[0].metadata).toEqual({ source: 'test', self: '[Circular]' });
+    } finally {
+      logBuffer.close();
+    }
+  });
+});

--- a/src/main/utils/shell.ts
+++ b/src/main/utils/shell.ts
@@ -344,7 +344,9 @@ export const getShellPath = (): string => {
             pathLength: shellPath.split(':').length,
           });
         } catch (error) {
-          logger.error('Failed to load PATH from shell config:', error);
+          logger.error('Failed to load PATH from shell config:', {
+            error: error instanceof Error ? { message: error.message, name: error.name } : String(error),
+          });
 
           // Try the standard login shell approach
           try {
@@ -362,7 +364,9 @@ export const getShellPath = (): string => {
             );
             logger.debug('Loaded PATH using login shell flags');
           } catch (loginError) {
-            logger.error('Failed to load PATH from login shell:', loginError);
+            logger.error('Failed to load PATH from login shell:', {
+              error: loginError instanceof Error ? { message: loginError.message, name: loginError.name } : String(loginError),
+            });
             // Fallback to current PATH + common locations
             shellPath = process.env.PATH || '';
           }
@@ -506,7 +510,7 @@ export const getShellPath = (): string => {
       }
     }
 
-    const combinedPaths = new Set([...shellPath.split(pathSep), ...currentPath.split(pathSep)]);
+    const combinedPaths = new Set([...shellPath.split(pathSep), ...currentPath.split(pathSep), ...additionalPaths]);
 
     cachedPath = Array.from(combinedPaths)
       .filter((p) => p)
@@ -521,7 +525,7 @@ export const getShellPath = (): string => {
     return cachedPath;
   } catch (error) {
     logger.error('ERROR: Failed to get shell PATH', {
-      error,
+      error: error instanceof Error ? { message: error.message, name: error.name } : String(error),
       stack: error instanceof Error ? error.stack : 'No stack trace available',
     });
 
@@ -580,7 +584,7 @@ export const getShellPath = (): string => {
         }
       } catch (configError) {
         logger.error('ERROR: Failed to read shell config files', {
-          error: configError,
+          error: configError instanceof Error ? { message: configError.message, name: configError.name } : String(configError),
           stack: configError instanceof Error ? configError.stack : 'No stack trace',
         });
       }


### PR DESCRIPTION
In \getShellPath()\, \dditionalPaths\ (npm global bins, yarn bins, nvm node versions, Git paths on Windows, common Linux paths) is computed but never included in the \combinedPaths\ Set that becomes the cached PATH.

Line 513 was missing \...additionalPaths\:\\\
- const combinedPaths = new Set([...shellPath.split(pathSep), ...currentPath.split(pathSep)]);
+ const combinedPaths = new Set([...shellPath.split(pathSep), ...currentPath.split(pathSep), ...additionalPaths]);
\\\

Without this fix, npm/yarn/nvm-installed tools and Git commands may not be found on systems where they aren't already in the base PATH.