### PR TITLE
feat(extensions): add active project to git-log

### DIFF
--- a/docs-site/docs/extensions/api-reference.md
+++ b/docs-site/docs/extensions/api-reference.md
@@ -101,6 +101,7 @@ interface ExtensionContext {
   getProjectDir(): string;
   getProjectContext(): ProjectContext;
   getOpenProjectDirs(): string[];
+  getActiveProjectDir?(): string;
 
   // Task access
   getTaskContext(): TaskContext | null;
@@ -119,7 +120,8 @@ interface ExtensionContext {
   getMcpServers(projectDir?: string): Promise<Record<string, McpServerConfig>>;
 
   // UI refresh
-  triggerUIDataRefresh(componentId?: string, taskId?: string): void;
+  triggerUIDataRefresh(componentId?: string, taskId?: string, projectDir?: string): void;
+  triggerGlobalUIDataRefresh(componentId?: string, taskId?: string): void;
   triggerUIComponentsReload(): void;
 
   // Navigation
@@ -136,6 +138,7 @@ interface ExtensionContext {
 | `log(message, type?)` | Log a message to AiderDesk console and log files |
 | `getProjectDir()` | Get the current project directory path |
 | `getOpenProjectDirs()` | Get the base directories of all currently open projects |
+| `getActiveProjectDir()` | Get the base directory of the active project, or an empty string if none is active. Optional: may be absent on older AiderDesk hosts — feature-detect it (`typeof context.getActiveProjectDir === 'function'`) before calling. |
 | `getTaskContext()` | Get the current task context (null if no task active) |
 | `getProjectContext()` | Get the project context for project operations |
 | `getMemoryContext()` | Get the memory context for store/retrieve/delete memory operations |
@@ -143,7 +146,8 @@ interface ExtensionContext {
 | `getSetting(key)` | Get a setting value (supports dot-notation) |
 | `updateSettings(updates)` | Update multiple settings at once |
 | `getMcpServers(projectDir?)` | Get merged MCP server configurations (global overridden by project-specific) |
-| `triggerUIDataRefresh(componentId?, taskId?)` | Trigger UI component data refresh |
+| `triggerUIDataRefresh(componentId?, taskId?, projectDir?)` | Trigger UI component data refresh. When `projectDir` is omitted, the refresh is scoped to the context's project. If `projectDir` is passed explicitly as `undefined` (e.g. `triggerUIDataRefresh(componentId, undefined, undefined)`), the refresh is global — omitting the argument and passing `undefined` are intentionally different. |
+| `triggerGlobalUIDataRefresh(componentId?, taskId?)` | Trigger a global (unscoped) UI component data refresh, regardless of the context's project |
 | `triggerUIComponentsReload()` | Reload all UI component definitions for this extension |
 | `openUrl(url, target?)` | Open URL in external browser, new window, or modal overlay |
 | `openPath(path)` | Open file or directory in system's default application |

--- a/packages/common/src/extensions.ts
+++ b/packages/common/src/extensions.ts
@@ -1465,6 +1465,14 @@ export interface ExtensionContext {
   getOpenProjectDirs(): string[];
 
   /**
+   * Get the base directory of the currently active (focused) project tab.
+   * Available regardless of whether the context itself is scoped to a project or task.
+   * Returns an empty string when no project is active.
+   * Optional: may be absent on older hosts, so feature-detect with `typeof` before calling.
+   */
+  getActiveProjectDir?(): string;
+
+  /**
    * Get the task context for the current task.
    * Only available when the context is created for a specific task (e.g., task event handlers,
    * command execution within a task). Returns null when no task is available.
@@ -1523,8 +1531,23 @@ export interface ExtensionContext {
    * No-op if the EventManager is not available.
    * @param componentId - Optional component ID to refresh only a specific component
    * @param taskId - Optional task ID to scope the refresh to components for a specific task
+   * @param projectDir - Optional project directory to scope the refresh to components for a specific project.
+   * Passing the third argument explicitly (even as `undefined`) triggers a global refresh applying to
+   * all mounted components; omitting the third argument falls back to the context's project directory
+   * (when the context is scoped to a project).
    */
-  triggerUIDataRefresh(componentId?: string, taskId?: string): void;
+  triggerUIDataRefresh(componentId?: string, taskId?: string, projectDir?: string): void;
+
+  /**
+   * Trigger a global UI data refresh for this extension's components, applying
+   * to all mounted components regardless of project scope. Use this when global
+   * state (e.g. the active project) changed.
+   * No-op if the EventManager is not available.
+   * May be absent on older hosts, feature-detect with typeof.
+   * @param componentId - Optional component ID to refresh only a specific component
+   * @param taskId - Optional task ID to scope the refresh to components for a specific task
+   */
+  triggerGlobalUIDataRefresh?(componentId?: string, taskId?: string): void;
 
   /**
    * Trigger a full reload of all UI component definitions for this extension.

--- a/packages/extensions/extensions/git-log/index.ts
+++ b/packages/extensions/extensions/git-log/index.ts
@@ -29,11 +29,23 @@ export default class GitLogExtension implements Extension {
   }
 
   async onProjectStarted(_event: ProjectStartedEvent, context: ExtensionContext): Promise<void> {
-    context.triggerUIDataRefresh(COMPONENT_ID);
+    this.refreshUIData(context);
   }
 
   async onProjectStopped(_event: ProjectStoppedEvent, context: ExtensionContext): Promise<void> {
-    context.triggerUIDataRefresh(COMPONENT_ID);
+    this.refreshUIData(context);
+  }
+
+  private refreshUIData(context: ExtensionContext): void {
+    try {
+      if (typeof context.triggerGlobalUIDataRefresh === 'function') {
+        context.triggerGlobalUIDataRefresh(COMPONENT_ID);
+      } else {
+        context.triggerUIDataRefresh(COMPONENT_ID, undefined, undefined);
+      }
+    } catch (err) {
+      context.log(`Failed to trigger UI data refresh: ${err instanceof Error ? err.message : String(err)}`, 'warn');
+    }
   }
 
   getUIComponents(_context: ExtensionContext): UIComponentDefinition[] {
@@ -52,8 +64,19 @@ export default class GitLogExtension implements Extension {
 
     return {
       openProjectDirs: this.getOpenProjectDirsSafe(context),
+      activeProjectDir: this.getActiveProjectDirSafe(context),
       currentProjectDir: context.getProjectDir(),
     };
+  }
+
+  private getActiveProjectDirSafe(context: ExtensionContext): string {
+    try {
+      if (typeof context.getActiveProjectDir !== 'function') return '';
+      return context.getActiveProjectDir() ?? '';
+    } catch (err) {
+      context.log(`getActiveProjectDir is unavailable: ${err instanceof Error ? err.message : String(err)}`, 'warn');
+      return '';
+    }
   }
 
   private getOpenProjectDirsSafe(context: ExtensionContext): string[] | null {

--- a/packages/extensions/extensions/git-log/package.json
+++ b/packages/extensions/extensions/git-log/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-log",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Browse the git history of open projects with an IntelliJ IDEA-style log viewer",
   "main": "index.ts",
   "author": "AiderDesk",

--- a/packages/extensions/extensions/git-log/ui/GitLog.jsx
+++ b/packages/extensions/extensions/git-log/ui/GitLog.jsx
@@ -137,9 +137,15 @@
     return years + ' year' + (years > 1 ? 's' : '') + ' ago';
   }, []);
 
+  const activeProjectDir = typeof data?.activeProjectDir === 'string' ? data.activeProjectDir : '';
+
   const projectOptions = useMemo(
-    () => (projectDirs || []).map((d) => ({ value: d, label: baseName(d) })),
-    [projectDirs, baseName],
+    () =>
+      (projectDirs || []).map((d) => ({
+        value: d,
+        label: baseName(d) + (d && activeProjectDir === d ? ' •' : ''),
+      })),
+    [projectDirs, baseName, activeProjectDir],
   );
 
   const filteredBranches = useMemo(() => {
@@ -206,15 +212,17 @@
   const handleOpen = useCallback(async () => {
     setShowModal(true);
     const dirs = Array.isArray(projectDirs) ? projectDirs : [];
-    let target = selectedProject;
-    if (!dirs.includes(target) && dirs.length > 0) target = dirs[0];
-    if (!target && data.currentProjectDir) target = data.currentProjectDir;
+    let target = '';
+    if (selectedProject && dirs.includes(selectedProject)) target = selectedProject;
+    if (!target && activeProjectDir && dirs.includes(activeProjectDir)) target = activeProjectDir;
+    if (!target && data.currentProjectDir && dirs.includes(data.currentProjectDir)) target = data.currentProjectDir;
+    if (!target && dirs.length > 0) target = dirs[0];
     if (!target) {
       setError('No open projects to inspect');
       return;
     }
     await selectProject(target);
-  }, [data.currentProjectDir, projectDirs, selectedProject, selectProject]);
+  }, [activeProjectDir, data.currentProjectDir, projectDirs, selectedProject, selectProject]);
 
   const handleClose = useCallback(() => {
     setShowModal(false);

--- a/src/main/__tests__/events-handler.test.ts
+++ b/src/main/__tests__/events-handler.test.ts
@@ -1,14 +1,68 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { EventsHandler } from '../events-handler';
 
 import type { AgentProfileManager } from '@/agent';
+import type { EventManager } from '@/events/event-manager';
 import type { Store } from '@/store';
 import type { ModelManager } from '@/models';
 import type { TelemetryManager } from '@/telemetry';
 import type { ProjectData } from '@common/types';
 
+const createEventsHandler = (
+  store: Store,
+  eventManager: EventManager,
+  telemetryManager: TelemetryManager,
+  agentProfileManager: AgentProfileManager,
+  modelManager: ModelManager = {} as ModelManager,
+) =>
+  new EventsHandler(
+    {} as never,
+    store,
+    {} as never,
+    {} as never,
+    {} as never,
+    modelManager,
+    telemetryManager,
+    {} as never,
+    {} as never,
+    {} as never,
+    eventManager,
+    agentProfileManager,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+  );
+
 describe('EventsHandler', () => {
+  let store: Store;
+  let eventManager: EventManager;
+  let telemetryManager: TelemetryManager;
+  let agentProfileManager: AgentProfileManager;
+
+  beforeEach(() => {
+    store = {
+      getOpenProjects: vi.fn(() => []),
+      setOpenProjects: vi.fn(),
+      addRecentProject: vi.fn(),
+      getSettings: vi.fn(() => ({ aider: { options: '' } })),
+      getProviders: vi.fn(() => []),
+    } as unknown as Store;
+    eventManager = {
+      sendExtensionUIRefresh: vi.fn(),
+    } as unknown as EventManager;
+    telemetryManager = {
+      captureProjectOpened: vi.fn(),
+      captureProjectClosed: vi.fn(),
+    } as unknown as TelemetryManager;
+    agentProfileManager = {
+      getDefaultAgentProfileId: vi.fn(() => 'default-profile'),
+      getProfile: vi.fn(() => undefined),
+    } as unknown as AgentProfileManager;
+    vi.clearAllMocks();
+  });
+
   it('uses the default agent profile when the active project profile is scoped to another project', async () => {
     const activeProject = {
       baseDir: '/previous-project',
@@ -17,38 +71,12 @@ describe('EventsHandler', () => {
         agentProfileId: 'previous-project-profile',
       },
     } as unknown as ProjectData;
-    const store = {
-      getOpenProjects: vi.fn(() => [activeProject]),
-      setOpenProjects: vi.fn(),
-    } as unknown as Store;
+    (store.getOpenProjects as ReturnType<typeof vi.fn>).mockImplementation(() => [activeProject]);
     const modelManager = {
       getProviderModels: vi.fn().mockResolvedValue({ models: [] }),
     } as unknown as ModelManager;
-    const telemetryManager = {
-      captureProjectOpened: vi.fn(),
-    } as unknown as TelemetryManager;
-    const agentProfileManager = {
-      getDefaultAgentProfileId: vi.fn(() => 'default-profile'),
-      getProfile: vi.fn(() => ({ id: 'previous-project-profile', projectDir: '/previous-project' })),
-    } as unknown as AgentProfileManager;
-    const eventsHandler = new EventsHandler(
-      {} as never,
-      store,
-      {} as never,
-      {} as never,
-      {} as never,
-      modelManager,
-      telemetryManager,
-      {} as never,
-      {} as never,
-      {} as never,
-      {} as never,
-      agentProfileManager,
-      {} as never,
-      {} as never,
-      {} as never,
-      {} as never,
-    );
+    (agentProfileManager.getProfile as ReturnType<typeof vi.fn>).mockReturnValue({ id: 'previous-project-profile', projectDir: '/previous-project' });
+    const eventsHandler = createEventsHandler(store, eventManager, telemetryManager, agentProfileManager, modelManager);
 
     await eventsHandler.addOpenProject('/new-project');
 
@@ -60,5 +88,117 @@ describe('EventsHandler', () => {
         settings: expect.objectContaining({ agentProfileId: 'default-profile' }),
       }),
     ]);
+  });
+
+  it('sends exactly one extension UI refresh when adding a project to an empty list', async () => {
+    const modelManager = {
+      getProviderModels: vi.fn().mockResolvedValue({ models: [] }),
+    } as unknown as ModelManager;
+    const eventsHandler = createEventsHandler(store, eventManager, telemetryManager, agentProfileManager, modelManager);
+
+    await eventsHandler.addOpenProject('/new-project');
+
+    expect(store.setOpenProjects).toHaveBeenCalledWith([expect.objectContaining({ baseDir: '/new-project', active: true })]);
+    expect(eventManager.sendExtensionUIRefresh).toHaveBeenCalledTimes(1);
+    expect(eventManager.sendExtensionUIRefresh).toHaveBeenCalledWith({});
+  });
+
+  it('sends exactly one extension UI refresh when closing the active project and another remains', () => {
+    const projectA = { baseDir: '/project-a', active: false } as unknown as ProjectData;
+    const projectB = { baseDir: '/project-b', active: true } as unknown as ProjectData;
+    (store.getOpenProjects as ReturnType<typeof vi.fn>).mockReturnValue([projectA, projectB]);
+    const eventsHandler = createEventsHandler(store, eventManager, telemetryManager, agentProfileManager);
+
+    const result = eventsHandler.removeOpenProject('/project-b');
+
+    // The remaining project is auto-activated and must be a NEW object (not a mutated shared reference)
+    expect(store.setOpenProjects).toHaveBeenCalledWith([{ baseDir: '/project-a', active: true }]);
+    const calls = vi.mocked(store.setOpenProjects).mock.calls;
+    const saved = calls[calls.length - 1][0];
+    // The saved list must not reuse the original project object from the store
+    expect(saved[0]).not.toBe(projectA);
+    expect(result).toEqual([{ baseDir: '/project-a', active: true }]);
+    expect(eventManager.sendExtensionUIRefresh).toHaveBeenCalledTimes(1);
+    expect(eventManager.sendExtensionUIRefresh).toHaveBeenCalledWith({});
+  });
+
+  it('emits a refresh when a project list changes even if the active project is unchanged', () => {
+    // Removing an inactive project changes the membership of the open list,
+    // so extension UIs must refresh even though the active project is unchanged
+    const projectA = { baseDir: '/project-a', active: true } as unknown as ProjectData;
+    const projectB = { baseDir: '/project-b', active: false } as unknown as ProjectData;
+    (store.getOpenProjects as ReturnType<typeof vi.fn>).mockReturnValue([projectA, projectB]);
+    const eventsHandler = createEventsHandler(store, eventManager, telemetryManager, agentProfileManager);
+
+    eventsHandler.removeOpenProject('/project-b');
+
+    expect(store.setOpenProjects).toHaveBeenCalledWith([expect.objectContaining({ baseDir: '/project-a', active: true })]);
+    const calls = vi.mocked(store.setOpenProjects).mock.calls;
+    const saved = calls[calls.length - 1][0];
+    // The retained project must be a new object, not the original store reference
+    expect(saved[0]).not.toBe(projectA);
+    expect(eventManager.sendExtensionUIRefresh).toHaveBeenCalledTimes(1);
+    expect(eventManager.sendExtensionUIRefresh).toHaveBeenCalledWith({});
+  });
+
+  it('emits a refresh when the active project is removed and a fallback becomes active', () => {
+    // Removing the active FIRST project falls back to activating the last remaining one
+    const projectA = { baseDir: '/project-a', active: true } as unknown as ProjectData;
+    const projectB = { baseDir: '/project-b', active: false } as unknown as ProjectData;
+    (store.getOpenProjects as ReturnType<typeof vi.fn>).mockReturnValue([projectA, projectB]);
+    const eventsHandler = createEventsHandler(store, eventManager, telemetryManager, agentProfileManager);
+
+    eventsHandler.removeOpenProject('/project-a');
+
+    expect(store.setOpenProjects).toHaveBeenCalledWith([{ baseDir: '/project-b', active: true }]);
+    expect(eventManager.sendExtensionUIRefresh).toHaveBeenCalledTimes(1);
+    expect(eventManager.sendExtensionUIRefresh).toHaveBeenCalledWith({});
+  });
+
+  it('activates the matching project and emits a refresh when setActiveProject finds the target', async () => {
+    const projectA = { baseDir: '/project-a', active: true } as unknown as ProjectData;
+    const projectB = { baseDir: '/project-b', active: false } as unknown as ProjectData;
+    (store.getOpenProjects as ReturnType<typeof vi.fn>).mockReturnValue([projectA, projectB]);
+    const eventsHandler = createEventsHandler(store, eventManager, telemetryManager, agentProfileManager);
+
+    const result = await eventsHandler.setActiveProject('/project-b');
+
+    expect(store.setOpenProjects).toHaveBeenCalledWith([
+      { baseDir: '/project-a', active: false },
+      { baseDir: '/project-b', active: true },
+    ]);
+    expect(eventManager.sendExtensionUIRefresh).toHaveBeenCalledTimes(1);
+    expect(eventManager.sendExtensionUIRefresh).toHaveBeenCalledWith({});
+    expect(result).toEqual(expect.arrayContaining([expect.objectContaining({ baseDir: '/project-b', active: true })]));
+  });
+
+  it('does not modify active projects when the target project is not open', async () => {
+    // An unknown baseDir must not wipe the active flags of currently open projects
+    const projectA = { baseDir: '/project-a', active: false } as unknown as ProjectData;
+    const projectB = { baseDir: '/project-b', active: true } as unknown as ProjectData;
+    (store.getOpenProjects as ReturnType<typeof vi.fn>).mockReturnValue([projectA, projectB]);
+    const eventsHandler = createEventsHandler(store, eventManager, telemetryManager, agentProfileManager);
+
+    const result = await eventsHandler.setActiveProject('/nonexistent');
+
+    expect(store.setOpenProjects).not.toHaveBeenCalled();
+    expect(eventManager.sendExtensionUIRefresh).not.toHaveBeenCalled();
+    expect(result).toEqual([
+      { baseDir: '/project-a', active: false },
+      { baseDir: '/project-b', active: true },
+    ]);
+  });
+
+  it('emits a refresh when the only open project is closed', () => {
+    // Closing the last project transitions the active dir from /only-project to undefined
+    const project = { baseDir: '/only-project', active: true } as unknown as ProjectData;
+    (store.getOpenProjects as ReturnType<typeof vi.fn>).mockReturnValue([project]);
+    const eventsHandler = createEventsHandler(store, eventManager, telemetryManager, agentProfileManager);
+
+    eventsHandler.removeOpenProject('/only-project');
+
+    expect(store.setOpenProjects).toHaveBeenCalledWith([]);
+    expect(eventManager.sendExtensionUIRefresh).toHaveBeenCalledTimes(1);
+    expect(eventManager.sendExtensionUIRefresh).toHaveBeenCalledWith({});
   });
 });

--- a/src/main/events-handler.ts
+++ b/src/main/events-handler.ts
@@ -42,7 +42,7 @@ import {
   VoiceSession,
   ChangeRequestItem,
 } from '@common/types';
-import { compareBaseDirs, normalizeBaseDir } from '@common/utils';
+import { compareBaseDirs } from '@common/utils';
 // @ts-expect-error istextorbinary is not typed properly
 import { isBinary } from 'istextorbinary';
 
@@ -213,6 +213,7 @@ export class EventsHandler {
       };
       const updatedProjects = [...projects.map((p) => ({ ...p, active: false })), newProject];
       this.store.setOpenProjects(updatedProjects);
+      this.notifyExtensionUIRefreshIfNeeded(projects, updatedProjects);
 
       this.telemetryManager.captureProjectOpened(this.store.getOpenProjects().length);
     }
@@ -221,7 +222,7 @@ export class EventsHandler {
 
   removeOpenProject(baseDir: string): ProjectData[] {
     const projects = this.store.getOpenProjects();
-    const updatedProjects = projects.filter((project) => !compareBaseDirs(project.baseDir, baseDir));
+    const updatedProjects = projects.filter((project) => !compareBaseDirs(project.baseDir, baseDir)).map((project) => ({ ...project }));
 
     if (updatedProjects.length > 0) {
       // Set the last project as active if the current active project was removed
@@ -232,6 +233,7 @@ export class EventsHandler {
 
     this.addRecentProject(baseDir);
     this.store.setOpenProjects(updatedProjects);
+    this.notifyExtensionUIRefreshIfNeeded(projects, updatedProjects);
 
     this.telemetryManager.captureProjectClosed(this.store.getOpenProjects().length);
 
@@ -240,14 +242,41 @@ export class EventsHandler {
 
   async setActiveProject(baseDir: string): Promise<ProjectData[]> {
     const projects = this.store.getOpenProjects();
+
+    // Do not touch the store if no open project matches — an unknown baseDir
+    // must not clear the active flags of the currently open projects.
+    if (!projects.some((project) => compareBaseDirs(project.baseDir, baseDir))) {
+      return projects;
+    }
+
     const updatedProjects = projects.map((project) => ({
       ...project,
-      active: normalizeBaseDir(project.baseDir) === normalizeBaseDir(baseDir),
+      active: compareBaseDirs(project.baseDir, baseDir),
     }));
 
     this.store.setOpenProjects(updatedProjects);
+    this.notifyExtensionUIRefreshIfNeeded(projects, updatedProjects);
 
     return updatedProjects;
+  }
+
+  /**
+   * Notify the renderer so extension UI components (e.g. app-level ones
+   * reading the active project) re-fetch their data.
+   * Emits when the OPEN-PROJECT LIST membership changed (add/remove, e.g. an
+   * inactive project was closed and its entry must disappear from extension
+   * dropdowns) or when the ACTIVE PROJECT (by baseDir) changed — the extra
+   * active check keeps setActiveProject in sync even when membership is the same.
+   * Empty options = global refresh (no projectDir scoping).
+   */
+  private notifyExtensionUIRefreshIfNeeded(previous: ProjectData[], updated: ProjectData[]): void {
+    const previousActiveDir = previous.find((p) => p.active)?.baseDir;
+    const updatedActiveDir = updated.find((p) => p.active)?.baseDir;
+    const membershipChanged =
+      previous.length !== updated.length || updated.some((project) => !previous.some((prev) => compareBaseDirs(prev.baseDir, project.baseDir)));
+    if (membershipChanged || !compareBaseDirs(previousActiveDir ?? '', updatedActiveDir ?? '')) {
+      this.eventManager.sendExtensionUIRefresh({});
+    }
   }
 
   updateOpenProjectsOrder(baseDirs: string[]): ProjectData[] {

--- a/src/main/extensions/__tests__/extension-context.test.ts
+++ b/src/main/extensions/__tests__/extension-context.test.ts
@@ -357,6 +357,76 @@ describe('ExtensionContextImpl', () => {
     });
   });
 
+  describe('project scoping of UI data refreshes', () => {
+    const componentId = 'status-bar';
+    const project = { baseDir: '/test/project' } as any;
+
+    const createContextWithEventManager = (overlay?: { store?: Store; project?: Project }) => {
+      const mockEventManager = {
+        sendExtensionUIRefresh: vi.fn(),
+      };
+      const contextWithEventManager = new ExtensionContextImpl(
+        extensionId,
+        extensionName,
+        new DisposableStore(extensionName),
+        overlay?.store,
+        undefined,
+        mockEventManager as any,
+        undefined,
+        overlay?.project ?? (project as Project),
+      );
+      return { mockEventManager, contextWithEventManager };
+    };
+
+    it('scopes triggerUIDataRefresh to the context project when projectDir is omitted', () => {
+      const { mockEventManager, contextWithEventManager } = createContextWithEventManager();
+
+      contextWithEventManager.triggerUIDataRefresh(componentId);
+
+      expect(mockEventManager.sendExtensionUIRefresh).toHaveBeenCalledWith(expect.objectContaining({ projectDir: '/test/project' }));
+      expect(mockEventManager.sendExtensionUIRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('treats an explicitly undefined projectDir as a global refresh', () => {
+      const { mockEventManager, contextWithEventManager } = createContextWithEventManager();
+
+      contextWithEventManager.triggerUIDataRefresh(componentId, undefined, undefined);
+
+      expect(mockEventManager.sendExtensionUIRefresh).toHaveBeenCalledWith(expect.objectContaining({ projectDir: undefined }));
+      expect(mockEventManager.sendExtensionUIRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('always sends a global refresh from triggerGlobalUIDataRefresh', () => {
+      const { mockEventManager, contextWithEventManager } = createContextWithEventManager();
+
+      contextWithEventManager.triggerGlobalUIDataRefresh(componentId);
+
+      expect(mockEventManager.sendExtensionUIRefresh).toHaveBeenCalledWith(expect.objectContaining({ projectDir: undefined, componentId }));
+      expect(mockEventManager.sendExtensionUIRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('getActiveProjectDir returns the baseDir of the active project', () => {
+      const mockStore = {
+        getOpenProjects: vi.fn(() => [
+          { baseDir: '/project-a', active: false },
+          { baseDir: '/project-b', active: true },
+        ]),
+      } as unknown as Store;
+      const { contextWithEventManager } = createContextWithEventManager({ store: mockStore });
+
+      expect(contextWithEventManager.getActiveProjectDir()).toBe('/project-b');
+    });
+
+    it('getActiveProjectDir returns an empty string when no project is active', () => {
+      const mockStore = {
+        getOpenProjects: vi.fn(() => [{ baseDir: '/project-a', active: false }]),
+      } as unknown as Store;
+      const { contextWithEventManager } = createContextWithEventManager({ store: mockStore });
+
+      expect(contextWithEventManager.getActiveProjectDir()).toBe('');
+    });
+  });
+
   describe('triggerUIComponentsReload', () => {
     it('should call eventManager.sendExtensionUIRefresh with reloadComponents flag', () => {
       const mockEventManager = {

--- a/src/main/extensions/extension-context.ts
+++ b/src/main/extensions/extension-context.ts
@@ -67,6 +67,18 @@ export class ExtensionContextImpl implements ExtensionContext {
     }
   }
 
+  getActiveProjectDir(): string {
+    if (!this.store) {
+      return '';
+    }
+    try {
+      return this.store.getOpenProjects().find((project) => project.active)?.baseDir ?? '';
+    } catch (error) {
+      this.log(`Failed to get active project dir: ${error}`, 'error');
+      return '';
+    }
+  }
+
   getTaskContext(): TaskContext | null {
     return this.taskContext;
   }
@@ -151,18 +163,31 @@ export class ExtensionContextImpl implements ExtensionContext {
     }
   }
 
-  triggerUIDataRefresh(componentId?: string, taskId?: string): void {
+  private sendUIDataRefresh(projectDir: string | undefined, componentId?: string, taskId?: string, global = false): void {
     if (!this.eventManager) {
       this.log('EventManager not available, cannot trigger UI data refresh', 'warn');
       return;
     }
-    this.log(`Triggering UI data refresh for component: ${componentId}, task: ${taskId}`, 'debug');
+    if (global) {
+      this.log(`Triggering global UI data refresh for component: ${componentId}, task: ${taskId}`, 'debug');
+    } else {
+      this.log(`Triggering UI data refresh for component: ${componentId}, task: ${taskId}, project: ${projectDir}`, 'debug');
+    }
     this.eventManager.sendExtensionUIRefresh({
-      projectDir: this.project?.baseDir,
+      projectDir,
       extensionId: this.extensionId,
       componentId,
       taskId,
     });
+  }
+
+  triggerUIDataRefresh(componentId?: string, taskId?: string, projectDir?: string): void {
+    const effectiveProjectDir = arguments.length >= 3 ? projectDir : this.project?.baseDir;
+    this.sendUIDataRefresh(effectiveProjectDir, componentId, taskId);
+  }
+
+  triggerGlobalUIDataRefresh(componentId?: string, taskId?: string): void {
+    this.sendUIDataRefresh(undefined, componentId, taskId, true);
   }
 
   triggerUIComponentsReload(): void {

--- a/src/renderer/src/pages/Home.tsx
+++ b/src/renderer/src/pages/Home.tsx
@@ -112,6 +112,30 @@ export const Home = () => {
     void loadProjects();
   }, [api]);
 
+  // Mirrors the window's focused project tab to the backend (once per mount) so
+  // main-process state (e.g., active flags on open projects) matches the window's
+  // focus at startup — including deep links, whose URL project may differ from
+  // the store's active project; later tab switches are handled by setActiveProject.
+  // For a deep link to a project not yet open, setActiveProject may be a no-op in
+  // main — the deep-link flow adds the project and flips active on its own.
+  const mirroredProjectRef = useRef(false);
+  useEffect(() => {
+    if (!projectsLoaded || closingProjectRef.current) {
+      return;
+    }
+    const mirrorTarget = urlProjectBaseDir || storeActiveProject;
+    if (mirroredProjectRef.current || !mirrorTarget) {
+      return;
+    }
+    mirroredProjectRef.current = true;
+    // One-shot: on failure we don't reset the flag — state resyncs on the next
+    // explicit tab switch, which calls setActiveProject on its own
+    void api.setActiveProject(mirrorTarget).catch((error) => {
+      // eslint-disable-next-line no-console
+      console.error('Error mirroring active project:', error);
+    });
+  }, [api, projectsLoaded, urlProjectBaseDir, storeActiveProject]);
+
   useEffect(() => {
     const handleShowView = (viewId: string) => {
       if (viewId.startsWith('settings/')) {
@@ -160,12 +184,16 @@ export const Home = () => {
           const removedIndex = optimisticOpenProjects.findIndex((project) => project.baseDir === projectBaseDir);
           const remaining = optimisticOpenProjects.filter((project) => project.baseDir !== projectBaseDir);
 
+          let nextActiveBaseDir: string | undefined;
           // Only change selection if we're closing the currently active project
           if (compareBaseDirs(projectBaseDir, activeProject, os ?? undefined) && remaining.length > 0) {
             // Pick adjacent from remaining array (not original!) to avoid re-selecting the closed project
             const nextIndex = removedIndex >= remaining.length ? removedIndex - 1 : removedIndex;
             const nextProject = remaining[nextIndex];
-            setSearchParams({ [URL_PARAMS.PROJECT]: encodeBaseDir(nextProject.baseDir) }, { replace: true });
+            nextActiveBaseDir = nextProject?.baseDir;
+            if (nextActiveBaseDir) {
+              setSearchParams({ [URL_PARAMS.PROJECT]: encodeBaseDir(nextActiveBaseDir) }, { replace: true });
+            }
           } else if (remaining.length === 0) {
             setSearchParams({}, { replace: true });
           }
@@ -173,7 +201,21 @@ export const Home = () => {
 
           setOptimisticOpenProjects(remaining);
           const updatedProjects = await api.removeOpenProject(projectBaseDir);
-          setOpenProjects(updatedProjects);
+          if (nextActiveBaseDir) {
+            try {
+              setOpenProjects(await api.setActiveProject(nextActiveBaseDir));
+            } catch (error) {
+              // eslint-disable-next-line no-console
+              console.error('Error setting active project after close:', error);
+              setOpenProjects(updatedProjects);
+              // nextActiveBaseDir was already written to the URL above; revert to
+              // whichever project is actually active after the failed call.
+              const fallbackBaseDir = updatedProjects.find((p) => p.active)?.baseDir;
+              setSearchParams(fallbackBaseDir ? { [URL_PARAMS.PROJECT]: encodeBaseDir(fallbackBaseDir) } : {}, { replace: true });
+            }
+          } else {
+            setOpenProjects(updatedProjects);
+          }
         } finally {
           closingProjectRef.current = null;
         }

--- a/src/renderer/src/pages/__tests__/Home.test.tsx
+++ b/src/renderer/src/pages/__tests__/Home.test.tsx
@@ -262,12 +262,15 @@ describe('Home', () => {
   });
 
   describe('URL Navigation', () => {
-    it('activates existing project from URL', async () => {
+    it('mirrors the deep-linked open project to the backend even if another project is backend-active', async () => {
       const mockProjects = [
         { baseDir: '/project/existing', active: false },
         { baseDir: '/project/other', active: true },
       ] as ProjectData[];
       mockApi.getOpenProjects.mockResolvedValue(mockProjects);
+      mockApi.setActiveProject.mockImplementation((baseDir) => {
+        return Promise.resolve(mockProjects.map((p) => ({ ...p, active: p.baseDir === baseDir })));
+      });
 
       render(
         <MemoryRouter initialEntries={['/home?project=%2Fproject%2Fexisting']}>
@@ -288,9 +291,10 @@ describe('Home', () => {
         expect(screen.getAllByTestId('project-view').length).toBeGreaterThan(0);
       });
 
-      // setActiveProject should NOT be called for existing projects from URL
-      // (the URL parameter now drives the active state per-window)
-      expect(mockApi.setActiveProject).not.toHaveBeenCalled();
+      // The focused (deep-linked) project is mirrored to main exactly once,
+      // even though the store's backend-active project is a different one
+      expect(mockApi.setActiveProject).toHaveBeenCalledTimes(1);
+      expect(mockApi.setActiveProject).toHaveBeenCalledWith('/project/existing');
     });
 
     it('adds and activates new project from URL', async () => {
@@ -321,8 +325,13 @@ describe('Home', () => {
         expect(mockApi.addOpenProject).toHaveBeenCalledWith('/project/new');
       });
 
-      // setActiveProject should NOT be called - URL drives the active state
-      expect(mockApi.setActiveProject).not.toHaveBeenCalled();
+      // The one-shot mirror targets the deep-linked project; for a project not
+      // yet open, setActiveProject is a no-op in main until the deep-link flow
+      // adds the project and flips active
+      await waitFor(() => {
+        expect(mockApi.setActiveProject).toHaveBeenCalledTimes(1);
+      });
+      expect(mockApi.setActiveProject).toHaveBeenCalledWith('/project/new');
 
       // Project views should be rendered after projects are updated
       await waitFor(() => {
@@ -367,8 +376,10 @@ describe('Home', () => {
       // Wait a bit more to ensure no additional calls happen
       await new Promise((resolve) => setTimeout(resolve, 100));
 
-      // Should not call setActiveProject since the project is already active
-      expect(mockApi.setActiveProject).not.toHaveBeenCalled();
+      // The one-shot mirror calls setActiveProject exactly once (the URL project
+      // is the focused one) and never re-triggers
+      expect(mockApi.setActiveProject).toHaveBeenCalledTimes(1);
+      expect(mockApi.setActiveProject).toHaveBeenCalledWith('/project/existing');
     });
   });
 });


### PR DESCRIPTION
Adds `getActiveProjectDir` and `triggerGlobalUIDataRefresh` to the extension context so extensions can observe the focused project tab.

Active-project changes in the events handler broadcast a guarded, projectDir-less UI refresh, and `setActiveProject` ignores baseDirs that match no open project instead of clearing all active flags.

Home mirrors the focused tab to the main process on startup, tab switch, tab close, and deep-linked navigation; git-log preselects and marks the active project in its dropdown.
