### PR TITLE
fix: auto-compact for models with unknown context size

### DIFF
--- a/src/main/agent/__tests__/agent.test.ts
+++ b/src/main/agent/__tests__/agent.test.ts
@@ -28,7 +28,7 @@ import path from 'path';
 // @ts-expect-error istextorbinary is not typed properly
 import { isBinary } from 'istextorbinary';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ToolApprovalState } from '@common/types';
+import { ContextCompactionType, ToolApprovalState } from '@common/types';
 import { POWER_TOOL_FILE_READ, POWER_TOOL_GROUP_NAME, TOOL_GROUP_NAME_SEPARATOR } from '@common/tools';
 import { fileTypeFromBuffer } from 'file-type';
 import { v4 as uuidv4 } from 'uuid';
@@ -822,5 +822,197 @@ describe('Agent - getContextFilesAsToolCallMessages', () => {
       expect(new Set(toolCallIds).size).toBe(toolCallIds.length);
       expect(mockUuidv4).toHaveBeenCalled();
     });
+  });
+});
+
+describe('Agent - compactMessagesIfNeeded', () => {
+  let agent: Agent;
+  let mockProfile: ReturnType<typeof createMockAgentProfile>;
+
+  const buildAgent = (getModelSettings: () => unknown, percentage = 90) => {
+    const mockStore = {
+      getSettings: vi.fn(() => ({
+        taskSettings: {
+          contextCompactingThreshold: { percentage, tokens: 100000 },
+          contextCompactionType: ContextCompactionType.Compact,
+        },
+      })),
+    };
+    const mockModelManager = {
+      getModelSettings: vi.fn(getModelSettings),
+    };
+
+    return new AgentClass(
+      mockStore as any,
+      {} as any,
+      { getConnectors: vi.fn(() => []) } as any,
+      { getMergedServers: vi.fn(() => ({})) } as any,
+      mockModelManager as any,
+      { captureAgentRun: vi.fn() } as any,
+      {} as any,
+      {} as any,
+      { isInitialized: vi.fn(() => false), createExtensionToolset: vi.fn(() => ({})) } as any,
+    );
+  };
+
+  const makeUserRequestMessage = (): any => ({
+    id: 'user-1',
+    role: 'user',
+    content: 'continue',
+  });
+
+  const makeResultMessages = (sentTokens: number): any[] => [
+    {
+      id: 'assistant-1',
+      role: 'assistant',
+      content: '',
+      usageReport: {
+        model: 'test-model',
+        sentTokens,
+        receivedTokens: 1000,
+        cacheReadTokens: 0,
+        messageCost: 0,
+        agentTotalCost: 0,
+      },
+    },
+  ];
+
+  const runCompact = async (resultMessages: any[]) => {
+    const task = createMockTask();
+    task.compactConversation = vi.fn().mockResolvedValue(undefined);
+    task.smartCompactConversation = vi.fn().mockResolvedValue([]);
+    task.handoffConversation = vi.fn().mockResolvedValue(undefined);
+    task.getContextMessages = vi.fn().mockResolvedValue([]);
+    task.addLogMessage = vi.fn();
+    task.reloadGroupMessages = vi.fn();
+
+    agent['prepareMessages'] = vi.fn().mockResolvedValue([]);
+
+    await agent['compactMessagesIfNeeded'](
+      task,
+      mockProfile,
+      { id: 'test-provider' } as any,
+      'test-model',
+      makeUserRequestMessage(),
+      [],
+      [],
+      [],
+      resultMessages,
+    );
+
+    return task;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockProfile = createMockAgentProfile();
+  });
+
+  it('should compact based on the token threshold when the model context size is unknown', async () => {
+    // maxInputTokens is undefined (custom/self-hosted model not in the catalog)
+    agent = buildAgent(() => undefined);
+
+    // 120000 + 1000 = 121000 > 100000 token threshold
+    const task = await runCompact(makeResultMessages(120000));
+
+    expect(task.compactConversation).toHaveBeenCalledTimes(1);
+  });
+
+  it('should NOT compact when token usage is below the token threshold and context size is unknown', async () => {
+    agent = buildAgent(() => undefined);
+
+    // 50000 + 1000 = 51000 < 100000 token threshold
+    const task = await runCompact(makeResultMessages(50000));
+
+    expect(task.compactConversation).not.toHaveBeenCalled();
+  });
+
+  it('should use the task-level token override even when the model context size is unknown', async () => {
+    agent = buildAgent(() => undefined);
+
+    // Set a low task-level override so that 121000 tokens exceeds it
+    const task = createMockTask({ contextCompactingThresholdTokens: 50000 } as any);
+    task.compactConversation = vi.fn().mockResolvedValue(undefined);
+    task.getContextMessages = vi.fn().mockResolvedValue([]);
+    task.addLogMessage = vi.fn();
+    task.reloadGroupMessages = vi.fn();
+    agent['prepareMessages'] = vi.fn().mockResolvedValue([]);
+
+    await agent['compactMessagesIfNeeded'](
+      task,
+      mockProfile,
+      { id: 'test-provider' } as any,
+      'test-model',
+      makeUserRequestMessage(),
+      [],
+      [],
+      [],
+      makeResultMessages(120000),
+    );
+
+    expect(task.compactConversation).toHaveBeenCalledTimes(1);
+  });
+
+  it('should honor the percentage threshold when the model context size is known', async () => {
+    // maxInputTokens known: 200000. percentage 90 -> 180000, tokens 100000 -> min = 100000
+    agent = buildAgent(() => ({ id: 'test-model', providerId: 'test-provider', maxInputTokens: 200000 }));
+
+    // 121000 > 100000
+    const task = await runCompact(makeResultMessages(120000));
+
+    expect(task.compactConversation).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not compact when percentage is 0 (explicit disable) with a known context size', async () => {
+    agent = buildAgent(() => ({ id: 'test-model', providerId: 'test-provider', maxInputTokens: 200000 }), 0);
+
+    const task = await runCompact(makeResultMessages(120000));
+
+    expect(task.compactConversation).not.toHaveBeenCalled();
+  });
+
+  it('should not compact when percentage is 0 (explicit disable) even with an unknown context size', async () => {
+    agent = buildAgent(() => undefined, 0);
+
+    const task = await runCompact(makeResultMessages(120000));
+
+    expect(task.compactConversation).not.toHaveBeenCalled();
+  });
+
+  it('should count a tool result appended after the last usage report when measuring context size', async () => {
+    agent = buildAgent(() => ({ id: 'test-model', providerId: 'test-provider', maxInputTokens: 200000 }));
+
+    // The usage report alone (51000) is below the 100000 threshold, but the large
+    // trailing tool result must push the measured total past it.
+    const bigText = 'lorem ipsum dolor sit amet '.repeat(10000); // ~70k tokens
+    const resultMessages = [
+      ...makeResultMessages(50000),
+      {
+        id: 'tool-1',
+        role: 'tool',
+        content: [{ type: 'tool-result', toolCallId: 'call-1', toolName: 'power:file_read', output: { type: 'text', value: bigText } }],
+      },
+    ];
+
+    const task = await runCompact(resultMessages);
+
+    expect(task.compactConversation).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not compact when the trailing tool result keeps the total below the threshold', async () => {
+    agent = buildAgent(() => ({ id: 'test-model', providerId: 'test-provider', maxInputTokens: 200000 }));
+
+    const resultMessages = [
+      ...makeResultMessages(50000),
+      {
+        id: 'tool-1',
+        role: 'tool',
+        content: [{ type: 'tool-result', toolCallId: 'call-1', toolName: 'power:file_read', output: { type: 'text', value: 'ok' } }],
+      },
+    ];
+
+    const task = await runCompact(resultMessages);
+
+    expect(task.compactConversation).not.toHaveBeenCalled();
   });
 });

