### PR TITLE
refactor(worktrees): prune stale worktrees and reorder creation steps

### DIFF
--- a/src/main/worktrees/__tests__/worktree-manager.create.test.ts
+++ b/src/main/worktrees/__tests__/worktree-manager.create.test.ts
@@ -1,0 +1,128 @@
+import { join } from 'path';
+
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+import { WorktreeManager } from '../worktree-manager';
+
+vi.mock('@/logger', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('@/utils', () => ({
+  execWithShellPath: vi.fn(),
+  withLock: vi.fn((_id: string, fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs/promises')>();
+  return {
+    ...actual,
+    rm: vi.fn(),
+    mkdir: vi.fn(),
+  };
+});
+
+import { AIDER_DESK_TASKS_DIR } from '@/constants';
+import { execWithShellPath } from '@/utils';
+
+const projectPath = '/test/project';
+const taskId = 'task-123';
+const worktreePath = join(projectPath, AIDER_DESK_TASKS_DIR, taskId, 'worktree');
+
+describe('WorktreeManager - createWorktree', () => {
+  let worktreeManager: WorktreeManager;
+
+  const getCommands = (): string[] => (execWithShellPath as Mock).mock.calls.map((call: unknown[]) => call[0] as string);
+
+  const mockGitCommands = (options?: { pruneFails?: boolean; removeFails?: boolean }) => {
+    (execWithShellPath as Mock).mockImplementation(async (command: string) => {
+      if (command === 'git rev-parse --is-inside-work-tree') {
+        return { stdout: 'true\n', stderr: '' };
+      }
+      if (command === 'git worktree prune') {
+        if (options?.pruneFails) {
+          throw new Error('prune failed');
+        }
+        return { stdout: '', stderr: '' };
+      }
+      if (command.startsWith('git worktree remove')) {
+        if (options?.removeFails) {
+          throw new Error("validation failed, cannot remove working tree: 'worktree/.git' does not exist");
+        }
+        return { stdout: '', stderr: '' };
+      }
+      if (command === 'git rev-parse HEAD') {
+        return { stdout: 'abc123\n', stderr: '' };
+      }
+      if (command === 'git show-ref --verify --quiet refs/heads/task-branch') {
+        throw new Error('branch does not exist');
+      }
+      if (command.startsWith('git worktree add')) {
+        return { stdout: '', stderr: '' };
+      }
+      if (command === 'git rev-parse task-branch') {
+        return { stdout: 'def456\n', stderr: '' };
+      }
+      if (command === 'git rev-parse --abbrev-ref HEAD') {
+        return { stdout: 'main\n', stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    worktreeManager = new WorktreeManager();
+  });
+
+  it('prunes stale worktree registrations and removes existing worktree before adding', async () => {
+    mockGitCommands({ removeFails: true });
+
+    const worktree = await worktreeManager.createWorktree(projectPath, taskId, 'task-branch');
+
+    const commands = getCommands();
+    const pruneIndex = commands.indexOf('git worktree prune');
+    const removeIndex = commands.findIndex((command) => command.startsWith('git worktree remove'));
+    const addIndex = commands.findIndex((command) => command.startsWith('git worktree add'));
+
+    expect(pruneIndex).toBeGreaterThanOrEqual(0);
+    expect(removeIndex).toBeGreaterThan(pruneIndex);
+    expect(addIndex).toBeGreaterThan(removeIndex);
+    expect(execWithShellPath).toHaveBeenCalledWith('git worktree prune', { cwd: projectPath });
+    expect(worktree).toEqual({
+      path: worktreePath,
+      baseCommit: 'abc123',
+      baseBranch: 'main',
+      branch: 'task-branch',
+    });
+  });
+
+  it('still creates the worktree when prune fails', async () => {
+    mockGitCommands({ pruneFails: true });
+
+    const worktree = await worktreeManager.createWorktree(projectPath, taskId, 'task-branch');
+
+    expect(worktree.path).toBe(worktreePath);
+    expect(worktree.branch).toBe('task-branch');
+  });
+
+  it('creates a detached worktree when no branch is provided', async () => {
+    mockGitCommands();
+
+    const worktree = await worktreeManager.createWorktree(projectPath, taskId);
+
+    const addCommand = getCommands().find((command) => command.startsWith('git worktree add'));
+    expect(addCommand).toBe(`git worktree add "${worktreePath}" HEAD`);
+    expect(worktree).toEqual({
+      path: worktreePath,
+      baseCommit: 'abc123',
+      baseBranch: 'main',
+      branch: 'main',
+    });
+  });
+});

--- a/src/main/worktrees/__tests__/worktree-manager.task-worktree.test.ts
+++ b/src/main/worktrees/__tests__/worktree-manager.task-worktree.test.ts
@@ -1,0 +1,73 @@
+import { join } from 'path';
+
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+import { WorktreeManager } from '../worktree-manager';
+
+vi.mock('@/logger', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('@/utils', () => ({
+  execWithShellPath: vi.fn(),
+  withLock: vi.fn((_id: string, fn: () => Promise<unknown>) => fn()),
+}));
+
+import { AIDER_DESK_TASKS_DIR } from '@/constants';
+import { execWithShellPath } from '@/utils';
+
+const projectPath = '/test/project';
+const taskId = 'task-123';
+const taskWorktreePath = join(projectPath, AIDER_DESK_TASKS_DIR, taskId, 'worktree');
+
+describe('WorktreeManager - getTaskWorktree', () => {
+  let worktreeManager: WorktreeManager;
+
+  const mockWorktreeList = (taskWorktreeEntry: string) => {
+    (execWithShellPath as Mock).mockImplementation(async (command: string) => {
+      if (command === 'git worktree list --porcelain') {
+        const stdout = `worktree ${projectPath}\nHEAD abc123\nbranch refs/heads/main\n\n${taskWorktreeEntry}\n`;
+        return { stdout, stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    worktreeManager = new WorktreeManager();
+  });
+
+  it('returns the task worktree when it exists and is valid', async () => {
+    mockWorktreeList(`worktree ${taskWorktreePath}\nHEAD def456\nbranch refs/heads/aider-desk/task/t2`);
+
+    const worktree = await worktreeManager.getTaskWorktree(projectPath, taskId);
+
+    expect(worktree).toEqual({
+      path: taskWorktreePath,
+      branch: 'aider-desk/task/t2',
+      baseCommit: 'def456',
+    });
+  });
+
+  it('returns null when the task worktree is prunable (stale registration)', async () => {
+    mockWorktreeList(`worktree ${taskWorktreePath}\nHEAD def456\nbranch refs/heads/old-branch\nprunable`);
+
+    const worktree = await worktreeManager.getTaskWorktree(projectPath, taskId);
+
+    expect(worktree).toBeNull();
+  });
+
+  it('returns null when no worktree exists for the task', async () => {
+    mockWorktreeList('');
+
+    const worktree = await worktreeManager.getTaskWorktree(projectPath, taskId);
+
+    expect(worktree).toBeNull();
+  });
+});

--- a/src/main/worktrees/worktree-manager.ts
+++ b/src/main/worktrees/worktree-manager.ts
@@ -1318,7 +1318,8 @@ export class WorktreeManager {
       // Find worktree that matches our task's worktree path
       const taskWorktree = worktrees.find((w) => w.path === taskWorktreePath);
 
-      if (taskWorktree) {
+      // A prunable worktree has a missing or invalid directory (stale registration), treat it as absent
+      if (taskWorktree && !taskWorktree.prunable) {
         return taskWorktree;
       }
 

--- a/src/main/worktrees/worktree-manager.ts
+++ b/src/main/worktrees/worktree-manager.ts
@@ -88,8 +88,6 @@ export class WorktreeManager {
 
   async createWorktree(projectPath: string, taskId: string, branch?: string, baseBranch = 'HEAD'): Promise<Worktree> {
     return await withLock(`worktree-create-${projectPath}-${taskId}`, async () => {
-      await this.initializeWorktree(projectPath, taskId);
-
       const worktreePath = this.getWorktreePath(projectPath, taskId);
 
       try {
@@ -103,14 +101,23 @@ export class WorktreeManager {
           await execWithShellPath('git init', { cwd: projectPath });
         }
 
-        // 2. Clean up any existing worktree directory first
+        // 2. Clean up stale worktree registrations (e.g. the directory was deleted out-of-band)
+        try {
+          await execWithShellPath('git worktree prune', { cwd: projectPath });
+        } catch (error) {
+          logger.warn('Failed to prune stale worktree registrations:', error);
+        }
+
+        // 3. Clean up any existing worktree before recreating its directory
         try {
           await execWithShellPath(`git worktree remove "${worktreePath}" --force`, { cwd: projectPath });
         } catch {
           // Ignore cleanup errors
         }
 
-        // 3. Ensure the repository has at least one commit
+        await this.initializeWorktree(projectPath, taskId);
+
+        // 4. Ensure the repository has at least one commit
         try {
           await execWithShellPath('git rev-parse HEAD', { cwd: projectPath });
         } catch {
@@ -129,7 +136,7 @@ export class WorktreeManager {
           }
         }
 
-        // 4. Logic for creating the worktree
+        // 5. Logic for creating the worktree
         let baseCommit: string;
         let newBranchName: string;
         const baseRef = baseBranch; // Will be 'HEAD' if not provided

--- a/src/main/worktrees/worktree-manager.ts
+++ b/src/main/worktrees/worktree-manager.ts
@@ -111,8 +111,8 @@ export class WorktreeManager {
         // 3. Clean up any existing worktree before recreating its directory
         try {
           await execWithShellPath(`git worktree remove "${worktreePath}" --force`, { cwd: projectPath });
-        } catch {
-          // Ignore cleanup errors
+        } catch (error) {
+          logger.warn(`Failed to remove existing worktree at ${worktreePath}:`, error);
         }
 
         await this.initializeWorktree(projectPath, taskId);
@@ -148,8 +148,9 @@ export class WorktreeManager {
             // Check if it's an actual branch (not just a commit SHA)
             await execWithShellPath(`git show-ref --verify --quiet refs/heads/${branch}`, { cwd: projectPath });
             branchExists = true;
-          } catch {
-            // Branch doesn't exist
+          } catch (error) {
+            // Branch doesn't exist, it will be created from baseRef
+            logger.debug(`Branch ${branch} not found, will create it from ${baseRef}:`, error);
           }
 
           if (branchExists) {


### PR DESCRIPTION
Fix with Test about the reported issue:

Hi Hotovoteam: i mean the worktree Feature is partially buggy, i created a project and let create a task list, and if i want to implement a task, i switch to the worktree mode, but AiderDesk says, "no" and i see this error in the logs:

genericNodeError (node:internal/errors:985:15)\n    at wrappedFn (node:internal/errors:539:14)\n    at ChildProcess.exithandler (node:child_process:417:12)\n    at ChildProcess.emit (node:events:509:28)\n    at maybeClose (node:internal/child_process:1124:16)\n    at ChildProcess._handle.onexit (node:internal/child_process:306:5)","stderr":"Preparing worktree (checking out 'aider-desk/task/docsai-t2-config-model-validation')\nfatal: 'C:/work/DocsAI/.aider-desk/tasks/19321b6c/worktree' is a missing but already registered worktree;\nuse 'add -f' to override, or 'prune' or 'remove' to clear\n","stdout":"","timestamp":"2026-08-24T11:09:09.082Z"}

**Further Analysis:**
I
Root cause: a task's workingMode is fixed at creation time — there's no way to switch an existing task to worktree mode. Your prepared T1–T10 series was created as local tasks, so AiderDesk never gives them real git worktrees. Evidence from the repo:

git worktree list shows real worktrees only for the tasks created with worktree mode (b25619dc = this task, e79df709 = plan task)
T1's worktree dir is a plain file copy (no .git), T2's is an empty leftover (marked prunable) — AiderDesk won't use them
Proposed plan:

Re-create the 9 prepared tasks (T2–T10) as new tasks with worktree=true, same names, same agent profile (dotnet), copying each original initial prompt verbatim so nothing is lost.
Delete the 9 old local-mode tasks (T2–T10) to avoid duplicate series. (T1 stays — it's READY_FOR_REVIEW and its scaffold is already committed on master.)
Cleanup: git worktree prune to drop the stale T2 worktree registration and empty dir.
Then you work the series one at a time as before; each task gets its own branch (aider-desk/task/...) and you merge sequentially so the "assume task N-1 done" prompts hold.
Side note: the old memory claiming these were plain subdirs is outdated — worktree-mode tasks here are real git worktrees; I'll correct that at the end.