### PR TITLE
Fix: include additionalPaths in getShellPath() PATH resolution

### DIFF
--- a/src/main/utils/shell.ts
+++ b/src/main/utils/shell.ts
@@ -506,7 +506,7 @@ export const getShellPath = (): string => {
       }
     }
 
-    const combinedPaths = new Set([...shellPath.split(pathSep), ...currentPath.split(pathSep)]);
+    const combinedPaths = new Set([...shellPath.split(pathSep), ...currentPath.split(pathSep), ...additionalPaths]);
 
     cachedPath = Array.from(combinedPaths)
       .filter((p) => p)


### PR DESCRIPTION
This PR includes dditionalPaths in the getShellPath() PATH resolution.

Previously, dditionalPaths was only used as a fallback when shellPath was empty. Now it's included in the combinedPaths set alongside shellPath and currentPath, ensuring that additional paths are always considered when resolving the shell PATH.

Fixes the issue where dditionalPaths were ignored when shellPath was already available.