--- a/src/main/agent/agent.ts
+++ b/src/main/agent/agent.ts
@@ -1979,15 +1979,27 @@ export class Agent {
     const usageReport = lastUsageReportMessage?.usageReport;
     const maxTokens = this.modelManager.getModelSettings(provider.id, model)?.maxInputTokens;
 
-    if (!usageReport || !maxTokens) {
-      logger.debug('No usageReport or maxTokens', {
+    if (!usageReport) {
+      logger.debug('No usageReport', {
         usageReport,
         maxTokens,
       });
       return true;
     }
 
-    const totalTokens = usageReport.sentTokens + usageReport.receivedTokens + (usageReport.cacheReadTokens ?? 0);
+    let totalTokens = usageReport.sentTokens + usageReport.receivedTokens + (usageReport.cacheReadTokens ?? 0);
+
+    // The usage report covers only up to (and including) the last model call. Tool
+    // results appended after it are not in that report, yet they are part of the next
+    // prompt — so a single large result (e.g. parallel file reads) can silently push
+    // the request past the model's context limit. Add an estimate for the trailing
+    // messages so the threshold reflects the real next-prompt size.
+    const lastReportIndex = resultMessages.indexOf(lastUsageReportMessage);
+    if (lastReportIndex >= 0 && lastReportIndex < resultMessages.length - 1) {
+      const trailingTokens = estimateMessageTokens(resultMessages.slice(lastReportIndex + 1));
+      totalTokens += trailingTokens;
+      logger.debug('Added trailing (post-usage-report) tokens to context total', { trailingTokens, totalTokens });
+    }
 
     let effectiveThreshold: number;
     let thresholdDescription: string;
@@ -1995,10 +2007,10 @@ export class Agent {
     if (taskTokensOverride !== undefined && taskTokensOverride > 0) {
       effectiveThreshold = taskTokensOverride;
       thresholdDescription = `task override: ${taskTokensOverride}`;
-    } else {
-      if (thresholdConfig.percentage === 0) {
-        return true;
-      }
+    } else if (thresholdConfig.percentage === 0) {
+      // percentage disabled → auto-compact off (consistent whether or not the context size is known)
+      return true;
+    } else if (maxTokens) {
       const percentageThreshold = (maxTokens * thresholdConfig.percentage) / 100;
       const tokenThreshold = thresholdConfig.tokens;
       if (tokenThreshold > 0) {
@@ -2007,6 +2019,16 @@ export class Agent {
         effectiveThreshold = percentageThreshold;
       }
       thresholdDescription = `percentage: ${percentageThreshold}, tokens: ${tokenThreshold}`;
+    } else if (thresholdConfig.tokens > 0) {
+      // model context size unknown — fall back to the absolute token threshold
+      effectiveThreshold = thresholdConfig.tokens;
+      thresholdDescription = `tokens: ${thresholdConfig.tokens}`;
+    } else {
+      logger.debug('No maxTokens or usable token threshold', {
+        maxTokens,
+        thresholdConfig,
+      });
+      return true;
     }
 
     logger.debug('Checking total tokens vs effective threshold', {

--- a/src/main/models/model-manager.ts
+++ b/src/main/models/model-manager.ts
@@ -61,7 +61,7 @@ const MODEL_LOAD_TIMEOUT_MS = 30_000;
 const MODELS_META_URL = 'https://models.dev/api.json';
 const MODELS_FILE = path.join(AIDER_DESK_DATA_DIR, 'models.json');
 const PROVIDER_MODELS_CACHE_FILE = path.join(AIDER_DESK_CACHE_DIR, 'provider-models.json');
-const PROVIDER_MODELS_CACHE_VERSION = 2;
+const PROVIDER_MODELS_CACHE_VERSION = 3;
 
 type ProviderModelsCache = {
   version: number;

--- a/src/main/models/providers/__tests__/ollama.test.ts
+++ b/src/main/models/providers/__tests__/ollama.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { OllamaProvider } from '@common/agent';
+import { ProviderProfile, SettingsData } from '@common/types';
+
+import { loadOllamaModels } from '../ollama';
+
+vi.mock('@/logger');
+
+const profile: ProviderProfile = {
+  id: 'ollama-test',
+  provider: { name: 'ollama', baseUrl: 'http://localhost:11434' } as OllamaProvider,
+} as unknown as ProviderProfile;
+
+const settings = {
+  aider: { environmentVariables: '', options: '' },
+} as unknown as SettingsData;
+
+const mockFetch = (payload: unknown) => {
+  (global.fetch as any) = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => payload,
+  } as any);
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('loadOllamaModels', () => {
+  it('sets maxInputTokens from the model context_length when present', async () => {
+    mockFetch({
+      models: [
+        { name: 'model-a:latest', details: { context_length: 262144 } },
+        { name: 'model-b:latest', details: {} },
+      ],
+    });
+
+    const result = await loadOllamaModels(profile, settings);
+
+    expect(result.success).toBe(true);
+    expect(result.models).toEqual([
+      { id: 'model-a:latest', providerId: 'ollama-test', maxInputTokens: 262144 },
+      { id: 'model-b:latest', providerId: 'ollama-test', maxInputTokens: undefined },
+    ]);
+  });
+
+  it('ignores non-positive or missing context_length', async () => {
+    mockFetch({
+      models: [{ name: 'model-zero:latest', details: { context_length: 0 } }, { name: 'model-none:latest' }],
+    });
+
+    const result = await loadOllamaModels(profile, settings);
+
+    expect(result.models).toEqual([
+      { id: 'model-zero:latest', providerId: 'ollama-test', maxInputTokens: undefined },
+      { id: 'model-none:latest', providerId: 'ollama-test', maxInputTokens: undefined },
+    ]);
+  });
+});

--- a/src/main/models/providers/ollama.ts
+++ b/src/main/models/providers/ollama.ts
@@ -38,10 +38,13 @@ export const loadOllamaModels = async (profile: ProviderProfile, settings: Setti
 
     const data = await response.json();
     const models =
-      data?.models?.map((m: { name: string }) => {
+      data?.models?.map((m: { name: string; details?: { context_length?: number } }) => {
+        const contextLength = m.details?.context_length;
+        const maxInputTokens = typeof contextLength === 'number' && contextLength > 0 ? contextLength : undefined;
         return {
           id: m.name,
           providerId: profile.id,
+          maxInputTokens,
         } satisfies Model;
       }) || [];
     logger.info(`Loaded ${models.length} Ollama models from ${effectiveBaseUrl} for profile ${profile.id}`);


### PR DESCRIPTION
Decouple the auto-compact token threshold from maxInputTokens so compaction still triggers when a model's context size is unknown, preventing prompts from growing past the model's hard limit. Also read Ollama models' maxInputTokens from the reported context_length so the percentage-based threshold and token bar work for Ollama (bumps provider-models cache version).

based on this error log, i have configured a context window of 240000, so this parameter have no impact

<img width="1360" height="209" alt="image" src="https://github.com/user-attachments/assets/c2df71fc-4b85-4654-bdd8-e40a7265d8bc" />


<img width="771" height="657" alt="image" src="https://github.com/user-attachments/assets/e8521aef-df89-46d3-8df5-23f0f91bc937" />


responseBody":"{"error":{"message":"This model's maximum context length is 262144 tokens. However, you requested 0 output tokens and your prompt contains at least 262145 input tokens, for a total of at least 262145 tokens. Please reduce the length of the input prompt or the number of requested output tokens. (parameter=input_tokens, value=262145)","type":"BadRequestError","param":"input_tokens","code":400}}"