### PR TITLE
fix(extensions): log tps-counter diagnostics at debug level

### DIFF
--- a/packages/extensions/extensions/tps-counter/index.ts
+++ b/packages/extensions/extensions/tps-counter/index.ts
@@ -97,11 +97,11 @@ export default class TPSCounterExtension implements Extension {
 
   async onResponseCompleted(event: ResponseCompletedEvent, context: ExtensionContext): Promise<void> {
     const messageId = event.response.messageId;
-    context.log(`[TPS] onResponseCompleted - messageId: ${messageId}`, 'info');
+    context.log(`[TPS] onResponseCompleted - messageId: ${messageId}`, 'debug');
     const startTime = this.messageStartTimes.get(messageId);
 
     if (!startTime || !event.response.usageReport) {
-      context.log(`[TPS] onResponseCompleted - skipping (no startTime or usageReport)`, 'info');
+      context.log(`[TPS] onResponseCompleted - skipping (no startTime or usageReport)`, 'debug');
       return;
     }
 
@@ -128,7 +128,7 @@ export default class TPSCounterExtension implements Extension {
       duration: durationSeconds,
     });
 
-    context.log(`[TPS] messageTpsData keys after update: ${JSON.stringify([...this.messageTpsData.keys()])}`, 'info');
+    context.log(`[TPS] messageTpsData keys after update: ${JSON.stringify([...this.messageTpsData.keys()])}`, 'debug');
 
     this.messageStartTimes.delete(messageId);
     context.triggerUIDataRefresh('tps-counter');
@@ -168,7 +168,7 @@ export default class TPSCounterExtension implements Extension {
 
     if (componentId === 'tps-counter-message-bar') {
       const data = Object.fromEntries(this.messageTpsData);
-      context.log(`[TPS] getUIExtensionData - returning keys: ${JSON.stringify(Object.keys(data))}`, 'info');
+      context.log(`[TPS] getUIExtensionData - returning keys: ${JSON.stringify(Object.keys(data))}`, 'debug');
       return data;
     }
 

--- a/packages/extensions/extensions/tps-counter/index.ts
+++ b/packages/extensions/extensions/tps-counter/index.ts
@@ -27,7 +27,7 @@ interface Settings {
 export default class TPSCounterExtension implements Extension {
   static metadata = {
     name: 'TPS Counter',
-    version: '1.1.0',
+    version: '1.1.1',
     description: 'Displays tokens per second for agent responses',
     author: 'wladimiiir',
     iconUrl: 'https://raw.githubusercontent.com/hotovo/aider-desk/refs/heads/main/packages/extensions/extensions/tps-counter/icon.png',


### PR DESCRIPTION
The TPS counter extension logged message UUIDs at info level every time `getUIExtensionData` was polled, flooding the logs during normal use.

All diagnostic logging (getUIExtensionData key dumps, onResponseCompleted traces, message data key dumps) now uses debug level, so it only appears when debug logging is enabled. Info level is kept for the extension-loaded message and the user-facing toggle confirmations.