### PR TITLE
fix: atomic context save and corrupt recovery

### DIFF
--- a/src/main/task/__tests__/context-manager.save-recovery.test.ts
+++ b/src/main/task/__tests__/context-manager.save-recovery.test.ts
@@ -53,6 +53,23 @@ describe('ContextManager - atomic save and corrupt recovery', () => {
       expect(dirFiles.some((file) => file.endsWith('.tmp'))).toBe(false);
     });
 
+    it('cleans up stale temp files orphaned by a crash', async () => {
+      const manager = new ContextManager(createTask(projectDir) as never, 'task-1');
+      await manager.getContextMessages();
+
+      const dir = path.dirname(getContextPath(projectDir));
+      await fs.mkdir(dir, { recursive: true });
+      const staleTemp = path.join(dir, 'context.json.1234567890.abc.tmp');
+      await fs.writeFile(staleTemp, '{"partial": true}', 'utf8');
+
+      manager.addContextMessage(createMessage('message-1', 'Clean me'));
+      await manager.save();
+
+      await expect(fs.access(staleTemp)).rejects.toThrow();
+      const dirFiles = await fs.readdir(dir);
+      expect(dirFiles.some((file) => file.endsWith('.tmp'))).toBe(false);
+    });
+
     it('keeps context.json valid across concurrent save calls', async () => {
       const manager = new ContextManager(createTask(projectDir) as never, 'task-1');
       await manager.getContextMessages();

--- a/src/main/task/__tests__/context-manager.save-recovery.test.ts
+++ b/src/main/task/__tests__/context-manager.save-recovery.test.ts
@@ -1,0 +1,115 @@
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ContextManager } from '../context-manager';
+
+import type { ContextMessage } from '@common/types';
+
+const createMessage = (id: string, content: string): ContextMessage => ({
+  id,
+  role: 'user',
+  content,
+  timestamp: Date.now(),
+});
+
+const getContextPath = (projectDir: string, taskId = 'task-1') => path.join(projectDir, '.aider-desk', 'tasks', taskId, 'context.json');
+
+const createTask = (projectDir: string) => ({
+  getProjectDir: () => projectDir,
+  getTaskDir: () => projectDir,
+  sendContextInfoUpdated: vi.fn(),
+});
+
+describe('ContextManager - atomic save and corrupt recovery', () => {
+  let projectDir: string;
+
+  beforeEach(async () => {
+    projectDir = await fs.mkdtemp(path.join(os.tmpdir(), 'aider-desk-context-save-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(projectDir, { recursive: true, force: true });
+  });
+
+  describe('save', () => {
+    it('writes a valid context.json and leaves no temp file behind', async () => {
+      const manager = new ContextManager(createTask(projectDir) as never, 'task-1');
+      await manager.getContextMessages();
+
+      const messages = [createMessage('message-1', 'Save me')];
+      manager.addContextMessage(messages[0]);
+      await manager.save();
+
+      const contextPath = getContextPath(projectDir);
+      const parsed = JSON.parse(await fs.readFile(contextPath, 'utf8'));
+      expect(parsed.version).toBe(2);
+      expect(parsed.contextMessages).toEqual(messages);
+      expect(parsed.contextFiles).toEqual([]);
+
+      const dirFiles = await fs.readdir(path.dirname(contextPath));
+      expect(dirFiles.some((file) => file.endsWith('.tmp'))).toBe(false);
+    });
+
+    it('keeps context.json valid across concurrent save calls', async () => {
+      const manager = new ContextManager(createTask(projectDir) as never, 'task-1');
+      await manager.getContextMessages();
+
+      const messages = [createMessage('message-1', 'First message'), createMessage('message-2', 'Second message')];
+      manager.addContextMessage(messages[0]);
+      manager.addContextMessage(messages[1]);
+
+      await Promise.all([manager.save(), manager.save(), manager.save(), manager.save()]);
+
+      const contextPath = getContextPath(projectDir);
+      const content = await fs.readFile(contextPath, 'utf8');
+      expect(() => JSON.parse(content)).not.toThrow();
+      const parsed = JSON.parse(content);
+      expect(parsed.contextMessages).toHaveLength(2);
+    });
+  });
+
+  describe('corrupt context recovery', () => {
+    it('moves a corrupt context.json aside and loads an empty context instead of throwing', async () => {
+      const contextPath = getContextPath(projectDir);
+      await fs.mkdir(path.dirname(contextPath), { recursive: true });
+      // Truncated JSON - unterminated string
+      await fs.writeFile(contextPath, '{"version":2,"contextMessages":[{"id":"broken","role":"user","content":"unterminated', 'utf8');
+
+      const manager = new ContextManager(createTask(projectDir) as never, 'task-1');
+
+      await expect(manager.load()).resolves.toBeUndefined();
+      await expect(manager.getContextMessages()).resolves.toEqual([]);
+
+      const dirFiles = await fs.readdir(path.dirname(contextPath));
+      const movedAside = dirFiles.find((file) => file.startsWith('context.json.corrupt-'));
+      expect(movedAside).toBeDefined();
+      await expect(fs.access(contextPath)).rejects.toThrow();
+    });
+
+    it('recovers from the newest backup when context.json is corrupt', async () => {
+      const dir = path.dirname(getContextPath(projectDir));
+      await fs.mkdir(dir, { recursive: true });
+
+      const backupMessages = [createMessage('backup-1', 'From backup')];
+      await fs.writeFile(path.join(dir, 'context.backup.001.json'), JSON.stringify({ version: 2, contextMessages: [], contextFiles: [] }), 'utf8');
+      await fs.writeFile(
+        path.join(dir, 'context.backup.002.json'),
+        JSON.stringify({
+          version: 2,
+          contextMessages: backupMessages,
+          contextFiles: [],
+        }),
+        'utf8',
+      );
+      await fs.writeFile(getContextPath(projectDir), '{"version":2,"contextMessages":["truncated', 'utf8');
+
+      const manager = new ContextManager(createTask(projectDir) as never, 'task-1');
+
+      await expect(manager.load()).resolves.toBeUndefined();
+      await expect(manager.getContextMessages()).resolves.toEqual(backupMessages);
+    });
+  });
+});

--- a/src/main/task/context-manager.ts
+++ b/src/main/task/context-manager.ts
@@ -670,7 +670,8 @@ export class ContextManager {
     // Serialize writes so concurrent saves cannot interleave and corrupt the file
     await withLock(`context-save-${this.taskId}`, async () => {
       try {
-        await fs.mkdir(path.dirname(this.storagePath), { recursive: true });
+        const dir = path.dirname(this.storagePath);
+        await fs.mkdir(dir, { recursive: true });
 
         const contextData: TaskContext = {
           version: CURRENT_CONTEXT_VERSION,
@@ -678,9 +679,13 @@ export class ContextManager {
           contextFiles: this.files,
         };
 
+        // Remove temp files orphaned by a crash between writeFile and rename
+        await this.cleanupStaleTempFiles(dir);
+
         // Write atomically: write to a temp file, then rename over the target so a
         // crash mid-write never leaves context.json half-written.
-        const temporaryPath = `${this.storagePath}.${process.pid}.tmp`;
+        const baseName = path.basename(this.storagePath);
+        const temporaryPath = path.join(dir, `${baseName}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`);
         await fs.writeFile(temporaryPath, JSON.stringify(contextData, null, 2), 'utf8');
         await fs.rename(temporaryPath, this.storagePath);
 
@@ -695,6 +700,28 @@ export class ContextManager {
         throw error;
       }
     });
+  }
+
+  /**
+   * Removes temp files orphaned by a crash between writeFile and rename.
+   * Only safe to call while holding the save lock for this task's storage path.
+   */
+  private async cleanupStaleTempFiles(dir: string): Promise<void> {
+    try {
+      const baseName = path.basename(this.storagePath);
+      const prefix = `${baseName}.`;
+      const files = await fs.readdir(dir);
+      for (const file of files) {
+        if (file.startsWith(prefix) && file.endsWith('.tmp')) {
+          await fs.unlink(path.join(dir, file)).catch(() => undefined);
+        }
+      }
+    } catch (error) {
+      logger.error('Failed to clean up stale task context temp files:', {
+        error,
+        taskId: this.taskId,
+      });
+    }
   }
 
   /**

--- a/src/main/task/context-manager.ts
+++ b/src/main/task/context-manager.ts
@@ -22,7 +22,7 @@ import { AIDER_TOOL_GROUP_NAME, AIDER_TOOL_RUN_PROMPT, SUBAGENTS_TOOL_GROUP_NAME
 
 import logger from '@/logger';
 import { Task } from '@/task';
-import { isDirectory, isFileIgnored } from '@/utils';
+import { isDirectory, isFileIgnored, withLock } from '@/utils';
 import { extractPromptContextFromToolResult } from '@/agent/utils';
 import { migrateContextV1toV2 } from '@/task/migrations/v1-to-v2';
 import { AIDER_DESK_TASKS_DIR } from '@/constants';
@@ -667,26 +667,34 @@ export class ContextManager {
   }
 
   async save(): Promise<void> {
-    try {
-      await fs.mkdir(path.dirname(this.storagePath), { recursive: true });
+    // Serialize writes so concurrent saves cannot interleave and corrupt the file
+    await withLock(`context-save-${this.taskId}`, async () => {
+      try {
+        await fs.mkdir(path.dirname(this.storagePath), { recursive: true });
 
-      const contextData: TaskContext = {
-        version: CURRENT_CONTEXT_VERSION,
-        contextMessages: this.messages,
-        contextFiles: this.files,
-      };
+        const contextData: TaskContext = {
+          version: CURRENT_CONTEXT_VERSION,
+          contextMessages: this.messages,
+          contextFiles: this.files,
+        };
 
-      await fs.writeFile(this.storagePath, JSON.stringify(contextData, null, 2), 'utf8');
-      logger.debug(`Task context saved to ${this.storagePath}`, {
-        taskId: this.taskId,
-      });
-    } catch (error) {
-      logger.error('Failed to save task context:', {
-        error,
-        taskId: this.taskId,
-      });
-      throw error;
-    }
+        // Write atomically: write to a temp file, then rename over the target so a
+        // crash mid-write never leaves context.json half-written.
+        const temporaryPath = `${this.storagePath}.${process.pid}.tmp`;
+        await fs.writeFile(temporaryPath, JSON.stringify(contextData, null, 2), 'utf8');
+        await fs.rename(temporaryPath, this.storagePath);
+
+        logger.debug(`Task context saved to ${this.storagePath}`, {
+          taskId: this.taskId,
+        });
+      } catch (error) {
+        logger.error('Failed to save task context:', {
+          error,
+          taskId: this.taskId,
+        });
+        throw error;
+      }
+    });
   }
 
   /**
@@ -832,7 +840,17 @@ export class ContextManager {
     }
 
     const content = await fs.readFile(this.storagePath, 'utf8');
-    const contextData = content ? JSON.parse(content) : null;
+    let contextData: unknown = null;
+    try {
+      contextData = content ? JSON.parse(content) : null;
+    } catch (error) {
+      logger.error('Failed to parse task context, attempting recovery:', {
+        error,
+        taskId: this.taskId,
+      });
+      const recovery = await this.recoverCorruptContext();
+      return recovery || null;
+    }
 
     if (!contextData) {
       logger.debug('Empty task context found:', { taskId: this.taskId });
@@ -843,6 +861,70 @@ export class ContextManager {
     }
 
     return this.migrateContext(contextData);
+  }
+
+  /**
+   * Recovers from a corrupt/truncated context.json by falling back to the newest
+   * backup if one exists, otherwise moving the corrupt file aside and returning an
+   * empty context so the task still loads instead of failing outright.
+   */
+  private async recoverCorruptContext(): Promise<TaskContext | null> {
+    try {
+      const dir = path.dirname(this.storagePath);
+      const files = await fs.readdir(dir);
+      const backupPattern = /^context\.backup\.(\d+)\.json$/;
+      const backups = files
+        .filter((file) => backupPattern.test(file))
+        .sort((a, b) => {
+          const numA = parseInt(backupPattern.exec(a)![1], 10);
+          const numB = parseInt(backupPattern.exec(b)![1], 10);
+          return numB - numA;
+        });
+
+      if (backups.length > 0) {
+        const backupPath = path.join(dir, backups[0]);
+        try {
+          const content = await fs.readFile(backupPath, 'utf8');
+          const data = JSON.parse(content) as TaskContext;
+          logger.warn('Recovered task context from backup:', {
+            backupPath,
+            taskId: this.taskId,
+          });
+          return this.migrateContext(data);
+        } catch (error) {
+          logger.error('Failed to parse backup task context:', {
+            error,
+            backupPath,
+            taskId: this.taskId,
+          });
+        }
+      }
+    } catch (error) {
+      logger.error('Failed to recover task context:', {
+        error,
+        taskId: this.taskId,
+      });
+    }
+
+    // No usable backup: move the corrupt file aside so it does not keep breaking loads.
+    try {
+      const corruptPath = `${this.storagePath}.corrupt-${Date.now()}`;
+      await fs.rename(this.storagePath, corruptPath);
+      logger.warn('Moved corrupt task context aside:', {
+        corruptPath,
+        taskId: this.taskId,
+      });
+    } catch (error) {
+      logger.error('Failed to move corrupt task context aside:', {
+        error,
+        taskId: this.taskId,
+      });
+    }
+
+    return {
+      contextMessages: [],
+      contextFiles: [],
+    };
   }
 
   private async loadInternal(): Promise<void> {


### PR DESCRIPTION
Writes task context atomically (temp file + rename) serialized through `withLock`, and recovers from a corrupt or truncated `context.json` by falling back to the newest backup or an empty context.

Adds tests for atomic save and corrupt-context recovery.
