### PR TITLE
feat(extensions): add skills context api

### DIFF
--- a/packages/common/src/extensions.ts
+++ b/packages/common/src/extensions.ts
@@ -1328,6 +1328,15 @@ export interface ProjectContext {
    * });
    */
   addDisposable(setup: () => (() => void | Promise<void>) | void): void;
+
+  /**
+   * Get the skills context for listing, finding, and writing AiderDesk skills.
+   * Backed by the same SkillManager used by the built-in skills tools, so skills created here
+   * are picked up by skill activation and the workspace skills panel.
+   * @returns SkillsContext instance (the project's SkillManager)
+   * @throws Error if no SkillManager is available
+   */
+  getSkillContext(): SkillsContext;
 }
 
 /**
@@ -1644,6 +1653,75 @@ export interface MemoryContext {
    * Persists the setting to the store
    */
   setMemoryEnabled(enabled: boolean): void;
+}
+
+/**
+ * Result of a skill write operation (create, update, or file write).
+ * Validation and I/O errors are reported via `success: false` and a human-readable message.
+ */
+export interface SkillWriteResult {
+  /** Whether the operation succeeded */
+  success: boolean;
+  /** Human-readable result or error message */
+  message: string;
+  /** Absolute path of the skill directory or written file (on success) */
+  path?: string;
+}
+
+/**
+ * Context providing access to AiderDesk's skill system.
+ * Backed by the project's SkillManager — the same source of truth used by
+ * skill activation, the workspace skills panel, and the REST API.
+ * Skills live in `~/.aider-desk/skills/` (global) or `<project>/.aider-desk/skills/` (project)
+ * as a directory containing a `SKILL.md` with YAML frontmatter (`name`, `description`)
+ * and optional supporting files under `references/`, `templates/`, `scripts/`, or `assets/`.
+ */
+export interface SkillsContext {
+  /**
+   * List all available skills, including extension-provided, project, global, and builtin skills,
+   * deduplicated by name (project takes precedence over global).
+   */
+  listSkills(): Promise<SkillDefinition[]>;
+
+  /**
+   * Find a skill by name. Checks project skills first, then global skills.
+   * @param name - Skill name to look up
+   */
+  findSkill(name: string): Promise<SkillDefinition | null>;
+
+  /**
+   * Get the directory where a skill with the given name would live in the given location,
+   * regardless of whether it exists yet.
+   * @param name - Skill name
+   * @param location - Write-capable location: 'global' (~/.aider-desk/skills/) or 'project' (<project>/.aider-desk/skills/)
+   */
+  resolveSkillDir(name: string, location: 'global' | 'project'): string;
+
+  /**
+   * Create a new skill from SKILL.md content. Rejects names/frontmatter that violate
+   * skill-authoring rules and skills that already exist at the target location
+   * (a project skill may deliberately shadow a global one).
+   * @param name - Skill name (lowercase-hyphenated). The frontmatter `name` must match.
+   * @param content - Full SKILL.md content including YAML frontmatter
+   * @param location - Where to save: 'global' (default) or 'project'
+   */
+  createSkill(name: string, content: string, location?: 'global' | 'project'): Promise<SkillWriteResult>;
+
+  /**
+   * Fully rewrite the SKILL.md of an existing skill (project first, then global).
+   * @param name - Skill name
+   * @param content - Full SKILL.md content including YAML frontmatter
+   */
+  updateSkill(name: string, content: string): Promise<SkillWriteResult>;
+
+  /**
+   * Write a supporting file inside an existing skill (e.g. 'references/api.md', 'scripts/deploy.sh').
+   * Creates intermediate directories as needed.
+   * @param name - Skill name
+   * @param filePath - Path within the skill, relative to the skill directory
+   * @param content - File content to write
+   */
+  writeSkillFile(name: string, filePath: string, content: string): Promise<SkillWriteResult>;
 }
 
 /**

--- a/packages/extensions/extensions/learn/__tests__/skill-writer.test.ts
+++ b/packages/extensions/extensions/learn/__tests__/skill-writer.test.ts
@@ -1,21 +1,19 @@
-import { mkdtemp, rm, readFile } from 'node:fs/promises';
+import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { createSaveSkillTool, validateName, validateFrontmatter, validateFilePath } from '../skill-writer';
+import { createSaveSkillTool } from '../skill-writer';
 
-const makeValidFrontmatter = (name: string, description = 'Does something useful.'): string => `---
+import type { SkillsContext } from '@aiderdesk/extensions';
+
+const makeValidSkill = (name: string): string => `---
 name: ${name}
-description: ${description}
+description: Does something useful.
 ---
 
 # ${name}
-
-## When to Use
-
-- When you need to do X
 `;
 
 const temporaryDirectories: string[] = [];
@@ -30,422 +28,153 @@ afterEach(async () => {
   await Promise.all(temporaryDirectories.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 });
 
-const createMockContext = (projectDir: string) => ({
-  getProjectDir: vi.fn(() => projectDir),
-  triggerUIDataRefresh: vi.fn(),
-  log: vi.fn(),
-});
-
-describe('validateName', () => {
-  it('accepts valid kebab-case names', () => {
-    expect(validateName('my-skill')).toBeNull();
-    expect(validateName('deploy-helper')).toBeNull();
-    expect(validateName('a.b.c')).toBeNull();
-    expect(validateName('skill_123')).toBeNull();
-  });
-
-  it('rejects empty name', () => {
-    expect(validateName('')).toContain('required');
-  });
-
-  it('rejects uppercase names', () => {
-    expect(validateName('MySkill')).toContain('Invalid');
-  });
-
-  it('rejects names starting with hyphen', () => {
-    expect(validateName('-skill')).toContain('Invalid');
-  });
-
-  it('rejects names with spaces', () => {
-    expect(validateName('my skill')).toContain('Invalid');
-  });
-
-  it('rejects names exceeding 64 characters', () => {
-    expect(validateName('a'.repeat(65))).toContain('exceeds');
-  });
-});
-
-describe('validateFrontmatter', () => {
-  it('accepts valid frontmatter with name and description', () => {
-    expect(validateFrontmatter(makeValidFrontmatter('my-skill'))).toBeNull();
-  });
-
-  it('rejects empty content', () => {
-    expect(validateFrontmatter('')).toContain('empty');
-  });
-
-  it('rejects content without frontmatter delimiters', () => {
-    expect(validateFrontmatter('Just some text')).toContain('frontmatter');
-  });
-
-  it('rejects unclosed frontmatter', () => {
-    expect(validateFrontmatter('---\nname: test\nNo closing delimiter')).toContain('not closed');
-  });
-
-  it('rejects frontmatter without name field', () => {
-    const content = `---
-description: A skill without a name.
----
-
-# Body
-`;
-    expect(validateFrontmatter(content)).toContain('name');
-  });
-
-  it('rejects frontmatter without description field', () => {
-    const content = `---
-name: test
----
-
-# Body
-`;
-    expect(validateFrontmatter(content)).toContain('description');
-  });
-
-  it('rejects empty body after frontmatter', () => {
-    const content = `---
-name: test
-description: Does things.
----
-`;
-    expect(validateFrontmatter(content)).toContain('content');
-  });
-
-  it('rejects description longer than 60 chars', () => {
-    const longDesc = 'A comprehensive skill that does many complex things for users.';
-    const content = `---
-name: test
-description: ${longDesc}
----
-
-# Body
-`;
-    const result = validateFrontmatter(content);
-    expect(result).toContain('60 chars');
-  });
-
-  it('trims whitespace when checking description length', () => {
-    const content = `---
-name: test
-description:    ${'x'.repeat(60)}   
----
-
-# Body
-`;
-    const result = validateFrontmatter(content);
-    expect(result).toBeNull();
-  });
-
-  it('accepts description exactly 60 chars', () => {
-    const exactDesc = 'x'.repeat(60);
-    const content = `---
-name: test
-description: ${exactDesc}
----
-
-# Body
-`;
-    expect(validateFrontmatter(content)).toBeNull();
-  });
-});
-
-describe('validateFilePath', () => {
-  it('accepts files under references/', () => {
-    expect(validateFilePath('references/api.md')).toBeNull();
-  });
-
-  it('accepts files under templates/', () => {
-    expect(validateFilePath('templates/deploy.sh')).toBeNull();
-  });
-
-  it('accepts files under scripts/', () => {
-    expect(validateFilePath('scripts/build.sh')).toBeNull();
-  });
-
-  it('accepts files under assets/', () => {
-    expect(validateFilePath('assets/logo.png')).toBeNull();
-  });
-
-  it('rejects path traversal', () => {
-    expect(validateFilePath('../../etc/passwd')).toContain('traversal');
-  });
-
-  it('rejects files outside allowed directories', () => {
-    expect(validateFilePath('random/file.md')).toContain('must be under');
-  });
-
-  it('rejects empty path', () => {
-    expect(validateFilePath('')).toContain('required');
-  });
-
-  it('accepts SKILL.md', () => {
-    expect(validateFilePath('SKILL.md')).toBeNull();
-  });
-
-  it('rejects bare directory name', () => {
-    expect(validateFilePath('references')).toContain('file path');
-  });
-});
-
 describe('save-skill tool', () => {
+  let mockSkillsContext: SkillsContext;
+  let projectDir: string;
+
+  const createContext = () => {
+    return {
+      getProjectDir: vi.fn(() => projectDir),
+      getProjectContext: vi.fn(() => ({
+        getSkillContext: () => mockSkillsContext,
+      })),
+      log: vi.fn(),
+    };
+  };
+
+  type ToolContext = ReturnType<typeof createContext>;
+
+  const callTool = async (context: ToolContext, input: { action: string } & Record<string, unknown>) => {
+    const tool = createSaveSkillTool();
+    return JSON.parse(((await tool.execute(input as never, undefined, context as never, {})) ?? '') as string) as {
+      success: boolean;
+      message: string;
+      path?: string;
+    };
+  };
+
+  beforeEach(async () => {
+    projectDir = await createTempDir();
+    mockSkillsContext = {
+      listSkills: vi.fn(async () => []),
+      findSkill: vi.fn(async () => null),
+      resolveSkillDir: vi.fn(() => join(projectDir, '.aider-desk', 'skills', 'test-skill')),
+      createSkill: vi.fn(async () => ({ success: true, message: 'Skill created.' })),
+      updateSkill: vi.fn(async () => ({ success: true, message: 'Skill updated.' })),
+      writeSkillFile: vi.fn(async () => ({ success: true, message: 'File written.' })),
+    } as unknown as SkillsContext;
+  });
+
   it('creates the tool with correct name and description', () => {
     const tool = createSaveSkillTool();
     expect(tool.name).toBe('save-skill');
     expect(tool.description).toContain('skills');
   });
 
-  it('returns error for unknown action', async () => {
-    const tempDir = await createTempDir();
-    const context = createMockContext(tempDir);
-    const tool = createSaveSkillTool();
+  it('delegates create action to the skills context with default global location', async () => {
+    const context = createContext();
+    await callTool(context, { action: 'create', name: 'create-global', content: makeValidSkill('create-global') });
 
-    const result = await tool.execute({ action: 'unknown' as never, location: 'global' }, undefined, context as never, {});
-    const parsed = JSON.parse(result as string);
-    expect(parsed.success).toBe(false);
-    expect(parsed.message).toContain('Unknown action');
+    expect(mockSkillsContext.createSkill).toHaveBeenCalledWith('create-global', makeValidSkill('create-global'), 'global');
   });
 
-  it('creates a skill with valid frontmatter', async () => {
-    const tempDir = await createTempDir();
-    const context = createMockContext(tempDir);
-    vi.stubEnv('AIDER_DESK_HOME_DIR', tempDir);
+  it('delegates create action with explicit project location', async () => {
+    const context = createContext();
+    await callTool(context, { action: 'create', name: 'create-project', content: makeValidSkill('create-project'), location: 'project' });
 
-    const tool = createSaveSkillTool();
-    const result = await tool.execute(
-      { action: 'create', name: 'test-skill', content: makeValidFrontmatter('test-skill'), location: 'global' },
-      undefined,
-      context as never,
-      {},
-    );
-    const parsed = JSON.parse(result as string);
-
-    expect(parsed.success).toBe(true);
-    expect(parsed.message).toContain('created');
-
-    const skillMd = await readFile(parsed.skill_md, 'utf8');
-    expect(skillMd).toContain('name: test-skill');
-    expect(skillMd).toContain('# test-skill');
-
-    vi.unstubAllEnvs();
+    expect(mockSkillsContext.createSkill).toHaveBeenCalledWith('create-project', makeValidSkill('create-project'), 'project');
   });
 
-  it('fails to create a skill that already exists', async () => {
-    const tempDir = await createTempDir();
-    const context = createMockContext(tempDir);
-    vi.stubEnv('AIDER_DESK_HOME_DIR', tempDir);
+  it('rejects create without content', async () => {
+    const context = createContext();
+    const result = await callTool(context, { action: 'create', name: 'no-content' });
 
-    const tool = createSaveSkillTool();
-    await tool.execute(
-      { action: 'create', name: 'dup-skill', content: makeValidFrontmatter('dup-skill'), location: 'global' },
-      undefined,
-      context as never,
-      {},
-    );
-    const result = await tool.execute(
-      { action: 'create', name: 'dup-skill', content: makeValidFrontmatter('dup-skill'), location: 'global' },
-      undefined,
-      context as never,
-      {},
-    );
-    const parsed = JSON.parse(result as string);
-
-    expect(parsed.success).toBe(false);
-    expect(parsed.message).toContain('already exists');
-
-    vi.unstubAllEnvs();
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('Content is required');
+    expect(mockSkillsContext.createSkill).not.toHaveBeenCalled();
   });
 
-  it('fails to create a skill with invalid frontmatter', async () => {
-    const tempDir = await createTempDir();
-    const context = createMockContext(tempDir);
-    vi.stubEnv('AIDER_DESK_HOME_DIR', tempDir);
+  it('delegates edit action to updateSkill', async () => {
+    const context = createContext();
+    await callTool(context, { action: 'edit', name: 'edit-me', content: makeValidSkill('edit-me') });
 
-    const tool = createSaveSkillTool();
-    const result = await tool.execute(
-      { action: 'create', name: 'bad-skill', content: 'no frontmatter here', location: 'global' },
-      undefined,
-      context as never,
-      {},
-    );
-    const parsed = JSON.parse(result as string);
-
-    expect(parsed.success).toBe(false);
-    expect(parsed.message).toContain('frontmatter');
-
-    vi.unstubAllEnvs();
+    expect(mockSkillsContext.updateSkill).toHaveBeenCalledWith('edit-me', makeValidSkill('edit-me'));
   });
 
-  it('writes a supporting file to an existing skill', async () => {
-    const tempDir = await createTempDir();
-    const context = createMockContext(tempDir);
-    vi.stubEnv('AIDER_DESK_HOME_DIR', tempDir);
+  it('rejects edit without name', async () => {
+    const context = createContext();
+    const result = await callTool(context, { action: 'edit', content: 'x' });
 
-    const tool = createSaveSkillTool();
-    await tool.execute(
-      { action: 'create', name: 'file-skill', content: makeValidFrontmatter('file-skill'), location: 'global' },
-      undefined,
-      context as never,
-      {},
-    );
-    const result = await tool.execute(
-      {
-        action: 'write_file',
-        name: 'file-skill',
-        file_path: 'references/api.md',
-        file_content: '# API Reference\n\n- endpoint: /api/v1',
-        location: 'global',
-      },
-      undefined,
-      context as never,
-      {},
-    );
-    const parsed = JSON.parse(result as string);
-
-    expect(parsed.success).toBe(true);
-    expect(parsed.path).toContain('references/api.md');
-
-    const content = await readFile(parsed.path, 'utf8');
-    expect(content).toContain('API Reference');
-
-    vi.unstubAllEnvs();
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('Skill name is required');
+    expect(mockSkillsContext.updateSkill).not.toHaveBeenCalled();
   });
 
-  it('rejects write_file for non-existent skill', async () => {
-    const tempDir = await createTempDir();
-    const context = createMockContext(tempDir);
-    vi.stubEnv('AIDER_DESK_HOME_DIR', tempDir);
+  it('delegates write_file action to writeSkillFile', async () => {
+    const context = createContext();
+    await callTool(context, { action: 'write_file', name: 'file-me', file_path: 'references/api.md', file_content: '# API' });
 
-    const tool = createSaveSkillTool();
-    const result = await tool.execute(
-      {
-        action: 'write_file',
-        name: 'no-exist',
-        file_path: 'references/test.md',
-        file_content: 'content',
-        location: 'global',
-      },
-      undefined,
-      context as never,
-      {},
-    );
-    const parsed = JSON.parse(result as string);
-
-    expect(parsed.success).toBe(false);
-    expect(parsed.message).toContain('not found');
-
-    vi.unstubAllEnvs();
+    expect(mockSkillsContext.writeSkillFile).toHaveBeenCalledWith('file-me', 'references/api.md', '# API');
   });
 
-  it('rejects write_file with path traversal', async () => {
-    const tempDir = await createTempDir();
-    const context = createMockContext(tempDir);
-    vi.stubEnv('AIDER_DESK_HOME_DIR', tempDir);
+  it('rejects write_file without file_content', async () => {
+    const context = createContext();
+    const result = await callTool(context, { action: 'write_file', name: 'file-me', file_path: 'references/api.md' });
 
-    const tool = createSaveSkillTool();
-    await tool.execute(
-      { action: 'create', name: 'trav-skill', content: makeValidFrontmatter('trav-skill'), location: 'global' },
-      undefined,
-      context as never,
-      {},
-    );
-    const result = await tool.execute(
-      {
-        action: 'write_file',
-        name: 'trav-skill',
-        file_path: '../../../etc/passwd',
-        file_content: 'malicious',
-        location: 'global',
-      },
-      undefined,
-      context as never,
-      {},
-    );
-    const parsed = JSON.parse(result as string);
-
-    expect(parsed.success).toBe(false);
-    expect(parsed.message).toContain('traversal');
-
-    vi.unstubAllEnvs();
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('file_content is required');
   });
 
-  it('edits an existing skill', async () => {
-    const tempDir = await createTempDir();
-    const context = createMockContext(tempDir);
-    vi.stubEnv('AIDER_DESK_HOME_DIR', tempDir);
+  it('adds a write_file hint to successful create results', async () => {
+    const result = await callTool(createContext(), { action: 'create', name: 'hinted', content: makeValidSkill('hinted') });
 
-    const tool = createSaveSkillTool();
-    await tool.execute(
-      { action: 'create', name: 'edit-skill', content: makeValidFrontmatter('edit-skill'), location: 'global' },
-      undefined,
-      context as never,
-      {},
-    );
-
-    const editedContent = `---
-name: edit-skill
-description: Updated description here.
----
-
-# Updated Title
-
-## When to Use
-
-- When you need updated things
-`;
-    const result = await tool.execute({ action: 'edit', name: 'edit-skill', content: editedContent, location: 'global' }, undefined, context as never, {});
-    const parsed = JSON.parse(result as string);
-
-    expect(parsed.success).toBe(true);
-    expect(parsed.message).toContain('updated');
-
-    const skillMd = await readFile(parsed.skill_md, 'utf8');
-    expect(skillMd).toContain('Updated description');
-    expect(skillMd).toContain('Updated Title');
-
-    vi.unstubAllEnvs();
+    expect(result.success).toBe(true);
+    expect((result as { hint?: string }).hint).toContain("action='write_file'");
   });
 
-  it('lists skills on refresh', async () => {
-    const tempDir = await createTempDir();
-    const context = createMockContext(tempDir);
-    vi.stubEnv('AIDER_DESK_HOME_DIR', tempDir);
+  it('lists skills for refresh action without mutating anything', async () => {
+    vi.mocked(mockSkillsContext.listSkills).mockResolvedValue([
+      { name: 'one', description: '', location: 'global' },
+      { name: 'two', description: '', location: 'project' },
+    ]);
+    const context = createContext();
 
-    const tool = createSaveSkillTool();
-    await tool.execute(
-      { action: 'create', name: 'list-skill', content: makeValidFrontmatter('list-skill'), location: 'global' },
-      undefined,
-      context as never,
-      {},
-    );
-    const result = await tool.execute({ action: 'refresh', location: 'global' }, undefined, context as never, {});
-    const parsed = JSON.parse(result as string);
+    const result = await callTool(context, { action: 'refresh' });
 
-    expect(parsed.success).toBe(true);
-    expect(parsed.message).toContain('skill');
-    expect(parsed.message).toContain('found');
-
-    vi.unstubAllEnvs();
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('2 skill(s)');
+    expect(mockSkillsContext.createSkill).not.toHaveBeenCalled();
+    expect(mockSkillsContext.updateSkill).not.toHaveBeenCalled();
+    expect(mockSkillsContext.writeSkillFile).not.toHaveBeenCalled();
   });
 
-  it('creates project-scoped skill', async () => {
-    const tempDir = await createTempDir();
-    const context = createMockContext(tempDir);
+  it('returns a failure result when the project context is unavailable', async () => {
+    const context = createContext();
+    vi.mocked(context.getProjectContext).mockImplementation(() => {
+      throw new Error('Project context not available');
+    });
 
-    const tool = createSaveSkillTool();
-    const result = await tool.execute(
-      { action: 'create', name: 'proj-skill', content: makeValidFrontmatter('proj-skill'), location: 'project' },
-      undefined,
-      context as never,
-      {},
-    );
-    const parsed = JSON.parse(result as string);
+    const result = await callTool(context, { action: 'refresh' });
 
-    expect(parsed.success).toBe(true);
-    expect(parsed.path).toContain(tempDir);
-    expect(parsed.path).toContain('.aider-desk');
-    expect(parsed.path).toContain('skills');
+    expect(result.success).toBe(false);
+    expect(result.message).toBe('Error: Project context not available');
+  });
 
-    const skillMd = await readFile(parsed.skill_md, 'utf8');
-    expect(skillMd).toContain('name: proj-skill');
+  it('propagates core validation failures as success:false results', async () => {
+    vi.mocked(mockSkillsContext.createSkill).mockResolvedValue({ success: false, message: 'A skill named seriously already exists.' });
+    const context = createContext();
+
+    const result = await callTool(context, { action: 'create', name: 'seriously', content: makeValidSkill('seriously') });
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('already exists');
+  });
+
+  it('returns an error result for unknown actions', async () => {
+    const context = createContext();
+    const result = await callTool(context, { action: 'teleport' as string, name: 'whatever' } as never);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('teleport');
   });
 });

--- a/packages/extensions/extensions/learn/skill-writer.ts
+++ b/packages/extensions/extensions/learn/skill-writer.ts
@@ -1,30 +1,11 @@
-import { mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
-import { homedir } from 'node:os';
-import { join } from 'node:path';
-
 import { z } from 'zod';
-import { loadFront } from 'yaml-front-matter';
 
 import type { ExtensionContext, ToolDefinition } from '@aiderdesk/extensions';
-
-const AIDER_DESK_DIR_NAME = process.env.AIDER_DESK_DIR || '.aider-desk';
-const SKILLS_DIR_NAME = 'skills';
-const SKILL_MARKDOWN_FILE = 'SKILL.md';
-const MAX_NAME_LENGTH = 64;
-const MAX_DESCRIPTION_LENGTH = 1024;
-const MAX_CONTENT_CHARS = 100_000;
-const MAX_FILE_BYTES = 1_048_576;
-const VALID_NAME_RE = /^[a-z0-9][a-z0-9._-]*$/;
-
-const ALLOWED_SUBDIRS = new Set(['references', 'templates', 'scripts', 'assets']);
-
-export const getHomeDir = (): string => process.env.AIDER_DESK_HOME_DIR || join(homedir(), AIDER_DESK_DIR_NAME);
 
 const inputSchema = z.object({
   action: z
     .enum(['create', 'edit', 'write_file', 'refresh'])
-    .describe('Action to perform: create a new skill, edit SKILL.md of an existing skill, write a supporting file, or refresh the skill index'),
+    .describe('Action to perform: create a new skill, edit SKILL.md of an existing skill, write a supporting file, or list all skills to refresh the index'),
   name: z.string().optional().describe("Skill name (lowercase-hyphenated). Required for all actions except 'refresh'"),
   content: z.string().optional().describe("SKILL.md content for 'create' or 'edit' actions. Must include YAML frontmatter with name and description"),
   file_path: z.string().optional().describe("Supporting file path within the skill (e.g. 'references/api.md', 'scripts/deploy.sh'). For 'write_file' action"),
@@ -42,346 +23,53 @@ interface SkillResult {
   success: boolean;
   message: string;
   path?: string;
-  skill_md?: string;
   hint?: string;
 }
 
-export const validateName = (name: string): string | null => {
-  if (!name) {
-    return 'Skill name is required.';
-  }
-  if (name.length > MAX_NAME_LENGTH) {
-    return `Skill name exceeds ${MAX_NAME_LENGTH} characters.`;
-  }
-  if (!VALID_NAME_RE.test(name)) {
-    return `Invalid skill name '${name}'. Use lowercase letters, numbers, hyphens, dots, and underscores. Must start with a letter or digit.`;
-  }
-  return null;
-};
-
-export const validateFrontmatter = (content: string): string | null => {
-  if (!content.trim()) {
-    return 'Content cannot be empty.';
-  }
-
-  const cleaned = content.replace(/^\uFEFF/, '');
-
-  if (!cleaned.startsWith('---')) {
-    return 'SKILL.md must start with YAML frontmatter (---).';
-  }
-
-  const endMatch = cleaned.slice(3).match(/\n---\s*\n/);
-  if (!endMatch || endMatch.index === undefined) {
-    return "SKILL.md frontmatter is not closed. Ensure you have a closing '---' line.";
-  }
-
-  const frontmatterEnd = endMatch.index + 3 + endMatch[0].length;
-  const frontmatterBlock = cleaned.slice(0, frontmatterEnd);
-
-  let parsed: Record<string, unknown>;
-  try {
-    parsed = loadFront(frontmatterBlock) as Record<string, unknown>;
-  } catch {
-    return 'YAML frontmatter parse error.';
-  }
-
-  if (typeof parsed !== 'object' || parsed === null) {
-    return 'Frontmatter must be a YAML mapping (key: value pairs).';
-  }
-
-  if (!('name' in parsed)) {
-    return "Frontmatter must include 'name' field.";
-  }
-  if (!('description' in parsed)) {
-    return "Frontmatter must include 'description' field.";
-  }
-
-  const desc = String(parsed.description);
-  if (desc.length > MAX_DESCRIPTION_LENGTH) {
-    return `Description exceeds ${MAX_DESCRIPTION_LENGTH} characters.`;
-  }
-
-  if (desc.trim().length > 60) {
-    return (
-      `Description is ${desc.trim().length} chars — skills must keep the ` +
-      'description <=60 chars (the skill index truncates it, destroying ' +
-      'the routing signal). Move detail into the skill body.'
-    );
-  }
-
-  const body = cleaned.slice(frontmatterEnd).trim();
-  if (!body) {
-    return 'SKILL.md must have content after the frontmatter.';
-  }
-
-  return null;
-};
-
-const validateContentSize = (content: string, label = 'SKILL.md'): string | null => {
-  if (content.length > MAX_CONTENT_CHARS) {
-    return (
-      `${label} content is ${content.length.toLocaleString()} characters ` +
-      `(limit: ${MAX_CONTENT_CHARS.toLocaleString()}). Consider splitting ` +
-      'into a smaller SKILL.md with supporting files in references/ or templates/.'
-    );
-  }
-  return null;
-};
-
-export const validateFilePath = (filePath: string): string | null => {
-  if (!filePath) {
-    return 'file_path is required.';
-  }
-
-  if (filePath.includes('..')) {
-    return "Path traversal ('..') is not allowed.";
-  }
-
-  const normalized = filePath.replace(/\\/g, '/');
-
-  if (normalized === 'SKILL.md' || normalized.endsWith('/SKILL.md')) {
-    return null;
-  }
-
-  const parts = normalized.split('/');
-  if (parts.length === 0 || !ALLOWED_SUBDIRS.has(parts[0]!)) {
-    const allowed = Array.from(ALLOWED_SUBDIRS).sort().join(', ');
-    return `File must be under one of: ${allowed}. Got: '${filePath}'`;
-  }
-
-  if (parts.length < 2) {
-    return `Provide a file path, not just a directory. Example: '${parts[0]}/myfile.md'`;
-  }
-
-  return null;
-};
-
-const resolveSkillDir = (name: string, location: 'global' | 'project', context: ExtensionContext): string => {
-  if (location === 'project') {
-    const projectDir = context.getProjectDir();
-    if (!projectDir) {
-      throw new Error('No project directory available for project-scoped skill');
-    }
-    return join(projectDir, AIDER_DESK_DIR_NAME, SKILLS_DIR_NAME, name);
-  }
-  return join(getHomeDir(), SKILLS_DIR_NAME, name);
-};
-
-const findSkill = async (name: string, context: ExtensionContext): Promise<string | null> => {
-  const globalDir = join(getHomeDir(), SKILLS_DIR_NAME, name);
-  if (existsSync(join(globalDir, SKILL_MARKDOWN_FILE))) {
-    return globalDir;
-  }
-
-  const projectDir = context.getProjectDir();
-  if (projectDir) {
-    const projectSkillDir = join(projectDir, AIDER_DESK_DIR_NAME, SKILLS_DIR_NAME, name);
-    if (existsSync(join(projectSkillDir, SKILL_MARKDOWN_FILE))) {
-      return projectSkillDir;
-    }
-  }
-
-  return null;
-};
-
-const listSkills = async (context: ExtensionContext): Promise<unknown[]> => {
-  const skills: { name: string; description: string; location: string }[] = [];
-
-  const scanDir = async (dir: string, location: string) => {
-    if (!existsSync(dir)) {
-      return;
-    }
-    let entries: string[];
-    try {
-      entries = await readdir(dir);
-    } catch {
-      return;
-    }
-    for (const entry of entries) {
-      const entryPath = join(dir, entry);
-      let entryStat;
-      try {
-        entryStat = await stat(entryPath);
-      } catch {
-        continue;
-      }
-      if (!entryStat.isDirectory()) {
-        continue;
-      }
-      const skillMdPath = join(entryPath, SKILL_MARKDOWN_FILE);
-      if (!existsSync(skillMdPath)) {
-        continue;
-      }
-      try {
-        const content = await readFile(skillMdPath, 'utf8');
-        const parsed = loadFront(content) as Record<string, unknown>;
-        const name = typeof parsed.name === 'string' ? parsed.name : entry;
-        const description = typeof parsed.description === 'string' ? parsed.description : '';
-        skills.push({ name, description, location });
-      } catch {
-        continue;
-      }
-    }
-  };
-
-  await scanDir(join(getHomeDir(), SKILLS_DIR_NAME), 'global');
-
-  const projectDir = context.getProjectDir();
-  if (projectDir) {
-    await scanDir(join(projectDir, AIDER_DESK_DIR_NAME, SKILLS_DIR_NAME), 'project');
-  }
-
-  return skills;
-};
-
 const handleCreate = async (input: SaveSkillInput, context: ExtensionContext): Promise<SkillResult> => {
-  const { name, content, location = 'global' } = input;
-
-  if (!name) {
+  if (!input.name) {
     return { success: false, message: 'Skill name is required for create action.' };
   }
-  if (!content) {
+  if (!input.content) {
     return { success: false, message: 'Content is required for create action.' };
   }
 
-  const nameErr = validateName(name);
-  if (nameErr) {
-    return { success: false, message: nameErr };
+  const result = await context.getProjectContext().getSkillContext().createSkill(input.name, input.content, input.location ?? 'global');
+  if (result.success) {
+    return { ...result, hint: "To add reference files, templates, or scripts, use action='write_file' with file_path like 'references/example.md'" };
   }
-
-  const fmErr = validateFrontmatter(content);
-  if (fmErr) {
-    return { success: false, message: fmErr };
-  }
-
-  const sizeErr = validateContentSize(content);
-  if (sizeErr) {
-    return { success: false, message: sizeErr };
-  }
-
-  const existing = await findSkill(name, context);
-  if (existing) {
-    return {
-      success: false,
-      message: `A skill named '${name}' already exists at ${existing}. Use action='edit' to modify it.`,
-    };
-  }
-
-  const skillDir = resolveSkillDir(name, location, context);
-  await mkdir(skillDir, { recursive: true });
-
-  const skillMdPath = join(skillDir, SKILL_MARKDOWN_FILE);
-  await writeFile(skillMdPath, content, 'utf8');
-
-  return {
-    success: true,
-    message: `Skill '${name}' created at ${location} location.`,
-    path: skillDir,
-    skill_md: skillMdPath,
-    hint: "To add reference files, templates, or scripts, use action='write_file' with file_path like 'references/example.md'",
-  };
+  return result;
 };
 
 const handleEdit = async (input: SaveSkillInput, context: ExtensionContext): Promise<SkillResult> => {
-  const { name, content } = input;
-
-  if (!name) {
+  if (!input.name) {
     return { success: false, message: 'Skill name is required for edit action.' };
   }
-  if (!content) {
+  if (!input.content) {
     return { success: false, message: 'Content is required for edit action.' };
   }
 
-  const fmErr = validateFrontmatter(content);
-  if (fmErr) {
-    return { success: false, message: fmErr };
-  }
-
-  const sizeErr = validateContentSize(content);
-  if (sizeErr) {
-    return { success: false, message: sizeErr };
-  }
-
-  const existing = await findSkill(name, context);
-  if (!existing) {
-    return {
-      success: false,
-      message: `Skill '${name}' not found. Use action='create' to create a new skill.`,
-    };
-  }
-
-  const skillMdPath = join(existing, SKILL_MARKDOWN_FILE);
-  await writeFile(skillMdPath, content, 'utf8');
-
-  return {
-    success: true,
-    message: `Skill '${name}' updated (full rewrite).`,
-    path: existing,
-    skill_md: skillMdPath,
-  };
+  return context.getProjectContext().getSkillContext().updateSkill(input.name, input.content);
 };
 
 const handleWriteFile = async (input: SaveSkillInput, context: ExtensionContext): Promise<SkillResult> => {
-  const { name, file_path, file_content } = input;
-
-  if (!name) {
+  if (!input.name) {
     return { success: false, message: 'Skill name is required for write_file action.' };
   }
-  if (!file_path) {
+  if (!input.file_path) {
     return { success: false, message: 'file_path is required for write_file action.' };
   }
-  if (file_content === undefined || file_content === null) {
+  if (input.file_content === undefined || input.file_content === null) {
     return { success: false, message: 'file_content is required for write_file action.' };
   }
 
-  const pathErr = validateFilePath(file_path);
-  if (pathErr) {
-    return { success: false, message: pathErr };
-  }
-
-  const contentBytes = Buffer.byteLength(file_content, 'utf8');
-  if (contentBytes > MAX_FILE_BYTES) {
-    return {
-      success: false,
-      message: `File content is ${contentBytes.toLocaleString()} bytes (limit: ${MAX_FILE_BYTES.toLocaleString()} bytes). Consider splitting into smaller files.`,
-    };
-  }
-
-  const sizeErr = validateContentSize(file_content, file_path);
-  if (sizeErr) {
-    return { success: false, message: sizeErr };
-  }
-
-  const existing = await findSkill(name, context);
-  if (!existing) {
-    return {
-      success: false,
-      message: `Skill '${name}' not found. Create it first with action='create'.`,
-    };
-  }
-
-  const targetPath = join(existing, file_path.replace(/\\/g, '/'));
-  const targetDir = targetPath.slice(0, targetPath.lastIndexOf('/'));
-  if (targetDir && !existsSync(targetDir)) {
-    await mkdir(targetDir, { recursive: true });
-  }
-
-  await writeFile(targetPath, file_content, 'utf8');
-
-  return {
-    success: true,
-    message: `File '${file_path}' written to skill '${name}'.`,
-    path: targetPath,
-  };
+  return context.getProjectContext().getSkillContext().writeSkillFile(input.name, input.file_path, input.file_content);
 };
 
-const handleRefresh = async (_input: SaveSkillInput, context: ExtensionContext): Promise<SkillResult> => {
-  const skills = await listSkills(context);
+const handleRefresh = async (context: ExtensionContext): Promise<SkillResult> => {
+  const skills = await context.getProjectContext().getSkillContext().listSkills();
 
-  return {
-    success: true,
-    message: `Skill index refreshed. ${skills.length} skill(s) found.`,
-  };
+  return { success: true, message: `Skill index refreshed. ${skills.length} skill(s) available.` };
 };
 
 export const createSaveSkillTool = (): ToolDefinition<typeof inputSchema> => ({
@@ -389,30 +77,28 @@ export const createSaveSkillTool = (): ToolDefinition<typeof inputSchema> => ({
   description:
     'Create, edit, or write files to AiderDesk skills. Skills are reusable procedural knowledge stored as SKILL.md files with optional supporting files (references/, templates/, scripts/, assets/). Use action="create" to create a new skill, action="edit" to rewrite SKILL.md, action="write_file" to add supporting files, or action="refresh" to list all skills and refresh the index.',
   inputSchema,
-  execute: async (input, _signal, context) => {
-    const typedInput = input as SaveSkillInput;
+  execute: async (input: SaveSkillInput, _signal: AbortSignal | undefined, context: ExtensionContext): Promise<unknown> => {
+    if (input.action !== 'refresh' && !input.name) {
+      return JSON.stringify({ success: false, message: 'Skill name is required for all actions except refresh.' }, null, 2);
+    }
+
     try {
       let result: SkillResult;
-
-      switch (typedInput.action) {
+      switch (input.action) {
         case 'create':
-          result = await handleCreate(typedInput, context);
+          result = await handleCreate(input, context);
           break;
         case 'edit':
-          result = await handleEdit(typedInput, context);
+          result = await handleEdit(input, context);
           break;
         case 'write_file':
-          result = await handleWriteFile(typedInput, context);
+          result = await handleWriteFile(input, context);
           break;
         case 'refresh':
-          result = await handleRefresh(typedInput, context);
+          result = await handleRefresh(context);
           break;
         default:
-          result = { success: false as const, message: `Unknown action: ${typedInput.action}` };
-      }
-
-      if (typedInput.action !== 'refresh') {
-        context.triggerUIDataRefresh();
+          result = { success: false, message: `Unknown action: ${input.action}` };
       }
 
       return JSON.stringify(result, null, 2);

--- a/src/main/extensions/__tests__/extension-manager.test.ts
+++ b/src/main/extensions/__tests__/extension-manager.test.ts
@@ -1714,4 +1714,85 @@ describe('ExtensionManager', () => {
       expect(result[1].provider.id).toBe('provider-b');
     });
   });
+
+  describe('skill manager caching and eviction', () => {
+    let mockProject: { baseDir: string };
+
+    beforeEach(() => {
+      mockProject = { baseDir: '/test/project' };
+      // dispatchEvent waits for initialization, which these tests assume completed
+      (manager as any).initialized = true;
+    });
+
+    const skillManagerMap = () => (manager as unknown as { projectSkillManagers: Map<string, unknown> }).projectSkillManagers;
+
+    const makeExtension = (handlerName: string, onContext: (context: unknown) => void) => ({
+      id: 'skill-manager-consumer',
+      instance: {
+        [handlerName]: async (_event: unknown, context: unknown) => {
+          onContext(context);
+        },
+      },
+      metadata: { name: 'consumer', version: '1.0.0', description: 'Test', author: 'Test' },
+      filePath: '/path/consumer.ts',
+      initialized: true,
+    });
+
+    it('caches one skill manager per project across contexts', async () => {
+      const seen: unknown[] = [];
+      (mockRegistry as { getExtensions: unknown }).getExtensions = vi
+        .fn()
+        .mockReturnValue([
+          makeExtension('onPromptStarted', (context) => seen.push((context as { getProjectContext: () => { getSkillContext: () => unknown } }).getProjectContext().getSkillContext())),
+        ]);
+
+      const event = { prompt: 'p', mode: 'agent' as const, promptContext: { id: '1' } };
+      await manager.dispatchEvent('onPromptStarted', event, mockProject as any);
+      expect(seen).toHaveLength(1);
+      expect(skillManagerMap().get('/test/project')).toBe(seen[0]);
+
+      await manager.dispatchEvent('onPromptStarted', event, mockProject as any);
+      expect(seen).toHaveLength(2);
+      expect(seen[0]).toBe(seen[1]);
+    });
+
+    it('evicts the project skill manager after an onProjectStopped dispatch, not before', async () => {
+      const cacheSizeInsideHandler: number[] = [];
+      (mockRegistry as { getExtensions: unknown }).getExtensions = vi.fn().mockReturnValue([
+        makeExtension('onProjectStopped', (context) => {
+          (context as { getProjectContext: () => { getSkillContext: () => unknown } }).getProjectContext().getSkillContext();
+          cacheSizeInsideHandler.push(skillManagerMap().size);
+        }),
+      ]);
+
+      await manager.dispatchEvent('onProjectStopped', {} as never, mockProject as any);
+      expect(cacheSizeInsideHandler).toEqual([1]);
+      expect(skillManagerMap().has('/test/project')).toBe(false);
+    });
+
+    it('evicts via the no-extensions early exit on stop', async () => {
+      skillManagerMap().set('/test/project', {});
+      await manager.dispatchEvent('onProjectStopped', {} as never, mockProject as any);
+      expect(skillManagerMap().size).toBe(0);
+    });
+
+    it('broadcasts skills-updated to every task of the project', async () => {
+      const sendSkillsUpdated = vi.fn();
+      (manager as unknown as { eventManager: unknown }).eventManager = { sendSkillsUpdated };
+      fsReaddirMock.mockResolvedValue([]);
+
+      const cached = (manager as unknown as { getProjectSkillManager: (project: unknown) => unknown }).getProjectSkillManager(mockProject);
+      expect(cached).toBeDefined();
+
+      const project = {
+        baseDir: '/test/project',
+        getTasks: vi.fn().mockResolvedValue([{ id: 'task-1' }, { id: 'task-2' }]),
+      };
+      (manager as unknown as { broadcastSkillsUpdated: (project: unknown) => void }).broadcastSkillsUpdated(project);
+
+      await vi.waitFor(() => expect(sendSkillsUpdated).toHaveBeenCalledTimes(2));
+      expect(sendSkillsUpdated).toHaveBeenCalledWith('/test/project', 'task-1', expect.any(Array));
+      expect(sendSkillsUpdated).toHaveBeenCalledWith('/test/project', 'task-2', expect.any(Array));
+    });
+  });
 });

--- a/src/main/extensions/__tests__/extension-manager.test.ts
+++ b/src/main/extensions/__tests__/extension-manager.test.ts
@@ -1743,7 +1743,9 @@ describe('ExtensionManager', () => {
       (mockRegistry as { getExtensions: unknown }).getExtensions = vi
         .fn()
         .mockReturnValue([
-          makeExtension('onPromptStarted', (context) => seen.push((context as { getProjectContext: () => { getSkillContext: () => unknown } }).getProjectContext().getSkillContext())),
+          makeExtension('onPromptStarted', (context) =>
+            seen.push((context as { getProjectContext: () => { getSkillContext: () => unknown } }).getProjectContext().getSkillContext()),
+          ),
         ]);
 
       const event = { prompt: 'p', mode: 'agent' as const, promptContext: { id: '1' } };

--- a/src/main/extensions/__tests__/project-context.test.ts
+++ b/src/main/extensions/__tests__/project-context.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { ProjectContextImpl } from '../project-context';
+import { DisposableStore } from '../disposable-store';
+
+import type { Project } from '@/project';
+import type { SkillsContext } from '@common/extensions';
+
+const createMockProject = (): Project => {
+  return {
+    baseDir: '/project/path',
+  } as unknown as Project;
+};
+
+describe('ProjectContextImpl.getSkillContext', () => {
+  it('should throw error when skills context is not available', () => {
+    const context = new ProjectContextImpl(createMockProject(), new DisposableStore('Test Extension'));
+
+    expect(() => context.getSkillContext()).toThrow('SkillManager not available');
+  });
+
+  it('should return the provided skills context', () => {
+    const mockSkillsContext = { listSkills: vi.fn() } as unknown as SkillsContext;
+
+    const context = new ProjectContextImpl(createMockProject(), new DisposableStore('Test Extension'), mockSkillsContext);
+
+    expect(context.getSkillContext()).toBe(mockSkillsContext);
+  });
+});

--- a/src/main/extensions/extension-context.ts
+++ b/src/main/extensions/extension-context.ts
@@ -32,10 +32,11 @@ export class ExtensionContextImpl implements ExtensionContext {
     private readonly project?: Project,
     private readonly task?: Task,
     private readonly mcpConfigManager?: McpConfigManager,
+    projectContext?: ProjectContext,
   ) {
     this.disposableStore = disposableStore;
     this.taskContext = this.task ? new TaskContextImpl(this.task) : null;
-    this.projectContext = this.project ? new ProjectContextImpl(this.project, disposableStore) : null;
+    this.projectContext = projectContext ?? (this.project ? new ProjectContextImpl(this.project, disposableStore) : null);
   }
 
   addDisposable(setup: () => (() => void | Promise<void>) | void): void {

--- a/src/main/extensions/extension-manager.ts
+++ b/src/main/extensions/extension-manager.ts
@@ -21,6 +21,7 @@ import { DEFAULT_AGENT_PROFILE } from '@common/agent';
 import { ExtensionLoader } from './extension-loader';
 import { ExtensionRegistry, LoadedExtension } from './extension-registry';
 import { ExtensionContextImpl } from './extension-context';
+import { ProjectContextImpl } from './project-context';
 import { DisposableStore } from './disposable-store';
 import { ExtensionFetcher } from './extension-fetcher';
 import { ExtensionLibraryLoader } from './extension-library-loader';
@@ -78,6 +79,7 @@ import type { MemoryManager } from '@/memory/memory-manager';
 import type { TelemetryManager } from '@/telemetry';
 import type { ToolExecutionOptions, ToolSet } from 'ai';
 
+import { SkillManager as SkillManagerImpl } from '@/skills/skill-manager';
 import { shouldUsePolling } from '@/utils/file-watch';
 import logger from '@/logger';
 import { AIDER_DESK_EXTENSIONS_DIR, AIDER_DESK_GLOBAL_EXTENSIONS_DIR } from '@/constants';
@@ -209,6 +211,7 @@ export class ExtensionManager {
   private listeners: ExtensionsChangeListener[] = [];
   private extensionMtimes: Map<string, number> = new Map();
   private readonly startedProjects = new Map<string, Project>();
+  private readonly projectSkillManagers = new Map<string, SkillManagerImpl>();
 
   private libraryLoader: ExtensionLibraryLoader;
 
@@ -800,6 +803,8 @@ export class ExtensionManager {
       throw new Error(`Cannot create context: extension '${extensionId}' not found`);
     }
     const store = this.getOrCreateDisposableStore(loaded);
+    const skillManager = task?.getSkillManager?.() ?? (project ? this.getProjectSkillManager(project) : undefined);
+    const projectContext = project ? new ProjectContextImpl(project, store, skillManager) : undefined;
     return new ExtensionContextImpl(
       extensionId,
       extensionName,
@@ -811,7 +816,40 @@ export class ExtensionManager {
       project,
       task,
       this.mcpConfigManager,
+      projectContext,
     );
+  }
+
+  private getProjectSkillManager(project: Project): SkillManagerImpl {
+    const existing = this.projectSkillManagers.get(project.baseDir);
+    if (existing) {
+      return existing;
+    }
+
+    const manager = new SkillManagerImpl(project.baseDir, this, () => this.broadcastSkillsUpdated(project));
+    this.projectSkillManagers.set(project.baseDir, manager);
+
+    return manager;
+  }
+
+  /**
+   * Notify every open task of a project that its skill list changed, so workspace
+   * skill panels reload. Used by the project-scoped skill manager (no task of its own).
+   */
+  private broadcastSkillsUpdated(project: Project): void {
+    void project
+      .getTasks()
+      .then(async (projectTasks) => {
+        const skills = await this.projectSkillManagers.get(project.baseDir)?.getSkills();
+        if (!skills) {
+          return;
+        }
+
+        for (const projectTask of projectTasks) {
+          this.eventManager?.sendSkillsUpdated(project.baseDir, projectTask.id, skills);
+        }
+      })
+      .catch((error: unknown) => logger.warn(`Failed to broadcast skills updated: ${error instanceof Error ? error.message : String(error)}`));
   }
 
   private findExtensionByPath(filePath: string): LoadedExtension | undefined {
@@ -2285,6 +2323,9 @@ export class ExtensionManager {
 
     // Early exit if no extensions
     if (enabledExtensions.length === 0) {
+      if (eventName === 'onProjectStopped') {
+        this.projectSkillManagers.delete(project.baseDir);
+      }
       return event;
     }
 
@@ -2341,6 +2382,11 @@ export class ExtensionManager {
         logger.error(`[Extensions] Error in '${String(eventName)}' handler for extension '${metadata.name}':`, error);
         // Continue to next extension - errors don't stop the chain
       }
+    }
+
+    // Evict after dispatch so handlers do not re-create and re-cache a manager for a stopped project
+    if (eventName === 'onProjectStopped') {
+      this.projectSkillManagers.delete(project.baseDir);
     }
 
     return currentEvent;

--- a/src/main/extensions/project-context.ts
+++ b/src/main/extensions/project-context.ts
@@ -1,7 +1,7 @@
 import { TaskContextImpl } from './task-context';
 
 import type { DisposableStore } from './disposable-store';
-import type { ProjectContext, TaskContext } from '@common/extensions';
+import type { ProjectContext, SkillsContext, TaskContext } from '@common/extensions';
 import type { AgentProfile, CommandsData, CreateTaskParams, ProjectSettings, TaskData } from '@common/types';
 import type { Project } from '@/project';
 
@@ -9,6 +9,7 @@ export class ProjectContextImpl implements ProjectContext {
   constructor(
     private readonly project: Project,
     private readonly disposableStore: DisposableStore,
+    private readonly skillsContext?: SkillsContext,
   ) {}
 
   addDisposable(setup: () => (() => void | Promise<void>) | void): void {
@@ -70,5 +71,19 @@ export class ProjectContextImpl implements ProjectContext {
 
   async getInputHistory(): Promise<string[]> {
     return this.project.loadInputHistory();
+  }
+
+  /**
+   * Get the skills context for listing, finding, and writing AiderDesk skills.
+   * Backed by the same SkillManager used by the built-in skills tools, so skills created here
+   * are picked up by skill activation and the workspace skills panel.
+   * @returns SkillsContext instance (the project's SkillManager)
+   * @throws Error if no SkillManager is available
+   */
+  getSkillContext(): SkillsContext {
+    if (!this.skillsContext) {
+      throw new Error('SkillManager not available');
+    }
+    return this.skillsContext;
   }
 }

--- a/src/main/skills/__tests__/skill-manager.test.ts
+++ b/src/main/skills/__tests__/skill-manager.test.ts
@@ -1,0 +1,602 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The global test setup mocks fs/path; these tests exercise real file I/O
+vi.unmock('fs');
+vi.unmock('path');
+vi.unmock('winston');
+
+import type { SkillDefinition } from '@common/types';
+
+const temporaryDirectories: string[] = [];
+
+const createTempDir = async (prefix: string): Promise<string> => {
+  const dir = await mkdtemp(join(tmpdir(), prefix));
+  temporaryDirectories.push(dir);
+  return dir;
+};
+
+const makeValidSkill = (name: string, description = 'Does something useful.'): string => `---
+name: ${name}
+description: ${description}
+---
+
+# ${name}
+
+## When to Use
+
+- When you need to do X
+`;
+
+describe('SkillManager', () => {
+  let globalDir: string;
+  let projectDir: string;
+  let SkillManager: (typeof import('../skill-manager'))['SkillManager'];
+  let skillValidation: typeof import('../skill-validation');
+  let skillsUpdated: ReturnType<typeof vi.fn>;
+
+  beforeAll(async () => {
+    globalDir = await createTempDir('aiderdesk-skills-global-');
+    projectDir = await createTempDir('aiderdesk-skills-project-');
+    vi.stubEnv('AIDER_DESK_HOME_DIR', globalDir);
+
+    skillValidation = await import('../skill-validation');
+    ({ SkillManager } = await import('../skill-manager'));
+  });
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    await Promise.all(temporaryDirectories.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  const createManager = (onSkillsUpdated?: () => void) => new SkillManager(projectDir, undefined, onSkillsUpdated);
+
+  beforeEach(() => {
+    skillsUpdated = vi.fn();
+  });
+
+  describe('validateSkillName', () => {
+    it('accepts valid kebab-case names', () => {
+      expect(skillValidation.validateSkillName('my-skill')).toBeNull();
+      expect(skillValidation.validateSkillName('deploy-helper')).toBeNull();
+      expect(skillValidation.validateSkillName('a.b.c')).toBeNull();
+      expect(skillValidation.validateSkillName('skill_123')).toBeNull();
+    });
+
+    it('rejects empty name', () => {
+      expect(skillValidation.validateSkillName('')).toContain('required');
+    });
+
+    it('rejects uppercase names', () => {
+      expect(skillValidation.validateSkillName('MySkill')).toContain('Invalid');
+    });
+
+    it('rejects names starting with hyphen', () => {
+      expect(skillValidation.validateSkillName('-skill')).toContain('Invalid');
+    });
+
+    it('rejects names with spaces', () => {
+      expect(skillValidation.validateSkillName('my skill')).toContain('Invalid');
+    });
+
+    it('rejects names exceeding 64 characters', () => {
+      expect(skillValidation.validateSkillName('a'.repeat(65))).toContain('exceeds');
+    });
+  });
+
+  describe('validateSkillFrontmatter', () => {
+    it('accepts valid frontmatter with name and description', () => {
+      expect(skillValidation.validateSkillFrontmatter(makeValidSkill('my-skill'))).toBeNull();
+    });
+
+    it('rejects empty content', () => {
+      expect(skillValidation.validateSkillFrontmatter('')).toContain('empty');
+    });
+
+    it('rejects content without frontmatter delimiters', () => {
+      expect(skillValidation.validateSkillFrontmatter('Just some text')).toContain('frontmatter');
+    });
+
+    it('rejects unclosed frontmatter', () => {
+      expect(skillValidation.validateSkillFrontmatter('---\nname: test\nNo closing delimiter')).toContain('not closed');
+    });
+
+    it('rejects frontmatter without name field', () => {
+      const content = `---
+description: A skill without a name.
+---
+
+# Body
+`;
+      expect(skillValidation.validateSkillFrontmatter(content)).toContain('name');
+    });
+
+    it('rejects frontmatter without description field', () => {
+      const content = `---
+name: test
+---
+
+# Body
+`;
+      expect(skillValidation.validateSkillFrontmatter(content)).toContain('description');
+    });
+
+    it('rejects empty body after frontmatter', () => {
+      const content = `---
+name: test
+description: Does things.
+---
+`;
+      expect(skillValidation.validateSkillFrontmatter(content)).toContain('content');
+    });
+
+    it('rejects non-string description values', () => {
+      const content = `---
+name: test
+description: 12345
+---
+
+# Body
+`;
+      expect(skillValidation.validateSkillFrontmatter(content)).toContain('must be a string');
+    });
+
+    it('rejects description longer than 60 chars', () => {
+      const longDesc = 'A comprehensive skill that does many complex things for users.';
+      const content = `---
+name: test
+description: ${longDesc}
+---
+
+# Body
+`;
+      expect(skillValidation.validateSkillFrontmatter(content)).toContain('60 chars');
+    });
+
+    it('trims whitespace when checking description length', () => {
+      const content = `---
+name: test
+description:    ${'x'.repeat(60)}   
+---
+
+# Body
+`;
+      expect(skillValidation.validateSkillFrontmatter(content)).toBeNull();
+    });
+
+    it('accepts description exactly 60 chars', () => {
+      const content = `---
+name: test
+description: ${'x'.repeat(60)}
+---
+
+# Body
+`;
+      expect(skillValidation.validateSkillFrontmatter(content)).toBeNull();
+    });
+  });
+
+  describe('validateSkillFilePath', () => {
+    it('accepts files under references/', () => {
+      expect(skillValidation.validateSkillFilePath('references/api.md')).toBeNull();
+    });
+
+    it('accepts files under templates/', () => {
+      expect(skillValidation.validateSkillFilePath('templates/deploy.sh')).toBeNull();
+    });
+
+    it('accepts files under scripts/', () => {
+      expect(skillValidation.validateSkillFilePath('scripts/build.sh')).toBeNull();
+    });
+
+    it('accepts files under assets/', () => {
+      expect(skillValidation.validateSkillFilePath('assets/logo.png')).toBeNull();
+    });
+
+    it('rejects path traversal', () => {
+      expect(skillValidation.validateSkillFilePath('../../etc/passwd')).toContain('traversal');
+    });
+
+    it('rejects files outside allowed directories', () => {
+      expect(skillValidation.validateSkillFilePath('random/file.md')).toContain('must be under');
+    });
+
+    it('rejects empty path', () => {
+      expect(skillValidation.validateSkillFilePath('')).toContain('required');
+    });
+
+    it('accepts SKILL.md', () => {
+      expect(skillValidation.validateSkillFilePath('SKILL.md')).toBeNull();
+    });
+
+    it('rejects bare directory name', () => {
+      expect(skillValidation.validateSkillFilePath('references')).toContain('file path');
+    });
+  });
+
+  describe('resolveSkillDir', () => {
+    it('resolves global skills under the home directory', () => {
+      const manager = createManager();
+      expect(manager.resolveSkillDir('my-skill', 'global')).toBe(join(globalDir, 'skills', 'my-skill'));
+    });
+
+    it('resolves project skills under .aider-desk/skills in the project dir', () => {
+      const manager = createManager();
+      expect(manager.resolveSkillDir('my-skill', 'project')).toBe(join(projectDir, '.aider-desk', 'skills', 'my-skill'));
+    });
+  });
+
+  describe('createSkill', () => {
+    it('creates a global skill by default and writes SKILL.md', async () => {
+      const manager = createManager(skillsUpdated as unknown as () => void);
+      const result = await manager.createSkill('create-global', makeValidSkill('create-global'));
+
+      expect(result.success).toBe(true);
+      expect(result.path).toBe(join(globalDir, 'skills', 'create-global'));
+      const written = await readFile(join(result.path!, 'SKILL.md'), 'utf8');
+      expect(written).toBe(makeValidSkill('create-global'));
+      expect(skillsUpdated).toHaveBeenCalledTimes(1);
+    });
+
+    it('creates a project skill under .aider-desk/skills when location is project', async () => {
+      const manager = createManager();
+      const result = await manager.createSkill('create-project', makeValidSkill('create-project'), 'project');
+
+      expect(result.success).toBe(true);
+      expect(result.path).toBe(join(projectDir, '.aider-desk', 'skills', 'create-project'));
+      expect(existsSync(join(result.path!, 'SKILL.md'))).toBe(true);
+    });
+
+    it('creates missing parent directories for the skill', async () => {
+      const manager = createManager();
+      const result = await manager.createSkill('nested-dirs-skill', makeValidSkill('nested-dirs-skill'), 'project');
+      expect(result.success).toBe(true);
+      expect(existsSync(join(projectDir, '.aider-desk', 'skills', 'nested-dirs-skill', 'SKILL.md'))).toBe(true);
+    });
+
+    it('rejects duplicate skills in the same location', async () => {
+      const manager = createManager();
+      await manager.createSkill('duplicate-global', makeValidSkill('duplicate-global'), 'global');
+
+      const result = await manager.createSkill('duplicate-global', makeValidSkill('duplicate-global'), 'global');
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('already exists');
+      expect(result.message).toContain('updateSkill');
+    });
+
+    it('allows a project skill to shadow a global skill with the same name', async () => {
+      const manager = createManager();
+      await manager.createSkill('project-shadows-global', makeValidSkill('project-shadows-global'), 'global');
+
+      const result = await manager.createSkill('project-shadows-global', makeValidSkill('project-shadows-global'), 'project');
+      expect(result.success).toBe(true);
+      expect(result.path).toBe(join(projectDir, '.aider-desk', 'skills', 'project-shadows-global'));
+    });
+
+    it('rejects invalid names', async () => {
+      const manager = createManager();
+      const result = await manager.createSkill('Invalid Name', makeValidSkill('invalid-name'));
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('Invalid skill name');
+    });
+
+    it('rejects content without valid frontmatter', async () => {
+      const manager = createManager();
+      const result = await manager.createSkill('no-frontmatter', 'just text, no frontmatter');
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('frontmatter');
+      expect(existsSync(join(globalDir, 'skills', 'no-frontmatter'))).toBe(false);
+    });
+
+    it('rejects empty content', async () => {
+      const manager = createManager();
+      const result = await manager.createSkill('empty-content', '');
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('Content is required');
+    });
+
+    it('rejects content whose frontmatter name differs from the skill name', async () => {
+      const manager = createManager();
+      const result = await manager.createSkill('foo', makeValidSkill('bar'));
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("does not match skill name 'foo'");
+      expect(existsSync(join(globalDir, 'skills', 'foo'))).toBe(false);
+    });
+
+    it('accepts content whose frontmatter name matches', async () => {
+      const manager = createManager();
+      const result = await manager.createSkill('matching-name', makeValidSkill('matching-name'));
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects oversized SKILL.md content', async () => {
+      const manager = createManager();
+      const oversizedBody = 'x'.repeat(100_001);
+      const content = `---
+name: oversized
+description: A very big skill.
+---
+
+${oversizedBody}
+`;
+      const result = await manager.createSkill('oversized', content);
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('characters');
+      expect(result.message).toContain('references/');
+    });
+  });
+
+  describe('updateSkill', () => {
+    it('rewrites the SKILL.md of an existing global skill', async () => {
+      const manager = createManager(skillsUpdated as unknown as () => void);
+      await manager.createSkill('update-me', makeValidSkill('update-me'));
+
+      const updated = makeValidSkill('update-me', 'Updated description.');
+      const result = await manager.updateSkill('update-me', updated);
+
+      expect(result.success).toBe(true);
+      expect(result.path).toBe(join(globalDir, 'skills', 'update-me'));
+      expect(await readFile(join(result.path!, 'SKILL.md'), 'utf8')).toBe(updated);
+      expect(skillsUpdated).toHaveBeenCalledTimes(2);
+    });
+
+    it('updates the project skill when it shadows a global skill of the same name', async () => {
+      const manager = createManager();
+      await manager.createSkill('shadowed-update', makeValidSkill('shadowed-update'), 'global');
+      await manager.createSkill('shadowed-update', makeValidSkill('shadowed-update'), 'project');
+
+      const updated = makeValidSkill('shadowed-update', 'Project wins.');
+      const result = await manager.updateSkill('shadowed-update', updated);
+
+      expect(result.success).toBe(true);
+      expect(result.path).toBe(join(projectDir, '.aider-desk', 'skills', 'shadowed-update'));
+      expect(await readFile(join(projectDir, '.aider-desk', 'skills', 'shadowed-update', 'SKILL.md'), 'utf8')).toBe(updated);
+    });
+
+    it('rejects updates to skills that do not exist', async () => {
+      const manager = createManager();
+      const result = await manager.updateSkill('does-not-exist', makeValidSkill('does-not-exist'));
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('not found');
+    });
+
+    it.each(['../../outside/SKILL.md', 'sub/dir/escape', 'back\\slash', '..', '.'])(
+      'rejects skill names that escape the skills directories: %s',
+      async (badName) => {
+        const manager = createManager();
+        await manager.createSkill('innocent', makeValidSkill('innocent'));
+
+        const result = await manager.updateSkill(badName, makeValidSkill(badName));
+        expect(result.success).toBe(false);
+        expect(result.message).toContain('not found');
+        expect(existsSync(join(globalDir, 'skills', 'innocent', 'SKILL.md'))).toBe(true);
+      },
+    );
+
+    it('validates content before updating', async () => {
+      const manager = createManager();
+      await manager.createSkill('update-validate', makeValidSkill('update-validate'));
+
+      const result = await manager.updateSkill('update-validate', 'invalid');
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('frontmatter');
+      expect(await readFile(join(globalDir, 'skills', 'update-validate', 'SKILL.md'), 'utf8')).toBe(makeValidSkill('update-validate'));
+    });
+
+    it('rejects updates whose frontmatter name does not match the skill name', async () => {
+      const manager = createManager();
+      await manager.createSkill('update-name-match', makeValidSkill('update-name-match'));
+
+      const result = await manager.updateSkill('update-name-match', makeValidSkill('something-else'));
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("does not match skill name 'update-name-match'");
+      expect(await readFile(join(globalDir, 'skills', 'update-name-match', 'SKILL.md'), 'utf8')).toBe(makeValidSkill('update-name-match'));
+    });
+  });
+
+  describe('writeSkillFile', () => {
+    it('writes a supporting file and creates intermediate directories', async () => {
+      const manager = createManager();
+      await manager.createSkill('with-support', makeValidSkill('with-support'), 'project');
+
+      const result = await manager.writeSkillFile('with-support', 'references/api.md', '# API');
+      expect(result.success).toBe(true);
+      const target = join(projectDir, '.aider-desk', 'skills', 'with-support', 'references', 'api.md');
+      expect(result.path).toBe(target);
+      expect(await readFile(target, 'utf8')).toBe('# API');
+    });
+
+    it('allows overwriting SKILL.md via writeSkillFile', async () => {
+      const manager = createManager();
+      await manager.createSkill('overwrite-smd', makeValidSkill('overwrite-smd'));
+
+      const result = await manager.writeSkillFile('overwrite-smd', 'SKILL.md', makeValidSkill('overwrite-smd', 'Rewritten.'));
+      expect(result.success).toBe(true);
+      expect(await readFile(join(globalDir, 'skills', 'overwrite-smd', 'SKILL.md'), 'utf8')).toContain('Rewritten.');
+    });
+
+    it('rejects path traversal', async () => {
+      const manager = createManager();
+      await manager.createSkill('traversal-target', makeValidSkill('traversal-target'));
+
+      const result = await manager.writeSkillFile('traversal-target', '../../etc/passwd', 'nsa');
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('traversal');
+    });
+
+    it('rejects files outside allowed directories', async () => {
+      const manager = createManager();
+      await manager.createSkill('disallowed-dir', makeValidSkill('disallowed-dir'));
+
+      const result = await manager.writeSkillFile('disallowed-dir', 'random/file.md', 'content');
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('must be under');
+    });
+
+    it('rejects writing when the skill does not exist', async () => {
+      const manager = createManager();
+      const result = await manager.writeSkillFile('missing-skill', 'references/api.md', 'content');
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('not found');
+    });
+
+    it('rejects writing when the skill name escapes the skills directories', async () => {
+      const manager = createManager();
+      await manager.createSkill('still-innocent', makeValidSkill('still-innocent'));
+
+      const result = await manager.writeSkillFile('../../other-suite', 'SKILL.md', makeValidSkill('other'));
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('not found');
+      expect(existsSync(join(globalDir, 'other-suite'))).toBe(false);
+      expect(existsSync(join(globalDir, 'skills', 'other-suite'))).toBe(false);
+    });
+
+    it('rejects oversized file content', async () => {
+      const manager = createManager();
+      await manager.createSkill('too-big-file', makeValidSkill('too-big-file'));
+
+      const result = await manager.writeSkillFile('too-big-file', 'references/big.md', 'x'.repeat(1_048_577));
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('bytes');
+      expect(existsSync(join(globalDir, 'skills', 'too-big-file', 'references', 'big.md'))).toBe(false);
+    });
+  });
+
+  describe('createSkill atomicity', () => {
+    it('lets only one of two concurrent same-name creates succeed', async () => {
+      const manager = createManager();
+
+      const results = await Promise.all([
+        manager.createSkill('raced-create', makeValidSkill('raced-create'), 'global'),
+        manager.createSkill('raced-create', makeValidSkill('raced-create'), 'global'),
+      ]);
+
+      expect(results.filter((r) => r.success)).toHaveLength(1);
+      const failure = results.find((r) => !r.success)!;
+      expect(failure.message).toContain('already exists');
+      expect(failure.path).toBeUndefined();
+    });
+  });
+
+  describe('findSkill', () => {
+    it('prefers project skills over global skills with the same name', async () => {
+      const manager = createManager();
+      await manager.createSkill('precedence', makeValidSkill('precedence'), 'global');
+      await manager.createSkill('precedence', makeValidSkill('precedence'), 'project');
+
+      const found = await manager.findSkill('precedence');
+      expect(found?.location).toBe('project');
+      expect(found?.dirPath).toBe(join(projectDir, '.aider-desk', 'skills', 'precedence'));
+    });
+
+    it('falls back to global skills', async () => {
+      const manager = createManager();
+      await manager.createSkill('only-global', makeValidSkill('only-global'), 'global');
+
+      const found = await manager.findSkill('only-global');
+      expect(found?.location).toBe('global');
+    });
+
+    it('returns null for missing skills', async () => {
+      const found = await createManager().findSkill('nope-not-here');
+      expect(found).toBeNull();
+    });
+  });
+
+  describe('loadAllSkills extension wiring', () => {
+    it('exposes this manager to extensions via the task stub', async () => {
+      let exposedContext: unknown;
+      const extensionManagerStub = {
+        getSkills: (_project: unknown, task: { getSkillManager?: () => unknown; getTaskDir?: () => string }) => {
+          expect(task.getSkillManager?.()).toBe(manager);
+          expect(task.getTaskDir?.()).toBe(projectDir);
+          exposedContext = task;
+          return [];
+        },
+      };
+
+      const manager = new SkillManager(projectDir, extensionManagerStub as never);
+
+      // The stub must collapse the promise-chain call order: getSkills is sync inside loadAllSkills
+      await manager.loadAllSkills();
+      expect(exposedContext).toBeDefined();
+    });
+  });
+
+  describe('loadAllSkills re-entrancy guard', () => {
+    it('does not recurse when an extension hook lists skills back on this manager', async () => {
+      const extensionManagerStub = {
+        getSkills: (_project: unknown, task: { getSkillManager?: () => { listSkills: () => Promise<unknown> } }) => {
+          // Synchronously list skills from within extension discovery, as an extension hook could
+          void task.getSkillManager?.().listSkills();
+          return [];
+        },
+      };
+
+      const manager = new SkillManager(projectDir, extensionManagerStub as never);
+      await expect(manager.listSkills()).resolves.toBeInstanceOf(Array);
+    });
+
+    it('does not re-run extension discovery for an async re-entrant call during the load await gap', async () => {
+      let outerCompleted = false;
+
+      const extensionManagerStub = {
+        getSkills: (_project: unknown, task: { getSkillManager?: () => { listSkills: () => Promise<unknown> } }) => {
+          // Schedule the re-entrant call with an async gap so it lands inside the outer await,
+          // after a sync-only guard would already have been reset
+          void (async () => {
+            await Promise.resolve();
+            await task.getSkillManager?.().listSkills();
+            outerCompleted = true;
+          })();
+          return [];
+        },
+      };
+
+      const manager = new SkillManager(projectDir, extensionManagerStub as never);
+      await expect(manager.listSkills()).resolves.toBeInstanceOf(Array);
+      // If the guard failed, the detached re-entrant load would recurse forever and never set the flag
+      await vi.waitFor(() => expect(outerCompleted).toBe(true));
+    });
+  });
+
+  describe('listSkills', () => {
+    it('includes project and global skills and dedupes by name with project precedence', async () => {
+      const manager = createManager();
+      await manager.createSkill('list-shared', makeValidSkill('list-shared'), 'global');
+      await manager.createSkill('list-project-only', makeValidSkill('list-project-only'), 'project');
+      await manager.createSkill('list-shared', makeValidSkill('list-shared'), 'project');
+
+      const skills = await manager.listSkills();
+      const names = skills.map((s) => s.name);
+      const shared = skills.find((s) => s.name === 'list-shared');
+
+      expect(names).toContain('list-project-only');
+      expect(shared?.location).toBe('project');
+      expect(names.filter((n) => n === 'list-shared')).toHaveLength(1);
+    });
+
+    it('returns the same skills as loadAllSkills', async () => {
+      const manager = createManager();
+      const list = await manager.listSkills();
+      const all = await manager.loadAllSkills();
+      expect(list).toEqual(all);
+    });
+  });
+
+  describe('skill written through SkillManager is visible to getSkills', () => {
+    it('shows up via getSkills without additional events', async () => {
+      const manager = createManager();
+      await manager.createSkill('visible-after-write', makeValidSkill('visible-after-write'), 'project');
+
+      const skills = await manager.getSkills();
+      expect(skills.some((s: SkillDefinition) => s.name === 'visible-after-write')).toBe(true);
+    });
+  });
+});

--- a/src/main/skills/skill-manager.ts
+++ b/src/main/skills/skill-manager.ts
@@ -1,4 +1,5 @@
 import fs from 'fs/promises';
+import { existsSync } from 'fs';
 import path from 'path';
 
 import { v4 as uuidv4 } from 'uuid';
@@ -6,14 +7,24 @@ import { loadFront } from 'yaml-front-matter';
 import { SKILLS_TOOL_GROUP_NAME, SKILLS_TOOL_ACTIVATE_SKILL, TOOL_GROUP_NAME_SEPARATOR } from '@common/tools';
 import { ContextAssistantMessage, ContextMessage, ContextToolMessage, SkillDefinition as Skill, SkillLocation } from '@common/types';
 
+import {
+  SKILL_MARKDOWN_FILE,
+  SKILLS_DIR_NAME,
+  MAX_FILE_BYTES,
+  validateSkillContentSize,
+  validateSkillFilePath,
+  validateSkillFrontmatter,
+  validateSkillName,
+  validateSkillNameMatch,
+} from './skill-validation';
+
 import type { Project } from '@/project';
 import type { Task } from '@/task';
+import type { SkillsContext, SkillWriteResult } from '@common/extensions';
 
 import { AIDER_DESK_BUILTIN_SKILLS_DIR, AIDER_DESK_DIR, AIDER_DESK_HOME_DIR } from '@/constants';
 import { ExtensionManager } from '@/extensions/extension-manager';
-
-const SKILLS_DIR_NAME = 'skills';
-const SKILL_MARKDOWN_FILE = 'SKILL.md';
+import logger from '@/logger';
 
 const TOOL_NAME = `${SKILLS_TOOL_GROUP_NAME}${TOOL_GROUP_NAME_SEPARATOR}${SKILLS_TOOL_ACTIVATE_SKILL}`;
 
@@ -85,41 +96,57 @@ const loadSkillsFromDir = async (skillsRootDir: string, location: SkillLocation)
   return skills;
 };
 
-export class SkillManager {
+export class SkillManager implements SkillsContext {
   private extensionManager: ExtensionManager | undefined;
   private projectDir: string;
+  private onSkillsUpdated?: () => void;
+  private collectingSkillIndex = false;
 
-  constructor(projectDir: string, extensionManager?: ExtensionManager) {
+  constructor(projectDir: string, extensionManager?: ExtensionManager, onSkillsUpdated?: () => void) {
     this.projectDir = projectDir;
     this.extensionManager = extensionManager;
+    this.onSkillsUpdated = onSkillsUpdated;
   }
 
   async loadAllSkills(): Promise<Skill[]> {
     const globalSkillsDir = path.join(AIDER_DESK_HOME_DIR, SKILLS_DIR_NAME);
     const projectSkillsDir = path.join(this.projectDir, AIDER_DESK_DIR, SKILLS_DIR_NAME);
 
-    const extensionSkills: Skill[] = this.extensionManager
-      ? this.extensionManager.getSkills({ baseDir: this.projectDir } as Project, { getTaskDir: () => this.projectDir } as Task)
-      : [];
+    // The task stub exposes this manager so extensions calling context.getSkillContext()
+    // bind to it; without it, createContext caches a manager whose broadcast callback is
+    // tied to a fake project and cannot refresh the UI.
+    const taskStub = { getTaskDir: () => this.projectDir, getSkillManager: () => this } as unknown as Task;
 
-    const [globalSkills, projectSkills, builtinSkills] = await Promise.all([
-      loadSkillsFromDir(globalSkillsDir, 'global'),
-      loadSkillsFromDir(projectSkillsDir, 'project'),
-      loadSkillsFromDir(AIDER_DESK_BUILTIN_SKILLS_DIR, 'builtin'),
-    ]);
+    // An extension hook may call listSkills()/findSkill() back on this manager (synchronously
+    // or via a scheduled async call), which would recurse unboundedly through loadAllSkills.
+    // The flag spans the whole load so re-entrant loads skip extension discovery instead.
+    const wasCollecting = this.collectingSkillIndex;
+    this.collectingSkillIndex = true;
+    try {
+      const extensionSkills: Skill[] =
+        this.extensionManager && !wasCollecting ? this.extensionManager.getSkills({ baseDir: this.projectDir } as Project, taskStub) : [];
 
-    const allSkills = [...extensionSkills, ...projectSkills, ...globalSkills, ...builtinSkills];
+      const [globalSkills, projectSkills, builtinSkills] = await Promise.all([
+        loadSkillsFromDir(globalSkillsDir, 'global'),
+        loadSkillsFromDir(projectSkillsDir, 'project'),
+        loadSkillsFromDir(AIDER_DESK_BUILTIN_SKILLS_DIR, 'builtin'),
+      ]);
 
-    const seen = new Set<string>();
-    const deduped: Skill[] = [];
-    for (const skill of allSkills) {
-      if (!seen.has(skill.name)) {
-        seen.add(skill.name);
-        deduped.push(skill);
+      const allSkills = [...extensionSkills, ...projectSkills, ...globalSkills, ...builtinSkills];
+
+      const seen = new Set<string>();
+      const deduped: Skill[] = [];
+      for (const skill of allSkills) {
+        if (!seen.has(skill.name)) {
+          seen.add(skill.name);
+          deduped.push(skill);
+        }
       }
-    }
 
-    return deduped;
+      return deduped;
+    } finally {
+      this.collectingSkillIndex = wasCollecting;
+    }
   }
 
   async getSkills(contextMessages?: ContextMessage[]): Promise<Skill[]> {
@@ -130,6 +157,10 @@ export class SkillManager {
       ...skill,
       activated: activatedSkillNames.has(skill.name),
     }));
+  }
+
+  async listSkills(): Promise<Skill[]> {
+    return this.loadAllSkills();
   }
 
   async getSkillContent(skillName: string): Promise<string | null> {
@@ -154,6 +185,169 @@ export class SkillManager {
     }
 
     return null;
+  }
+
+  resolveSkillDir(name: string, location: 'global' | 'project'): string {
+    if (location === 'project') {
+      return path.join(this.projectDir, AIDER_DESK_DIR, SKILLS_DIR_NAME, name);
+    }
+    return path.join(AIDER_DESK_HOME_DIR, SKILLS_DIR_NAME, name);
+  }
+
+  async findSkill(name: string): Promise<Skill | null> {
+    // findSkill backs the write paths (updateSkill, writeSkillFile), so reject anything that
+    // could escape the skills directories; createSkill enforces the same via validateSkillName
+    if (!name || name === '.' || name.includes('..') || name.includes('/') || name.includes('\\')) {
+      return null;
+    }
+
+    // Project precedence matches loadAllSkills(), where project skills shadow global skills of the same name
+    const projectSkillDir = path.join(this.projectDir, AIDER_DESK_DIR, SKILLS_DIR_NAME, name);
+    if (existsSync(path.join(projectSkillDir, SKILL_MARKDOWN_FILE))) {
+      return { name, description: '', location: 'project', dirPath: projectSkillDir };
+    }
+
+    const globalSkillDir = path.join(AIDER_DESK_HOME_DIR, SKILLS_DIR_NAME, name);
+    if (existsSync(path.join(globalSkillDir, SKILL_MARKDOWN_FILE))) {
+      return { name, description: '', location: 'global', dirPath: globalSkillDir };
+    }
+
+    return null;
+  }
+
+  async createSkill(name: string, content: string, location: 'global' | 'project' = 'global'): Promise<SkillWriteResult> {
+    if (!content) {
+      return { success: false, message: 'Content is required for create action.' };
+    }
+
+    const nameError = validateSkillName(name);
+    if (nameError) {
+      return { success: false, message: nameError };
+    }
+
+    const frontmatterError = validateSkillFrontmatter(content);
+    if (frontmatterError) {
+      return { success: false, message: frontmatterError };
+    }
+
+    const nameMatchError = validateSkillNameMatch(name, content);
+    if (nameMatchError) {
+      return { success: false, message: nameMatchError };
+    }
+
+    const sizeError = validateSkillContentSize(content);
+    if (sizeError) {
+      return { success: false, message: sizeError };
+    }
+
+    // Only the target location blocks creation; a project skill may shadow a global one
+    // (loadAllSkills() gives project precedence when deduplicating).
+    const skillDir = this.resolveSkillDir(name, location);
+    // Atomicity: a recursive mkdir would silently succeed for concurrent creates of the same
+    // name and let their writeFile calls clobber each other; a `recursive: false` mkdir fails
+    // with EEXIST for whichever create loses the race.
+    await fs.mkdir(path.dirname(skillDir), { recursive: true });
+    try {
+      await fs.mkdir(skillDir, { recursive: false });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+        return {
+          success: false,
+          message: `A skill named '${name}' already exists at ${skillDir}. Use updateSkill to modify it.`,
+        };
+      }
+      throw error;
+    }
+    await fs.writeFile(path.join(skillDir, SKILL_MARKDOWN_FILE), content, 'utf8');
+
+    this.notifySkillsUpdated();
+
+    return {
+      success: true,
+      message: `Skill '${name}' created at ${location} location.`,
+      path: skillDir,
+    };
+  }
+
+  async updateSkill(name: string, content: string): Promise<SkillWriteResult> {
+    if (!content) {
+      return { success: false, message: 'Content is required for update action.' };
+    }
+
+    const frontmatterError = validateSkillFrontmatter(content);
+    if (frontmatterError) {
+      return { success: false, message: frontmatterError };
+    }
+
+    const nameMatchError = validateSkillNameMatch(name, content);
+    if (nameMatchError) {
+      return { success: false, message: nameMatchError };
+    }
+
+    const sizeError = validateSkillContentSize(content);
+    if (sizeError) {
+      return { success: false, message: sizeError };
+    }
+
+    const existing = await this.findSkill(name);
+    if (!existing?.dirPath) {
+      return { success: false, message: `Skill '${name}' not found. Use createSkill to create a new skill.` };
+    }
+
+    await fs.writeFile(path.join(existing.dirPath, SKILL_MARKDOWN_FILE), content, 'utf8');
+
+    this.notifySkillsUpdated();
+
+    return {
+      success: true,
+      message: `Skill '${name}' updated (full rewrite).`,
+      path: existing.dirPath,
+    };
+  }
+
+  async writeSkillFile(name: string, filePath: string, content: string): Promise<SkillWriteResult> {
+    const pathError = validateSkillFilePath(filePath);
+    if (pathError) {
+      return { success: false, message: pathError };
+    }
+
+    const contentBytes = Buffer.byteLength(content, 'utf8');
+    if (contentBytes > MAX_FILE_BYTES) {
+      return {
+        success: false,
+        message: `File content is ${contentBytes.toLocaleString()} bytes (limit: ${MAX_FILE_BYTES.toLocaleString()} bytes). Consider splitting into smaller files.`,
+      };
+    }
+
+    const sizeError = validateSkillContentSize(content, filePath);
+    if (sizeError) {
+      return { success: false, message: sizeError };
+    }
+
+    const existing = await this.findSkill(name);
+    if (!existing?.dirPath) {
+      return { success: false, message: `Skill '${name}' not found. Create it first with createSkill.` };
+    }
+
+    const targetPath = path.join(existing.dirPath, filePath.replace(/\\/g, '/'));
+    await fs.mkdir(path.dirname(targetPath), { recursive: true });
+    await fs.writeFile(targetPath, content, 'utf8');
+
+    this.notifySkillsUpdated();
+
+    return {
+      success: true,
+      message: `File '${filePath}' written to skill '${name}'.`,
+      path: targetPath,
+    };
+  }
+
+  private notifySkillsUpdated(): void {
+    try {
+      this.onSkillsUpdated?.();
+    } catch (error) {
+      logger.warn(`Failed to notify skills updated: ${error instanceof Error ? error.message : String(error)}`);
+    }
   }
 
   getActivatedSkillNames(contextMessages: ContextMessage[]): Set<string> {

--- a/src/main/skills/skill-validation.ts
+++ b/src/main/skills/skill-validation.ts
@@ -1,0 +1,155 @@
+import { loadFront } from 'yaml-front-matter';
+
+export const SKILLS_DIR_NAME = 'skills';
+export const SKILL_MARKDOWN_FILE = 'SKILL.md';
+
+export const MAX_NAME_LENGTH = 64;
+export const MAX_DESCRIPTION_LENGTH = 1024;
+export const MAX_CONTENT_CHARS = 100_000;
+export const MAX_FILE_BYTES = 1_048_576;
+
+const VALID_NAME_RE = /^[a-z0-9][a-z0-9._-]*$/;
+const ALLOWED_SUBDIRS = new Set(['references', 'templates', 'scripts', 'assets']);
+
+// The skill index renders only the first ~60 characters of the description in every
+// session's system prompt, so anything longer is silently truncated and breaks routing.
+export const MAX_ROUTABLE_DESCRIPTION_CHARS = 60;
+
+const validateSkillName = (name: string): string | null => {
+  if (!name) {
+    return 'Skill name is required.';
+  }
+  if (name.length > MAX_NAME_LENGTH) {
+    return `Skill name exceeds ${MAX_NAME_LENGTH} characters.`;
+  }
+  if (!VALID_NAME_RE.test(name)) {
+    return `Invalid skill name '${name}'. Use lowercase letters, numbers, hyphens, dots, and underscores. Must start with a letter or digit.`;
+  }
+  return null;
+};
+
+const parseFrontMatterBlock = (content: string): { front: Record<string, unknown>; body: string } | string => {
+  const cleaned = content.replace(/^\uFEFF/, '');
+
+  if (!cleaned.startsWith('---')) {
+    return 'SKILL.md must start with YAML frontmatter (---).';
+  }
+
+  const endMatch = cleaned.slice(3).match(/\n---\s*\n/);
+  if (!endMatch || endMatch.index === undefined) {
+    return "SKILL.md frontmatter is not closed. Ensure you have a closing '---' line.";
+  }
+
+  const frontmatterEnd = endMatch.index + 3 + endMatch[0].length;
+  const frontmatterBlock = cleaned.slice(0, frontmatterEnd);
+  const body = cleaned.slice(frontmatterEnd).trim();
+
+  let parsed: unknown;
+  try {
+    parsed = loadFront(frontmatterBlock) as Record<string, unknown>;
+  } catch {
+    return 'YAML frontmatter parse error.';
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) {
+    return 'Frontmatter must be a YAML mapping (key: value pairs).';
+  }
+
+  return { front: parsed as Record<string, unknown>, body };
+};
+
+const validateSkillFrontmatter = (content: string): string | null => {
+  if (!content.trim()) {
+    return 'Content cannot be empty.';
+  }
+
+  const parsedBlock = parseFrontMatterBlock(content);
+  if (typeof parsedBlock === 'string') {
+    return parsedBlock;
+  }
+  const { front, body } = parsedBlock;
+
+  if (!('name' in front)) {
+    return "Frontmatter must include 'name' field.";
+  }
+  if (!('description' in front)) {
+    return "Frontmatter must include 'description' field.";
+  }
+
+  if (typeof front.description !== 'string') {
+    return "Frontmatter 'description' must be a string.";
+  }
+  const desc = front.description;
+  if (desc.length > MAX_DESCRIPTION_LENGTH) {
+    return `Description exceeds ${MAX_DESCRIPTION_LENGTH} characters.`;
+  }
+
+  if (desc.trim().length > MAX_ROUTABLE_DESCRIPTION_CHARS) {
+    return (
+      `Description is ${desc.trim().length} chars — skills must keep the ` +
+      `description <=${MAX_ROUTABLE_DESCRIPTION_CHARS} chars (the skill index truncates it, destroying ` +
+      'the routing signal). Move detail into the skill body.'
+    );
+  }
+
+  if (!body) {
+    return 'SKILL.md must have content after the frontmatter.';
+  }
+
+  return null;
+};
+
+const validateSkillNameMatch = (name: string, content: string): string | null => {
+  const parsedBlock = parseFrontMatterBlock(content);
+  if (typeof parsedBlock === 'string') {
+    return parsedBlock;
+  }
+
+  const frontName = typeof parsedBlock.front.name === 'string' ? parsedBlock.front.name : undefined;
+  if (frontName !== name) {
+    return `Frontmatter name '${frontName}' does not match skill name '${name}'. The directory is keyed by the skill name, so they must be identical for the skill to be discoverable.`;
+  }
+
+  return null;
+};
+
+const validateSkillContentSize = (content: string, label = 'SKILL.md'): string | null => {
+  if (content.length > MAX_CONTENT_CHARS) {
+    return (
+      `${label} content is ${content.length.toLocaleString()} characters ` +
+      `(limit: ${MAX_CONTENT_CHARS.toLocaleString()}). Consider splitting ` +
+      'into a smaller SKILL.md with supporting files in references/ or templates/.'
+    );
+  }
+  return null;
+};
+
+const validateSkillFilePath = (filePath: string): string | null => {
+  if (!filePath) {
+    return 'file_path is required.';
+  }
+
+  if (filePath.includes('..')) {
+    return "Path traversal ('..') is not allowed.";
+  }
+
+  const normalized = filePath.replace(/\\/g, '/');
+
+  if (normalized === SKILL_MARKDOWN_FILE || normalized.endsWith(`/${SKILL_MARKDOWN_FILE}`)) {
+    return null;
+  }
+
+  const parts = normalized.split('/');
+  if (parts.length === 0 || !ALLOWED_SUBDIRS.has(parts[0]!)) {
+    const allowed = Array.from(ALLOWED_SUBDIRS).sort().join(', ');
+    return `File must be under one of: ${allowed}. Got: '${filePath}'`;
+  }
+
+  if (parts.length < 2) {
+    return `Provide a file path, not just a directory. Example: '${parts[0]}/myfile.md'`;
+  }
+
+  return null;
+};
+
+export { validateSkillName, validateSkillFrontmatter, validateSkillNameMatch, validateSkillContentSize, validateSkillFilePath };

--- a/src/main/task/task.ts
+++ b/src/main/task/task.ts
@@ -219,7 +219,7 @@ export class Task {
     };
     this.taskDataPath = path.join(this.project.baseDir, AIDER_DESK_TASKS_DIR, this.taskId, 'settings.json');
     this.contextManager = new ContextManager(this, this.taskId);
-    this.skillManager = new SkillManager(project.baseDir, extensionManager);
+    this.skillManager = new SkillManager(project.baseDir, extensionManager, () => this.sendSkillsUpdated());
     this.agent = new Agent(
       this.store,
       this.agentProfileManager,


### PR DESCRIPTION
Adds a SkillsContext to the extensions api (list/find/resolve/create/update/writeSkillFile) backed by SkillManager, with shared authoring validation (name, frontmatter, size, path safety) and an atomic createSkill that allows project skills to shadow global ones.

The extension manager now caches one project skill manager per project, evicts it after event dispatch, and broadcasts skills updates so the ui refreshes after project-scoped writes.

The learn extension's skill-writer is refactored to delegate to the new context instead of reimplementing path resolution and file controls.
