### PR TITLE
fix(aider): clear stale state after natural process exit

### DIFF
--- a/src/main/task/__tests__/aider-manager.test.ts
+++ b/src/main/task/__tests__/aider-manager.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { AiderManager } from '../aider-manager';
+
+type FakeAiderProcess = { pid?: number };
+
+const createManager = (): AiderManager => {
+  const task = {
+    getProjectDir: () => '/tmp/aider-desk-test-project',
+    getTaskDir: () => '/tmp/aider-desk-test-project/task',
+    task: { id: 'task-id' },
+    taskId: 'task-id',
+  };
+
+  return new AiderManager(task as never, {} as never, {} as never, {} as never, () => [], {} as never);
+};
+
+describe('AiderManager process lifecycle', () => {
+  it('clears the started state when the child exits naturally', () => {
+    const manager = createManager();
+    const process = { pid: 1234 } as FakeAiderProcess;
+    const internals = manager as unknown as {
+      aiderProcess: FakeAiderProcess | null;
+      aiderStarting: boolean;
+      currentCommand: string | null;
+      handleAiderProcessExit: (process: FakeAiderProcess, code: number | null) => void;
+    };
+
+    internals.aiderProcess = process;
+    internals.aiderStarting = false;
+    internals.currentCommand = 'ask';
+
+    internals.handleAiderProcessExit(process, 0);
+
+    expect(manager.isStarted()).toBe(false);
+    expect(internals.currentCommand).toBeNull();
+  });
+});

--- a/src/main/task/aider-manager.ts
+++ b/src/main/task/aider-manager.ts
@@ -25,6 +25,8 @@ export class AiderManager {
   private aiderStarting: boolean = false;
   private aiderStartPromise: Promise<void> | null = null;
   private aiderStartResolve: (() => void) | null = null;
+  private aiderStartReject: ((reason?: unknown) => void) | null = null;
+  private aiderStartError: Error | null = null;
   private aiderModelsData: ModelsData | null = null;
   private currentCommand: string | null = null;
   private commandOutputs: Map<string, string> = new Map();
@@ -50,6 +52,7 @@ export class AiderManager {
     await this.checkAndCleanupPidFile();
 
     // Set aiderStarting to true when starting aider
+    this.aiderStartError = null;
     this.aiderStarting = true;
     this.eventManager.sendAiderConnectorStatus({ state: 'starting-connector' }, this.task.getProjectDir(), this.task.taskId);
 
@@ -214,13 +217,8 @@ export class AiderManager {
       });
     });
 
-    this.aiderProcess.on('close', (code) => {
-      logger.info('Aider process exited:', {
-        baseDir: this.task.getTaskDir(),
-        taskId: this.task.task.id,
-        code,
-      });
-    });
+    const aiderProcess = this.aiderProcess;
+    aiderProcess.on('close', (code) => this.handleAiderProcessExit(aiderProcess, code));
 
     void this.writeAiderProcessPidFile();
   }
@@ -266,13 +264,44 @@ export class AiderManager {
     return !!this.aiderProcess;
   }
 
+  private handleAiderProcessExit(process: ChildProcessWithoutNullStreams, code: number | null): void {
+    logger.info('Aider process exited:', {
+      baseDir: this.task.getTaskDir(),
+      taskId: this.task.task.id,
+      code,
+    });
+
+    // A forced restart can spawn a replacement before the old close event is
+    // delivered. Never let that stale event clear the replacement process.
+    if (this.aiderProcess !== process) {
+      return;
+    }
+
+    this.aiderProcess = null;
+    this.aiderStarting = false;
+    this.removeAiderProcessPidFile();
+    this.currentCommand = null;
+
+    const error = new Error(`Aider process exited before the connector became ready (code ${code ?? 'unknown'})`);
+    this.aiderStartError = error;
+    this.aiderStartReject?.(error);
+    this.aiderStartReject = null;
+    this.aiderStartResolve = null;
+    this.aiderStartPromise = null;
+  }
+
   private createAiderStartPromise(): Promise<void> {
+    if (this.aiderStartError) {
+      return Promise.reject(this.aiderStartError);
+    }
+
     if (this.aiderStartPromise) {
       return this.aiderStartPromise;
     }
 
-    this.aiderStartPromise = new Promise((resolve) => {
+    this.aiderStartPromise = new Promise((resolve, reject) => {
       this.aiderStartResolve = resolve;
+      this.aiderStartReject = reject;
       if (!this.aiderStarting) {
         resolve();
       }
@@ -357,10 +386,12 @@ export class AiderManager {
     // Set aiderStarting to false when a connector with source==='aider' is added
     if (connector.source === 'aider') {
       this.aiderStarting = false;
+      this.aiderStartError = null;
       this.eventManager.sendAiderConnectorStatus({ state: 'ready' }, this.task.getProjectDir(), this.task.taskId);
       if (this.aiderStartResolve) {
         this.aiderStartResolve();
         this.aiderStartResolve = null;
+        this.aiderStartReject = null;
         this.aiderStartPromise = null;
       }
     }


### PR DESCRIPTION
## Summary

A naturally exited Aider child process remained stored in `AiderManager`, so `isStarted()` stayed true and later commands could not restart Aider. The close handler now clears the process reference, PID file, command output state, and startup state, rejects a pending startup wait when the connector never became ready, and ignores stale close events from a replaced process.

## Verification

- `npm run test:node -- src/main/task/__tests__/aider-manager.test.ts` — passed
- `npm run typecheck` — passed
- `npm exec eslint -- src/main/task/aider-manager.ts src/main/task/__tests__/aider-manager.test.ts` — passed
- `git diff --check` — passed

The change is limited to the managed Aider child-process lifecycle; no data migration or API change is involved.