### PR TITLE
feat(notifications): add notification contract and browser deduplication

### DIFF
--- a/packages/common/src/extensions.ts
+++ b/packages/common/src/extensions.ts
@@ -20,6 +20,7 @@ import {
   Model,
   ModelCallSettings,
   ModelCallTimeout,
+  NotificationData,
   OS,
   ProjectSettings,
   PromptContext,
@@ -545,6 +546,14 @@ export interface ResponseChunkEvent {
 
 export interface ResponseCompletedEvent {
   response: ResponseCompletedData;
+}
+
+/** Event payload for notification events (desktop/remote notification delivery) */
+export interface NotificationEvent {
+  /** The notification contract object delivered to windows, browser clients, and extensions */
+  notification: NotificationData;
+  /** Set blocked = true to prevent default notification delivery (Electron windows + browser clients) */
+  blocked?: boolean;
 }
 
 export interface HandleApprovalEvent {
@@ -2015,6 +2024,28 @@ export interface Extension {
    * @returns void or partial event to modify message
    */
   onResponseCompleted?(event: ResponseCompletedEvent, context: ExtensionContext): Promise<void | Partial<ResponseCompletedEvent>>;
+
+  // Notification Events
+
+  /**
+   * Called when a notification is about to be delivered to the user (desktop and remote browser clients)
+   * Dispatched by the task notification pipeline (Task.notifyIfEnabled); the low-level
+   * EventManager transport (sendNotification/sendNotificationData) does not dispatch extension hooks
+   * The hook fires REGARDLESS of the notificationsEnabled setting — only the built-in
+   * delivery (socket event + desktop notification) is gated by that setting, so sound/relay
+   * extensions can observe or self-deliver notifications even when built-in ones are off.
+   * Modify event.notification to change the title, body, or kind before delivery — returning
+   * a PARTIAL notification (e.g. only { title }) is safe: the returned fields are merged
+   * over the running notification, so unaffected fields such as baseDir/body are never dropped
+   * Set event.blocked = true to prevent default notification delivery
+   * (useful for extensions that handle notification delivery themselves, e.g., custom sound or relay forwarding)
+   * The dispatch is bounded (NOTIFICATION_HOOK_TIMEOUT_MS, 2s): a hung handler cannot
+   * suppress core delivery — the unmodified notification is delivered when it elapses.
+   * Delivery is serialized per project (FIFO in dispatch order); ordering across
+   * different projects is not guaranteed.
+   * @returns void or partial event to modify the notification
+   */
+  onNotification?(event: NotificationEvent, context: ExtensionContext): Promise<void | Partial<NotificationEvent>>;
 
   // Approval Events
 

--- a/packages/common/src/types/common.ts
+++ b/packages/common/src/types/common.ts
@@ -1205,10 +1205,28 @@ export interface BranchInfo {
   ahead?: number;
   behind?: number;
 }
+/**
+ * Machine-readable notification category.
+ * Producers map their events to a known kind so consumers (remote sound
+ * delivery, extensions) can route or select sounds without parsing text.
+ */
+export type NotificationKind = 'task-finished' | 'input-needed' | 'generic';
+
 export interface NotificationData {
   baseDir: string;
   title: string;
   body: string;
+  /**
+   * Stable unique notification ID used to deduplicate redeliveries across reconnects.
+   * Optional at the type level for third-party source compatibility — the delivery
+   * boundary (EventManager.sendNotificationData) always populates it before transport
+   * so the browser-side deduplication by `id` always sees a fully-formed contract.
+   */
+  id?: string;
+  /** Unix epoch (ms) when the notification was created. Always populated by the delivery boundary. */
+  timestamp?: number;
+  /** Machine-readable category for delivery/sound routing (defaults to 'generic' via the delivery boundary) */
+  kind?: NotificationKind;
 }
 
 export interface InstalledExtension {

--- a/resources/skills/extension-creator/references/event-types.md
+++ b/resources/skills/extension-creator/references/event-types.md
@@ -38,6 +38,7 @@ Every Extension interface method dispatches a specific event type. All handlers 
 | `onRuleFilesRetrieved` | `RuleFilesRetrievedEvent` | — |
 | `onResponseChunk` | `ResponseChunkEvent` | — |
 | `onResponseCompleted` | `ResponseCompletedEvent` | — |
+| `onNotification` | `NotificationEvent` | ✅ Yes |
 | `onHandleApproval` | `HandleApprovalEvent` | ✅ Yes |
 | `onSubagentStarted` | `SubagentStartedEvent` | ✅ Yes |
 | `onSubagentFinished` | `SubagentFinishedEvent` | — |
@@ -58,7 +59,7 @@ Events with a `blocked?: boolean` field allow extensions to **block** the operat
 
 | Capability | Events |
 |---|---|
-| **Can Block** (have `blocked?` field) | `PromptStartedEvent`, `AgentStartedEvent`, `InterruptedEvent`, `ToolApprovalEvent`, `ToolCalledEvent`, `HandleApprovalEvent`, `SubagentStartedEvent`, `CommandExecutedEvent`, `CustomCommandExecutedEvent`, `AiderPromptStartedEvent`, `BeforeCommitEvent`, `TaskDeletedEvent` |
+| **Can Block** (have `blocked?` field) | `PromptStartedEvent`, `AgentStartedEvent`, `InterruptedEvent`, `ToolApprovalEvent`, `ToolCalledEvent`, `HandleApprovalEvent`, `SubagentStartedEvent`, `CommandExecutedEvent`, `CustomCommandExecutedEvent`, `AiderPromptStartedEvent`, `BeforeCommitEvent`, `TaskDeletedEvent`, `NotificationEvent` |
 | **Read-Only** (all fields `readonly`) | `TaskInitializedEvent`, `TaskClosedEvent`, `ProjectStartedEvent`, `ProjectStoppedEvent`, `AfterCommitEvent` |
 
 ---
@@ -402,6 +403,52 @@ Dispatched when a response is completed.
 ```typescript
 interface ResponseCompletedEvent {
   response: ResponseCompletedData;
+}
+```
+
+---
+
+## Notification Events
+
+### NotificationEvent (Can Block)
+
+Dispatched when a notification is about to be delivered to the user (desktop and remote
+browser clients). Extensions can modify the title, body, or kind (e.g., `'task-finished'`,
+`'input-needed'`, `'generic'`) before delivery, or set `blocked: true` to prevent default
+delivery — useful for extensions that handle notification delivery themselves (custom
+sounds, relay forwarding).
+
+> **Dispatch point:** `onNotification` is dispatched by the task notification pipeline
+> (`Task.notifyIfEnabled`) before delivery. The low-level `EventManager` transport
+> (`sendNotification` / `sendNotificationData`) is a pure delivery layer and does **not**
+> dispatch extension hooks — it only carries the already-filtered notification.
+>
+> **Always observed:** the hook fires regardless of the `notificationsEnabled` setting —
+> only the **built-in** delivery (socket event + desktop notification) is gated by it, so
+> sound/relay extensions can observe or self-deliver notifications even when built-in
+> notifications are disabled. Returning `blocked: true` skips only default delivery.
+>
+> **Ordering:** per project, notifications are delivered FIFO in dispatch order; ordering
+> across different projects is not guaranteed.
+
+> **Bounded dispatch:** the hook is awaited for at most `NOTIFICATION_HOOK_TIMEOUT_MS`
+> (2 s, `src/main/task/task.ts`). A hung or slow hook cannot suppress core delivery —
+> when the deadline passes, the original (pre-dispatch) notification is delivered: the
+> hook receives a snapshot of the payload, so in-place mutations by a hung handler are
+> discarded. Handler errors are **isolated**: a hook that **throws** is logged and the
+> dispatch chain continues (remaining handlers still run), so default delivery
+> **proceeds** — throwing is not the same as blocking; only `blocked: true` (or a
+> dispatch-level failure, e.g. the extension system erroring before handlers run) skips
+> default delivery. Returning a partial `notification` object is safe: the returned fields
+> are merged over the running notification field-by-field (unaffected fields such as
+> `baseDir`/`body` are never dropped, explicit `undefined` values are ignored), and missing
+> `id`/`timestamp`/`kind` — including empty-string values — are filled in at the delivery
+> boundary (`EventManager.sendNotificationData`) before transport.
+
+```typescript
+interface NotificationEvent {
+  notification: NotificationData;
+  blocked?: boolean;
 }
 ```
 

--- a/resources/skills/extension-creator/references/event-types.md
+++ b/resources/skills/extension-creator/references/event-types.md
@@ -59,7 +59,7 @@ Events with a `blocked?: boolean` field allow extensions to **block** the operat
 
 | Capability | Events |
 |---|---|
-| **Can Block** (have `blocked?` field) | `PromptStartedEvent`, `AgentStartedEvent`, `InterruptedEvent`, `ToolApprovalEvent`, `ToolCalledEvent`, `HandleApprovalEvent`, `SubagentStartedEvent`, `CommandExecutedEvent`, `CustomCommandExecutedEvent`, `AiderPromptStartedEvent`, `BeforeCommitEvent`, `TaskDeletedEvent`, `NotificationEvent` |
+| **Can Block** (have `blocked?` field) | `PromptStartedEvent`, `AgentStartedEvent`, `InterruptedEvent`, `ToolApprovalEvent`, `HandleApprovalEvent`, `SubagentStartedEvent`, `CommandExecutedEvent`, `CustomCommandExecutedEvent`, `AiderPromptStartedEvent`, `BeforeCommitEvent`, `TaskDeletedEvent`, `NotificationEvent` |
 | **Read-Only** (all fields `readonly`) | `TaskInitializedEvent`, `TaskClosedEvent`, `ProjectStartedEvent`, `ProjectStoppedEvent`, `AfterCommitEvent` |
 
 ---

--- a/resources/skills/extension-creator/references/extension-interface.md
+++ b/resources/skills/extension-creator/references/extension-interface.md
@@ -216,6 +216,15 @@ interface Extension {
 }
 ```
 
+### Notification Events
+
+```typescript
+interface Extension {
+  /** Called when a notification is about to be delivered (desktop + remote browser clients). Dispatched by the task notification pipeline (Task.notifyIfEnabled) — the low-level EventManager transport does NOT dispatch extension hooks. The hook fires regardless of the `notificationsEnabled` setting (only built-in delivery is gated), so sound/relay extensions observe events even when native notifications are off. Modify `event.notification` (title, body, kind — a partial return is merged field-by-field and never drops unrelated fields) or set `event.blocked = true` to prevent default delivery — e.g., for custom sound or relay-forwarding extensions. The dispatch is bounded (2 s timeout): a hung handler cannot suppress core delivery (the original pre-dispatch payload is delivered on timeout, so in-place mutations by a hung handler are discarded), and a throwing handler is logged and isolated — the dispatch chain continues and default delivery still proceeds (only `blocked: true` or a dispatch-level failure skips it). Delivery is serialized per project (FIFO); ordering across projects is not guaranteed. */
+  onNotification?(event: NotificationEvent, context: ExtensionContext): Promise<void | Partial<NotificationEvent>>;
+}
+```
+
 ### Approval Events
 
 ```typescript

--- a/src/main/events/__tests__/event-manager.test.ts
+++ b/src/main/events/__tests__/event-manager.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { BrowserWindow } from 'electron';
-import { MessageRemovedData } from '@common/types';
+import { MessageRemovedData, NotificationData, NotificationKind } from '@common/types';
 
 import { EventManager } from '../event-manager';
 
@@ -79,5 +79,146 @@ describe('EventManager - sendTaskMessageRemoved', () => {
 
     // Should not throw
     expect(true).toBe(true);
+  });
+});
+
+describe('EventManager - sendNotification', () => {
+  let eventManager: EventManager;
+  let mockWebContents: { send: ReturnType<typeof vi.fn>; isDestroyed: ReturnType<typeof vi.fn> };
+  let mockWindowManager: WindowManager;
+
+  beforeEach(() => {
+    mockWebContents = {
+      send: vi.fn(),
+      isDestroyed: vi.fn(() => false),
+    };
+    mockWindowManager = {
+      getAllWindows: vi.fn(() => [{ webContents: mockWebContents, isDestroyed: () => false } as unknown as BrowserWindow]),
+      getMainWindow: vi.fn(() => null),
+      addWindow: vi.fn(),
+      removeWindow: vi.fn(),
+      isMainWindow: vi.fn(() => true),
+      getWindowCount: vi.fn(() => 1),
+    } as any;
+
+    eventManager = new EventManager(mockWindowManager);
+  });
+
+  it('enriches the notification with a stable id, timestamp, and kind', () => {
+    const returned = eventManager.sendNotification('/test/project', 'Task finished', 'all done');
+
+    const sent = mockWebContents.send.mock.calls.find(([type]) => type === 'notification')?.[1] as NotificationData;
+
+    expect(sent).toMatchObject({
+      baseDir: '/test/project',
+      title: 'Task finished',
+      body: 'all done',
+      kind: 'generic',
+    });
+    expect(returned.id).toBe(sent.id);
+    expect(sent.id).toBeTruthy();
+    expect(returned.timestamp).toBe(sent.timestamp);
+    expect(sent.timestamp).toBeLessThanOrEqual(Date.now());
+  });
+
+  it('propagates the provided notification kind', () => {
+    eventManager.sendNotification('/test/project', 'Waiting for your input', 'question?', 'input-needed');
+
+    const sent = mockWebContents.send.mock.calls.find(([type]) => type === 'notification')?.[1] as NotificationData;
+
+    expect(sent.kind).toBe('input-needed');
+  });
+
+  it('generates a unique id per notification', () => {
+    const first = eventManager.sendNotification('/test/project', 'a', 'b');
+    const second = eventManager.sendNotification('/test/project', 'a', 'b');
+
+    expect(first.id).not.toBe(second.id);
+    expect(mockWebContents.send).toHaveBeenCalledTimes(2);
+  });
+
+  it('sendNotificationData forwards the exact payload without regenerating metadata', () => {
+    const data: NotificationData = {
+      baseDir: '/test/project',
+      title: 'Custom',
+      body: 'from extension flow',
+      kind: 'task-finished',
+      id: 'fixed-id',
+      timestamp: 1234567890,
+    };
+
+    eventManager.sendNotificationData(data);
+
+    expect(mockWebContents.send).toHaveBeenCalledWith('notification', data);
+  });
+
+  it('sendNotificationData normalizes partial payloads: fills missing id/timestamp/kind (back-compat with id-less older-server payloads)', () => {
+    eventManager.sendNotificationData({ baseDir: '/test/project', title: 'Partial', body: 'no metadata' });
+
+    const sent = mockWebContents.send.mock.calls.find(([type]) => type === 'notification')?.[1] as NotificationData;
+
+    // Delivery-boundary normalization: the wire contract (and browser dedup keyed by id) needs metadata
+    expect(sent.id).toBeTruthy();
+    expect(sent.timestamp).toBeLessThanOrEqual(Date.now());
+    expect(sent.kind).toBe('generic');
+  });
+
+  it('sendNotificationData treats empty-string id and kind as absent (normalizes like missing metadata)', () => {
+    // '' is not a valid NotificationKind at the type level, but third-party/older payloads
+    // can carry it at runtime — the delivery boundary must normalize it anyway
+    const blankKind = '' as unknown as NotificationKind;
+    eventManager.sendNotificationData({ baseDir: '/test/project', title: 'Blank metadata', body: 'b', id: '', kind: blankKind });
+
+    const sent = mockWebContents.send.mock.calls.find(([type]) => type === 'notification')?.[1] as NotificationData;
+
+    // A blank id cannot serve as the dedup key and a blank kind is not a valid kind
+    expect(sent.id).toBeTruthy();
+    expect(sent.id).not.toBe('');
+    expect(sent.kind).toBe('generic');
+  });
+
+  it('sendNotificationData assigns distinct normalized ids to empty-string-id payloads (dedup-safe)', () => {
+    eventManager.sendNotificationData({ baseDir: '/test/project', title: 'a', body: 'b', id: '' });
+    eventManager.sendNotificationData({ baseDir: '/test/project', title: 'a', body: 'b', id: '' });
+
+    const ids = mockWebContents.send.mock.calls.filter(([type]) => type === 'notification').map(([, data]) => (data as NotificationData).id);
+
+    expect(ids).toHaveLength(2);
+    expect(ids[0]).not.toBe(ids[1]);
+  });
+
+  it('sendNotificationData assigns distinct normalized ids to distinct partial payloads (dedup-safe)', () => {
+    eventManager.sendNotificationData({ baseDir: '/test/project', title: 'a', body: 'b' });
+    eventManager.sendNotificationData({ baseDir: '/test/project', title: 'a', body: 'b' });
+
+    const ids = mockWebContents.send.mock.calls.filter(([type]) => type === 'notification').map(([, data]) => (data as NotificationData).id);
+
+    expect(ids).toHaveLength(2);
+    expect(ids[0]).toBeTruthy();
+    expect(ids[0]).not.toBe(ids[1]);
+  });
+
+  it('is a transport-only convenience: delivery is synchronous and equivalent to sendNotificationData (onNotification hook is dispatched by Task.notifyIfEnabled, not here)', () => {
+    // Documented contract (see EventManager.sendNotification JSDoc and
+    // resources/skills/extension-creator/references/event-types.md): the EventManager is a
+    // pure transport layer. It must deliver synchronously with the same wire payload as the
+    // low-level sendNotificationData primitive, so hooks can never double-fire or block
+    // only one of the two paths.
+    const returned = eventManager.sendNotification('/test/project', 'title', 'body');
+
+    const manual: NotificationData = {
+      baseDir: '/test/project',
+      title: 'title',
+      body: 'body',
+      kind: 'generic',
+      id: returned.id,
+      timestamp: returned.timestamp,
+    };
+    eventManager.sendNotificationData(manual);
+
+    const notificationCalls = mockWebContents.send.mock.calls.filter(([type]) => type === 'notification');
+    expect(notificationCalls).toHaveLength(2);
+    // Same wire payload shape as the low-level primitive, delivered in the same synchronous turn
+    expect(notificationCalls[1][1]).toEqual(manual);
   });
 });

--- a/src/main/events/event-manager.ts
+++ b/src/main/events/event-manager.ts
@@ -30,6 +30,7 @@ import {
   AgentProfile,
   AgentProfilesUpdatedData,
   McpServersData,
+  NotificationKind,
   WorktreeIntegrationStatus,
   WorktreeIntegrationStatusUpdatedData,
   TaskCreatedData,
@@ -44,6 +45,7 @@ import {
   ModalOverlayUrlData,
   ContextInfoData,
 } from '@common/types';
+import { v4 as uuidv4 } from 'uuid';
 
 import type { WindowManager } from '@/window-manager';
 
@@ -387,14 +389,47 @@ export class EventManager {
     this.broadcastToEventConnectors('message-removed', data);
   }
 
-  sendNotification(baseDir: string, title: string, body: string): void {
+  /**
+   * Convenience that enriches the notification contract (id, timestamp, kind) and
+   * delivers it immediately to windows and event connectors.
+   *
+   * NOTE: The EventManager is a pure transport layer and does NOT dispatch the
+   * `onNotification` extension hook (it has no Project/Task context for the
+   * extension dispatch). The hook is dispatched by the high-level task notification
+   * pipeline — `Task.notifyIfEnabled` — before it hands the (potentially
+   * extension-modified or blocked) notification to `sendNotificationData`.
+   * Never use this method as a second delivery hop after the hook.
+   */
+  sendNotification(baseDir: string, title: string, body: string, kind: NotificationKind = 'generic'): NotificationData {
     const data: NotificationData = {
+      baseDir,
       title,
       body,
-      baseDir,
+      kind,
+      id: uuidv4(),
+      timestamp: Date.now(),
     };
-    this.sendToWindows('notification', data);
-    this.broadcastToEventConnectors('notification', data);
+    this.sendNotificationData(data);
+    return data;
+  }
+
+  /**
+   * Low-level delivery primitive: does NOT dispatch extension hooks (see sendNotification).
+   * Normalizes partial payloads at the delivery boundary: `NotificationData.id`, `timestamp`,
+   * and `kind` are optional at the type level (third-party source compatibility), but the
+   * wire contract — and the browser-side deduplication keyed by `id` — requires them, so
+   * missing or empty-string values are filled in here. Provided non-empty values are never
+   * regenerated.
+   */
+  sendNotificationData(data: NotificationData): void {
+    const normalized: NotificationData = {
+      ...data,
+      id: data.id || uuidv4(),
+      timestamp: data.timestamp ?? Date.now(),
+      kind: data.kind || 'generic',
+    };
+    this.sendToWindows('notification', normalized);
+    this.broadcastToEventConnectors('notification', normalized);
   }
 
   subscribe(socket: Socket, config: EventsConnectorConfig): void {

--- a/src/main/extensions/__tests__/extension-manager.test.ts
+++ b/src/main/extensions/__tests__/extension-manager.test.ts
@@ -10,6 +10,7 @@ import type { Store } from '@/store';
 import type { ModelManager } from '@/models';
 import type { EventManager } from '@/events';
 import type { FSWatcher } from 'chokidar';
+import type { NotificationEvent } from '@common/extensions';
 
 import { TelemetryManager } from '@/telemetry';
 import logger from '@/logger';
@@ -1028,6 +1029,154 @@ describe('ExtensionManager', () => {
       expect(handler1).toHaveBeenCalled();
       expect(handler2).toHaveBeenCalled();
       expect(result.prompt).toBe('modified');
+      expect(result.blocked).toBeUndefined();
+    });
+
+    it('should isolate a throwing onNotification handler and return the event unblocked so delivery proceeds', async () => {
+      const throwingHandler = vi.fn().mockRejectedValue(new Error('hook blew up'));
+      const passingHandler = vi.fn().mockImplementation(async (event: NotificationEvent) => {
+        // Extensions modify the event's notification in place (per the documented contract)
+        event.notification.title = 'Modified notification';
+      });
+
+      const ext1 = {
+        instance: { onNotification: throwingHandler },
+        metadata: { name: 'ext1', version: '1.0.0', description: 'Test', author: 'Test' },
+        filePath: '/path/ext1.ts',
+        initialized: true,
+      };
+
+      const ext2 = {
+        instance: { onNotification: passingHandler },
+        metadata: { name: 'ext2', version: '1.0.0', description: 'Test', author: 'Test' },
+        filePath: '/path/ext2.ts',
+        initialized: true,
+      };
+
+      (mockRegistry as ExtensionRegistry).getExtensions = vi.fn().mockReturnValue([ext1, ext2]);
+
+      const event = { notification: { baseDir: '/test/project', title: 'Task finished', body: 'all done' } };
+      const result = await manager.dispatchEvent('onNotification', event, mockProject as any, mockTask as any);
+
+      // The throwing handler is logged and skipped; the chain continues and the event
+      // is delivered (not blocked) — a throwing hook never suppresses notification delivery.
+      expect(throwingHandler).toHaveBeenCalled();
+      expect(passingHandler).toHaveBeenCalled();
+      expect(result.notification).toEqual({ baseDir: '/test/project', title: 'Modified notification', body: 'all done' });
+      expect(result.blocked).toBeUndefined();
+      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("Error in 'onNotification' handler"), expect.any(Error));
+    });
+
+    it('merges a PARTIAL notification returned by onNotification field-by-field instead of dropping unrelated fields', async () => {
+      const partialHandler = vi.fn().mockImplementation(async () => ({
+        // Extension returns only the field(s) it wants to change
+        notification: { title: 'Renamed by extension' } as NotificationEvent['notification'],
+      }));
+
+      const ext1 = {
+        instance: { onNotification: partialHandler },
+        metadata: { name: 'ext1', version: '1.0.0', description: 'Test', author: 'Test' },
+        filePath: '/path/ext1.ts',
+        initialized: true,
+      };
+
+      (mockRegistry as ExtensionRegistry).getExtensions = vi.fn().mockReturnValue([ext1]);
+
+      const event = {
+        notification: {
+          baseDir: '/test/project',
+          title: 'Task finished',
+          body: 'all done',
+          kind: 'task-finished' as const,
+          id: 'fixed-id',
+          timestamp: 123,
+        },
+      };
+      const result = await manager.dispatchEvent('onNotification', event, mockProject as any, mockTask as any);
+
+      // Updated field wins; unaffected fields (baseDir/body/kind/id/timestamp) survive
+      expect(result.notification).toEqual({
+        baseDir: '/test/project',
+        title: 'Renamed by extension',
+        body: 'all done',
+        kind: 'task-finished',
+        id: 'fixed-id',
+        timestamp: 123,
+      });
+      expect(result.blocked).toBeUndefined();
+    });
+
+    it("merges a partial onNotification result over the previous handlers' edits when chained", async () => {
+      const firstHandler = vi.fn().mockImplementation(async (event: NotificationEvent) => ({
+        notification: { ...event.notification, title: 'Set by first', body: 'Body by first' },
+      }));
+      const secondHandler = vi.fn().mockImplementation(async () => ({ notification: { title: 'Set by second' } }));
+
+      const ext1 = {
+        instance: { onNotification: firstHandler },
+        metadata: { name: 'ext1', version: '1.0.0', description: 'Test', author: 'Test' },
+        filePath: '/path/ext1.ts',
+        initialized: true,
+      };
+      const ext2 = {
+        instance: { onNotification: secondHandler },
+        metadata: { name: 'ext2', version: '1.0.0', description: 'Test', author: 'Test' },
+        filePath: '/path/ext2.ts',
+        initialized: true,
+      };
+
+      (mockRegistry as ExtensionRegistry).getExtensions = vi.fn().mockReturnValue([ext1, ext2]);
+
+      const event = { notification: { baseDir: '/test/project', title: 'Task finished', body: 'all done' } };
+      const result = await manager.dispatchEvent('onNotification', event, mockProject as any, mockTask as any);
+
+      // Second handler's partial is merged over the first handler's complete edit,
+      // not over the original payload
+      expect(result.notification.title).toBe('Set by second');
+      expect(result.notification.body).toBe('Body by first');
+      expect(result.notification.baseDir).toBe('/test/project');
+    });
+
+    it('does not let undefined-valued fields in a returned partial notification clobber existing values', async () => {
+      const partialHandler = vi.fn().mockImplementation(async () => ({
+        notification: { title: 'Renamed by extension', body: undefined },
+      }));
+
+      const ext1 = {
+        instance: { onNotification: partialHandler },
+        metadata: { name: 'ext1', version: '1.0.0', description: 'Test', author: 'Test' },
+        filePath: '/path/ext1.ts',
+        initialized: true,
+      };
+
+      (mockRegistry as ExtensionRegistry).getExtensions = vi.fn().mockReturnValue([ext1]);
+
+      const event = { notification: { baseDir: '/test/project', title: 'Task finished', body: 'all done' } };
+      const result = await manager.dispatchEvent('onNotification', event, mockProject as any, mockTask as any);
+
+      expect(result.notification.title).toBe('Renamed by extension');
+      expect(result.notification.body).toBe('all done');
+    });
+
+    it('still replaces the notification wholesale when a handler returns a complete notification object', async () => {
+      const replaceHandler = vi.fn().mockImplementation(async (event: NotificationEvent) => ({
+        notification: { ...event.notification, title: 'Full replacement' },
+      }));
+
+      const ext1 = {
+        instance: { onNotification: replaceHandler },
+        metadata: { name: 'ext1', version: '1.0.0', description: 'Test', author: 'Test' },
+        filePath: '/path/ext1.ts',
+        initialized: true,
+      };
+
+      (mockRegistry as ExtensionRegistry).getExtensions = vi.fn().mockReturnValue([ext1]);
+
+      const event = { notification: { baseDir: '/test/project', title: 'Task finished', body: 'all done' } };
+      const result = await manager.dispatchEvent('onNotification', event, mockProject as any, mockTask as any);
+
+      expect(result.notification.title).toBe('Full replacement');
+      expect(result.notification.body).toBe('all done');
       expect(result.blocked).toBeUndefined();
     });
 

--- a/src/main/extensions/extension-manager.ts
+++ b/src/main/extensions/extension-manager.ts
@@ -45,6 +45,7 @@ import type {
   ImportantRemindersEvent,
   InterruptedEvent,
   ModeDefinition,
+  NotificationEvent,
   OptimizeMessagesEvent,
   ProjectStartedEvent,
   ProjectStoppedEvent,
@@ -157,6 +158,7 @@ export type ExtensionEventMap = {
   onRuleFilesRetrieved: RuleFilesRetrievedEvent;
   onResponseChunk: ResponseChunkEvent;
   onResponseCompleted: ResponseCompletedEvent;
+  onNotification: NotificationEvent;
   onHandleApproval: HandleApprovalEvent;
   onSubagentStarted: SubagentStartedEvent;
   onSubagentFinished: SubagentFinishedEvent;
@@ -2329,7 +2331,26 @@ export class ExtensionManager {
         if (result && typeof result === 'object') {
           // Merge partial event modifications
           const partialEvent = result as Partial<ExtensionEventMap[K]>;
-          currentEvent = { ...currentEvent, ...partialEvent };
+          if (eventName === 'onNotification') {
+            // Field-level merge for notifications: an extension may return a PARTIAL
+            // notification (e.g. only { title }) to update a single field. Spreading it
+            // wholesale over the previous event would drop unaffected fields such as
+            // baseDir/body — merge the defined fields of the returned partial over the
+            // running notification instead (also preserves earlier handlers' edits).
+            const currentNotification = (currentEvent as unknown as NotificationEvent).notification;
+            const returnedNotification = (partialEvent as unknown as Partial<NotificationEvent>).notification;
+            if (returnedNotification && currentNotification) {
+              const mergedNotification = {
+                ...currentNotification,
+                ...Object.fromEntries(Object.entries(returnedNotification).filter(([, value]) => value !== undefined)),
+              };
+              currentEvent = { ...currentEvent, notification: mergedNotification } as unknown as ExtensionEventMap[K];
+            } else {
+              currentEvent = { ...currentEvent, ...partialEvent };
+            }
+          } else {
+            currentEvent = { ...currentEvent, ...partialEvent };
+          }
 
           // Check for blocking
           if ('blocked' in currentEvent && currentEvent.blocked) {

--- a/src/main/task/__tests__/task.notifyIfEnabled.test.ts
+++ b/src/main/task/__tests__/task.notifyIfEnabled.test.ts
@@ -1,0 +1,470 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { NOTIFICATION_HOOK_TIMEOUT_MS, Task } from '../task';
+
+import type { NotificationData } from '@common/types';
+
+import logger from '@/logger';
+
+vi.mock('@/logger', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('fs/promises', () => ({
+  default: {
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    readFile: vi.fn().mockResolvedValue('{}'),
+    stat: vi.fn().mockRejectedValue(new Error('File not found')),
+    readdir: vi.fn().mockResolvedValue([]),
+    rm: vi.fn().mockResolvedValue(undefined),
+  },
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  readFile: vi.fn().mockResolvedValue('{}'),
+  stat: vi.fn().mockRejectedValue(new Error('File not found')),
+  readdir: vi.fn().mockResolvedValue([]),
+  rm: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/utils', () => ({
+  fileExists: vi.fn().mockResolvedValue(false),
+  filterIgnoredFiles: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('@/constants', () => ({
+  PROBE_BINARY_PATH: '/probe',
+  AIDER_DESK_TASKS_DIR: '.aider-desk/tasks',
+  AIDER_DESK_DIR: '.aider-desk',
+  AIDER_DESK_TODOS_FILE: 'todos.json',
+  AIDER_DESK_RULES_DIR: 'rules',
+  AIDER_DESK_PROJECT_RULES_DIR: '.aider-desk/rules',
+  AIDER_DESK_GLOBAL_RULES_DIR: '/home/.aider-desk/rules',
+  AIDER_DESK_COMMANDS_DIR: '.aider-desk/commands',
+  AIDER_DESK_PROMPTS_DIR: '.aider-desk/prompts',
+  AIDER_DESK_BUILTIN_PROMPTS_DIR: '/resources/prompts',
+  AIDER_DESK_GLOBAL_PROMPTS_DIR: '/home/.aider-desk/prompts',
+  AIDER_DESK_AGENTS_DIR: '.aider-desk/agents',
+  AIDER_DESK_TMP_DIR: '.aider-desk/tmp',
+  AIDER_DESK_WATCH_FILES_LOCK: '.aider-desk/watch-files.lock',
+  WORKTREE_BRANCH_PREFIX: 'aider-desk/task/',
+  AIDER_DESK_MEMORY_FILE: '/data/memory.db',
+  LOGS_DIR: '/logs',
+}));
+
+vi.mock('@/agent', () => ({
+  Agent: class {
+    run = vi.fn();
+    dispose = vi.fn();
+  },
+  McpManager: class {},
+  AgentProfileManager: class {},
+}));
+
+vi.mock('@/task/aider-manager', () => ({
+  AiderManager: class {
+    start = vi.fn();
+    stop = vi.fn();
+    dispose = vi.fn();
+    sendUpdateAiderModels = vi.fn();
+  },
+}));
+
+vi.mock('@/prompts', () => ({
+  PromptsManager: class {},
+}));
+
+vi.mock('@/data-manager', () => ({
+  DataManager: class {},
+}));
+
+vi.mock('@/telemetry', () => ({
+  TelemetryManager: class {},
+}));
+
+vi.mock('@/models', () => ({
+  ModelManager: class {},
+}));
+
+vi.mock('@/memory/memory-manager', () => ({
+  MemoryManager: class {},
+}));
+
+vi.mock('@/worktrees', () => ({
+  WorktreeManager: class {},
+}));
+
+vi.mock('@/custom-commands', () => ({
+  CustomCommandManager: class {},
+}));
+
+vi.mock('@/skills/skill-manager', () => ({
+  SkillManager: class {
+    getSkills = vi.fn().mockResolvedValue([]);
+  },
+}));
+
+vi.mock('@/store', () => ({
+  Store: class {},
+}));
+
+// Avoid touching Electron from the notification pipeline under test
+vi.mock('@/app', () => ({
+  getElectronApp: vi.fn(() => undefined),
+}));
+
+describe('Task - notifyIfEnabled', () => {
+  const baseDir = '/test/project';
+  const taskId = 'test-task-id';
+
+  let mockStore: { getSettings: ReturnType<typeof vi.fn> };
+  let mockEventManager: { sendNotificationData: ReturnType<typeof vi.fn> };
+  let mockExtensionManager: { isInitialized: ReturnType<typeof vi.fn>; dispatchEvent: ReturnType<typeof vi.fn> };
+
+  // Bound to the instance created by createTask()
+  let notifyIfEnabled: (title: string, text: string, kind?: 'task-finished' | 'input-needed' | 'generic') => Promise<void>;
+
+  const createTask = () => {
+    const mockProject = {
+      baseDir,
+      getProjectSettings: vi.fn(() => ({
+        mainModel: 'default-model',
+        agentProfileId: 'default-profile',
+        modelEditFormats: {},
+        currentMode: 'agent',
+        autonomyModeLocked: false,
+      })),
+      isWorktreeSharedWithOtherTasks: vi.fn(() => false),
+    };
+
+    mockEventManager.sendNotificationData = vi.fn();
+
+    const task = new Task(
+      mockProject as any,
+      taskId,
+      mockStore as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      mockEventManager as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      mockExtensionManager as any,
+      {} as any,
+    );
+
+    notifyIfEnabled = (title, text, kind) => (task as any).notifyIfEnabled(title, text, kind);
+    return task;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockStore = {
+      getSettings: vi.fn(() => ({ notificationsEnabled: true })),
+    };
+    mockEventManager = { sendNotificationData: vi.fn() };
+    mockExtensionManager = {
+      isInitialized: vi.fn(() => false),
+      dispatchEvent: vi.fn().mockImplementation((_event: string, payload: unknown) => Promise.resolve(payload)),
+    };
+
+    createTask();
+  });
+
+  it('dispatches the onNotification extension hook and delivers the notification', async () => {
+    await notifyIfEnabled('Task finished', 'all done', 'task-finished');
+
+    expect(mockExtensionManager.dispatchEvent).toHaveBeenCalledWith(
+      'onNotification',
+      expect.objectContaining({ notification: expect.objectContaining({ baseDir, title: 'Task finished', kind: 'task-finished' }) }),
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(mockEventManager.sendNotificationData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseDir,
+        title: 'Task finished',
+        body: 'all done',
+        kind: 'task-finished',
+        id: expect.any(String),
+        timestamp: expect.any(Number),
+      }),
+    );
+  });
+
+  it('does not deliver when an extension blocks the notification', async () => {
+    mockExtensionManager.dispatchEvent.mockImplementation(() => Promise.resolve({ blocked: true }));
+
+    await notifyIfEnabled('Task finished', 'all done');
+
+    expect(mockEventManager.sendNotificationData).not.toHaveBeenCalled();
+  });
+
+  it('delivers the extension-modified notification', async () => {
+    mockExtensionManager.dispatchEvent.mockImplementation((_event: string, payload: { notification: NotificationData } & { blocked?: boolean }) =>
+      Promise.resolve({ ...payload, notification: { ...payload.notification, title: 'Modified title' } }),
+    );
+
+    await notifyIfEnabled('Task finished', 'all done');
+
+    expect(mockEventManager.sendNotificationData).toHaveBeenCalledWith(expect.objectContaining({ title: 'Modified title' }));
+  });
+
+  it('preserves the original notification when an extension result has notification: undefined and blocked: false', async () => {
+    mockExtensionManager.dispatchEvent.mockImplementation(() => Promise.resolve({ notification: undefined, blocked: false }));
+
+    await notifyIfEnabled('Task finished', 'all done');
+
+    // The original id/title payload built by notifyIfEnabled must survive the extension pass
+    expect(mockEventManager.sendNotificationData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseDir,
+        title: 'Task finished',
+        body: 'all done',
+        id: expect.any(String),
+        timestamp: expect.any(Number),
+      }),
+    );
+    const delivered = mockEventManager.sendNotificationData.mock.calls[0][0] as NotificationData;
+    expect(delivered.id).toBeTruthy();
+  });
+
+  // Extension observation is decoupled from the notificationsEnabled setting: the hook
+  // always fires, only the built-in (transport + Electron) delivery is gated by it.
+  it('still dispatches the hook when notifications are disabled, but skips core delivery', async () => {
+    mockStore.getSettings = vi.fn(() => ({ notificationsEnabled: false }));
+
+    await notifyIfEnabled('Task finished', 'all done', 'task-finished');
+
+    // Sound/relay extensions must be able to observe (or self-deliver) even when the
+    // user disabled built-in notifications
+    expect(mockExtensionManager.dispatchEvent).toHaveBeenCalledWith(
+      'onNotification',
+      expect.objectContaining({ notification: expect.objectContaining({ title: 'Task finished', kind: 'task-finished' }) }),
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(mockEventManager.sendNotificationData).not.toHaveBeenCalled();
+  });
+
+  it('does not deliver an extension-modified notification when notifications are disabled', async () => {
+    mockStore.getSettings = vi.fn(() => ({ notificationsEnabled: false }));
+    mockExtensionManager.dispatchEvent.mockImplementation((_event: string, payload: { notification: NotificationData }) =>
+      Promise.resolve({ ...payload, notification: { ...payload.notification, title: 'Modified title' } }),
+    );
+
+    await notifyIfEnabled('Task finished', 'all done');
+
+    expect(mockExtensionManager.dispatchEvent).toHaveBeenCalled();
+    expect(mockEventManager.sendNotificationData).not.toHaveBeenCalled();
+  });
+
+  it('preserves original baseDir/body when an extension returns a partial notification', async () => {
+    mockExtensionManager.dispatchEvent.mockImplementation(() => Promise.resolve({ notification: { title: 'Only title changed' } }));
+
+    await notifyIfEnabled('Task finished', 'all done', 'task-finished');
+
+    expect(mockEventManager.sendNotificationData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseDir,
+        title: 'Only title changed',
+        body: 'all done',
+        kind: 'task-finished',
+        id: expect.any(String),
+        timestamp: expect.any(Number),
+      }),
+    );
+    const delivered = mockEventManager.sendNotificationData.mock.calls[0][0] as NotificationData;
+    expect(delivered.id).toBeTruthy();
+  });
+
+  it('ignores undefined-valued fields in a returned notification instead of clobbering the original', async () => {
+    mockExtensionManager.dispatchEvent.mockImplementation(() =>
+      Promise.resolve({ notification: { title: 'New title', body: undefined } as unknown as NotificationData }),
+    );
+
+    await notifyIfEnabled('Task finished', 'all done');
+
+    const delivered = mockEventManager.sendNotificationData.mock.calls[0][0] as NotificationData;
+    expect(delivered.title).toBe('New title');
+    expect(delivered.body).toBe('all done');
+  });
+
+  describe('per-project delivery ordering', () => {
+    it('delivers concurrent notifications for the same project FIFO', async () => {
+      let releaseFirst: (() => void) | undefined;
+      const firstGate = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      // First notification's hook stalls until released; second must still queue behind it
+      mockExtensionManager.dispatchEvent.mockImplementationOnce(() => firstGate.then(() => ({ blocked: false })));
+
+      const first = notifyIfEnabled('first', 'one');
+      const second = notifyIfEnabled('second', 'two');
+
+      // Let the queue start the first delivery and stall on its gate
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      expect(mockEventManager.sendNotificationData).not.toHaveBeenCalled();
+
+      releaseFirst?.();
+      await Promise.all([first, second]);
+
+      const titles = mockEventManager.sendNotificationData.mock.calls.map((call) => (call[0] as NotificationData).title);
+      expect(titles).toEqual(['first', 'second']);
+    });
+
+    it('a failed delivery does not stall subsequent notifications for the same project', async () => {
+      // First delivery fails at the dispatch level; second must still deliver
+      mockExtensionManager.dispatchEvent.mockImplementationOnce(() => Promise.reject(new Error('hook blew up')));
+
+      const first = notifyIfEnabled('first', 'one');
+      const second = notifyIfEnabled('second', 'two');
+
+      await Promise.all([first, second]);
+
+      const titles = mockEventManager.sendNotificationData.mock.calls.map((call) => (call[0] as NotificationData).title);
+      expect(titles).toEqual(['second']);
+      expect(logger.error).toHaveBeenCalled();
+    });
+  });
+
+  // Fire-and-forget call sites use `void this.notifyIfEnabled(...)` — every failure below
+  // must resolve (never reject / become an unhandledRejection).
+  describe('fire-and-forget safety: errors never reject', () => {
+    it('resolves when settings access throws', async () => {
+      mockStore.getSettings = vi.fn(() => {
+        throw new Error('settings blew up');
+      });
+
+      await expect(notifyIfEnabled('Task finished', 'all done')).resolves.toBeUndefined();
+      expect(mockEventManager.sendNotificationData).not.toHaveBeenCalled();
+    });
+
+    it('resolves when transporting via sendNotificationData throws', async () => {
+      mockEventManager.sendNotificationData = vi.fn(() => {
+        throw new Error('transport blew up');
+      });
+
+      await expect(notifyIfEnabled('Task finished', 'all done')).resolves.toBeUndefined();
+      expect(mockExtensionManager.dispatchEvent).toHaveBeenCalled();
+    });
+
+    it('resolves when the extension hook dispatch throws', async () => {
+      mockExtensionManager.dispatchEvent = vi.fn(() => Promise.reject(new Error('extension hook blew up')));
+
+      await expect(notifyIfEnabled('Task finished', 'all done')).resolves.toBeUndefined();
+      expect(mockEventManager.sendNotificationData).not.toHaveBeenCalled();
+    });
+  });
+
+  // A hung onNotification extension must never suppress core delivery indefinitely.
+  // Core delivery proceeds with the unmodified notification after NOTIFICATION_HOOK_TIMEOUT_MS.
+  describe('hook dispatch timeout', () => {
+    it('delivers the unmodified notification when the hook never settles', async () => {
+      vi.useFakeTimers();
+      try {
+        mockExtensionManager.dispatchEvent.mockImplementation(() => new Promise(() => {}));
+
+        const delivery = notifyIfEnabled('Task finished', 'all done');
+        await vi.advanceTimersByTimeAsync(NOTIFICATION_HOOK_TIMEOUT_MS);
+        await expect(delivery).resolves.toBeUndefined();
+
+        expect(mockEventManager.sendNotificationData).toHaveBeenCalledWith(expect.objectContaining({ title: 'Task finished', body: 'all done' }));
+        expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('did not settle in time'), expect.objectContaining({ title: 'Task finished' }));
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('delivers the pristine original when a hanging hook mutates the notification in place', async () => {
+      vi.useFakeTimers();
+      try {
+        mockExtensionManager.dispatchEvent.mockImplementation((_event: string, payload: { notification: NotificationData } & { blocked?: boolean }) => {
+          // Corrupt the shared payload BEFORE hanging: the timeout fallback must deliver
+          // the snapshot, not the mutated in-place object
+          payload.notification.title = 'MUTATED';
+          payload.notification.body = 'MUTATED';
+          return new Promise(() => {});
+        });
+
+        const delivery = notifyIfEnabled('Task finished', 'all done');
+        await vi.advanceTimersByTimeAsync(NOTIFICATION_HOOK_TIMEOUT_MS);
+        await expect(delivery).resolves.toBeUndefined();
+
+        const delivered = mockEventManager.sendNotificationData.mock.calls[0][0] as NotificationData;
+        expect(delivered.title).toBe('Task finished');
+        expect(delivered.body).toBe('all done');
+        expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('did not settle in time'), expect.objectContaining({ title: 'Task finished' }));
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('ignores a hook result that arrives after the timeout (no duplicate delivery once it settles)', async () => {
+      vi.useFakeTimers();
+      try {
+        let resolveLateHook: (value: unknown) => void = () => {};
+        mockExtensionManager.dispatchEvent.mockImplementation(
+          () =>
+            new Promise((resolve) => {
+              resolveLateHook = resolve;
+            }),
+        );
+
+        const delivery = notifyIfEnabled('Task finished', 'all done');
+        await vi.advanceTimersByTimeAsync(NOTIFICATION_HOOK_TIMEOUT_MS);
+        await delivery;
+        expect(mockEventManager.sendNotificationData).toHaveBeenCalledTimes(1);
+
+        // Late hook settlement (blocked: true) must not retroactively suppress delivery
+        resolveLateHook({ blocked: true });
+        await Promise.resolve();
+
+        expect(mockEventManager.sendNotificationData).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not surface an unhandled rejection when the raced hook rejects after the timeout', async () => {
+      vi.useFakeTimers();
+      const unhandled: unknown[] = [];
+      const unhandledRejectionListener = (reason: unknown) => unhandled.push(reason);
+      process.on('unhandledRejection', unhandledRejectionListener);
+      try {
+        let rejectLateHook: (error: Error) => void = () => {};
+        mockExtensionManager.dispatchEvent.mockImplementation(
+          () =>
+            new Promise((_resolve, reject) => {
+              rejectLateHook = reject;
+            }),
+        );
+
+        const delivery = notifyIfEnabled('Task finished', 'all done');
+        await vi.advanceTimersByTimeAsync(NOTIFICATION_HOOK_TIMEOUT_MS);
+        await delivery;
+        expect(mockEventManager.sendNotificationData).toHaveBeenCalledTimes(1);
+
+        rejectLateHook(new Error('hook blew up after delivery'));
+        await vi.advanceTimersByTimeAsync(0);
+        await Promise.resolve();
+
+        expect(unhandled).toHaveLength(0);
+      } finally {
+        process.off('unhandledRejection', unhandledRejectionListener);
+        vi.useRealTimers();
+      }
+    });
+  });
+});

--- a/src/main/task/task.ts
+++ b/src/main/task/task.ts
@@ -27,6 +27,8 @@ import {
   Mode,
   ModelInfo,
   ModelsData,
+  NotificationData,
+  NotificationKind,
   ProjectSettings,
   PromptContext,
   QuestionData,
@@ -128,6 +130,17 @@ import { CompactionLevel, extractSummary, smartCompactMessages } from '@/agent/c
 export const INTERNAL_TASK_ID = 'internal';
 export const RESPONSE_CHUNK_FLUSH_INTERVAL_MS = 10;
 export const TOOL_INPUT_FLUSH_INTERVAL_MS = 50;
+/**
+ * Bounded wait for the `onNotification` extension hook before core notification delivery
+ * proceeds. A hung extension must never suppress core delivery indefinitely.
+ */
+export const NOTIFICATION_HOOK_TIMEOUT_MS = 2_000;
+
+/**
+ * Per-project FIFO queues serializing notification delivery (see Task.notifyIfEnabled).
+ * Keyed by project baseDir; entries are removed as soon as their tail settles.
+ */
+const projectNotificationQueues = new Map<string, Promise<void>>();
 
 export const EMPTY_TASK_DATA: TaskData = {
   id: '',
@@ -1115,7 +1128,7 @@ export class Task {
     responses.push(...nextResponses);
 
     if (sendNotification) {
-      this.notifyIfEnabled('Task finished', getTaskFinishedNotificationText(this.task));
+      void this.notifyIfEnabled('Task finished', getTaskFinishedNotificationText(this.task), 'task-finished');
     }
 
     return responses;
@@ -1206,7 +1219,7 @@ export class Task {
     }
 
     if (sendNotification) {
-      this.notifyIfEnabled('Task finished', getTaskFinishedNotificationText(this.task));
+      void this.notifyIfEnabled('Task finished', getTaskFinishedNotificationText(this.task), 'task-finished');
     }
 
     return [];
@@ -1706,28 +1719,141 @@ export class Task {
     this.eventManager.sendToolInputChunk(data);
   }
 
-  private notifyIfEnabled(title: string, text: string) {
-    const settings = this.store.getSettings();
-    if (!settings.notificationsEnabled) {
-      return;
-    }
+  /**
+   * Serializes per-project notification delivery. Notifications for the same project are
+   * delivered FIFO in dispatch order; different projects are independent. Queues are
+   * cleaned up as soon as their tail settles to avoid unbounded growth.
+   */
+  private notifyIfEnabled(title: string, text: string, kind: NotificationKind = 'generic') {
+    const projectDir = this.getProjectDir();
+    const previous = projectNotificationQueues.get(projectDir) ?? Promise.resolve();
+    // Run the delivery regardless of whether the previous tail rejected (it never should:
+    // deliverNotification swallows its own errors, but stay defensive).
+    const delivery = previous.then(
+      () => this.deliverNotification(title, text, kind),
+      () => this.deliverNotification(title, text, kind),
+    );
+    const tail = delivery.then(
+      () => {
+        if (projectNotificationQueues.get(projectDir) === tail) {
+          projectNotificationQueues.delete(projectDir);
+        }
+      },
+      () => {
+        if (projectNotificationQueues.get(projectDir) === tail) {
+          projectNotificationQueues.delete(projectDir);
+        }
+      },
+    );
+    projectNotificationQueues.set(projectDir, tail);
+    return delivery;
+  }
 
-    this.eventManager.sendNotification(this.getProjectDir(), title, text);
-
-    const app = getElectronApp();
-    if (!app) {
-      return;
-    }
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { Notification } = require('electron');
-    if (Notification.isSupported()) {
-      const notification = new Notification({
+  /**
+   * Fire-and-forget notification pipeline body (call sites use `void notifyIfEnabled`, so
+   * failures must never escape as unhandled rejections): swallows and logs any error
+   * instead of throwing.
+   */
+  private async deliverNotification(title: string, text: string, kind: NotificationKind) {
+    try {
+      let notification: NotificationData = {
+        baseDir: this.getProjectDir(),
         title,
         body: text,
-      });
-      notification.show();
-    } else {
-      logger.warn('Notifications are not supported on this platform.');
+        kind,
+        id: uuidv4(),
+        timestamp: Date.now(),
+      };
+
+      // Let extensions observe, modify, or block the notification before default delivery.
+      // The hook fires REGARDLESS of the notificationsEnabled setting: sound/relay
+      // extensions must be able to observe (or self-deliver) notifications even when the
+      // user disabled the built-in core delivery. Core delivery (transport + Electron)
+      // below remains gated by that setting.
+      // An extension result of {notification: undefined, blocked: false} must preserve the
+      // original notification instead of sending undefined downstream.
+      // The hook receives a CLONE of the notification: handlers get the payload by reference
+      // and may mutate it in place, so if the dispatch below races to its timeout (a hung
+      // hook), the pristine original is delivered instead of a half-mutated object.
+      // The dispatch is raced against a bounded timeout so an indefinitely pending hook
+      // cannot suppress core delivery (the timeout delivers the unmodified notification).
+      const dispatchPayload: NotificationData = { ...notification };
+      const dispatchPromise = this.extensionManager.dispatchEvent('onNotification', { notification: dispatchPayload }, this.project, this);
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const dispatchOutcome = await Promise.race([
+        dispatchPromise.then(
+          (value) => ({ value }) as const,
+          (error: unknown) => ({ error }) as const,
+        ),
+        new Promise<null>((resolve) => {
+          timer = setTimeout(() => resolve(null), NOTIFICATION_HOOK_TIMEOUT_MS);
+        }),
+      ]);
+      if (timer) {
+        clearTimeout(timer);
+      }
+
+      if (dispatchOutcome === null) {
+        logger.warn('onNotification extension hook did not settle in time; delivering the unmodified notification', {
+          title: notification.title,
+          timeoutMs: NOTIFICATION_HOOK_TIMEOUT_MS,
+        });
+      } else if ('error' in dispatchOutcome) {
+        logger.error('onNotification extension hook failed to dispatch:', dispatchOutcome.error);
+        return;
+      } else {
+        // Extension result handling: a returned notification is merged field-by-field over
+        // the original. dispatchEvent already performs this merge for chained handlers, but
+        // the delivery boundary must never drop core fields (baseDir/body/id) even if a
+        // partial notification somehow reaches this point; undefined-valued fields in the
+        // returned object are ignored rather than clobbering the original.
+        const returnedNotification = dispatchOutcome.value.notification;
+        if (returnedNotification) {
+          notification = {
+            ...notification,
+            ...Object.fromEntries(Object.entries(returnedNotification).filter(([, value]) => value !== undefined)),
+          };
+        }
+
+        if (dispatchOutcome.value.blocked) {
+          logger.debug('Notification delivery blocked by extension', {
+            title: notification.title,
+            kind: notification.kind,
+          });
+          return;
+        }
+      }
+
+      // Default delivery gating: extension observation above is decoupled from this
+      // setting — the hook always runs, but the built-in transport (socket event +
+      // Electron notification) is skipped when the user disabled notifications.
+      const settings = this.store.getSettings();
+      if (!settings.notificationsEnabled) {
+        return;
+      }
+
+      this.eventManager.sendNotificationData(notification);
+
+      const app = getElectronApp();
+      if (!app) {
+        return;
+      }
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { Notification } = require('electron');
+      if (Notification.isSupported()) {
+        const electronNotification = new Notification({
+          title: notification.title,
+          body: notification.body,
+        });
+        electronNotification.show();
+      } else {
+        logger.warn('Notifications are not supported on this platform.');
+      }
+    } catch (error) {
+      // All call sites are `void` fire-and-forget: log and swallow so former synchronous
+      // throws (settings access, Electron notification, transport) never become unhandled
+      // rejections.
+      logger.error('Failed to deliver notification:', error);
     }
   }
 
@@ -2235,7 +2361,7 @@ export class Task {
       return Promise.resolve([storedAnswer, undefined]);
     }
 
-    this.notifyIfEnabled('Waiting for your input', questionData.text);
+    void this.notifyIfEnabled('Waiting for your input', questionData.text, 'input-needed');
 
     // Store the resolve function for the promise
     return new Promise<[string, string | undefined]>((resolve) => {

--- a/src/renderer/src/api/__tests__/browser-api.notification-dedup.test.ts
+++ b/src/renderer/src/api/__tests__/browser-api.notification-dedup.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { BrowserApi } from '../browser-api';
+
+import type { NotificationData } from '@common/types';
+
+// Capture the socket 'event' handler so tests can simulate wire deliveries.
+const { socketHandlers, emitMock } = vi.hoisted(() => {
+  const socketHandlers = new Map<string, (...args: unknown[]) => void>();
+  return {
+    socketHandlers,
+    emitMock: vi.fn(),
+  };
+});
+
+vi.mock('socket.io-client', () => ({
+  io: vi.fn(() => ({
+    connected: true,
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      socketHandlers.set(event, handler);
+    }),
+    once: vi.fn(),
+    off: vi.fn(),
+    emit: emitMock,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  })),
+}));
+
+const emitEvent = (type: string, data: unknown) => {
+  const handler = socketHandlers.get('event');
+  if (!handler) {
+    throw new Error('socket event handler was never registered');
+  }
+  handler({ type, data });
+};
+
+const makeNotification = (id: string): NotificationData => ({
+  baseDir: '/test/project',
+  title: 'Task finished',
+  body: 'all done',
+  id,
+  timestamp: 1,
+  kind: 'task-finished',
+});
+
+describe('BrowserApi - notification deduplication wiring', () => {
+  let browserApi: BrowserApi;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    socketHandlers.clear();
+    browserApi = new BrowserApi();
+  });
+
+  it('suppresses a duplicate notification id while a listener is registered', () => {
+    const callback = vi.fn();
+    browserApi.addNotificationListener('/test/project', callback);
+
+    emitEvent('notification', makeNotification('n-1'));
+    emitEvent('notification', makeNotification('n-1'));
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('records the notification id even when no listener exists yet, so a later redelivery is suppressed', () => {
+    // First delivery arrives before any notification listener has registered
+    emitEvent('notification', makeNotification('n-1'));
+
+    // Listener attaches afterwards; the redelivery must hit the deduplicator
+    const callback = vi.fn();
+    browserApi.addNotificationListener('/test/project', callback);
+    emitEvent('notification', makeNotification('n-1'));
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('delivers a fresh notification after listener registration following a listener-less delivery', () => {
+    emitEvent('notification', makeNotification('n-1'));
+
+    const callback = vi.fn();
+    browserApi.addNotificationListener('/test/project', callback);
+    emitEvent('notification', makeNotification('n-2'));
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback.mock.calls[0][0]).toMatchObject({ id: 'n-2', title: 'Task finished' });
+  });
+
+  it('never deduplicates notifications without a stable id (back-compat with older servers)', () => {
+    const callback = vi.fn();
+    browserApi.addNotificationListener('/test/project', callback);
+
+    const idlePayload = { baseDir: '/test/project', title: 'T', body: 'B' };
+    emitEvent('notification', idlePayload);
+    emitEvent('notification', idlePayload);
+
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it('never suppresses malformed wire payloads (no throw aborts dispatch)', () => {
+    const callback = vi.fn();
+    browserApi.addNotificationListener('/test/project', callback);
+
+    emitEvent('notification', null);
+    emitEvent('notification', 'garbage');
+
+    expect(callback).not.toHaveBeenCalled();
+    // Must not have thrown: reaching this assertion means dispatch survived
+    expect(true).toBe(true);
+  });
+});

--- a/src/renderer/src/api/__tests__/browser-api.notification-dedup.test.ts
+++ b/src/renderer/src/api/__tests__/browser-api.notification-dedup.test.ts
@@ -35,8 +35,8 @@ const emitEvent = (type: string, data: unknown) => {
   handler({ type, data });
 };
 
-const makeNotification = (id: string): NotificationData => ({
-  baseDir: '/test/project',
+const makeNotification = (id: string, baseDir = '/test/project'): NotificationData => ({
+  baseDir,
   title: 'Task finished',
   body: 'all done',
   id,
@@ -95,6 +95,27 @@ describe('BrowserApi - notification deduplication wiring', () => {
     emitEvent('notification', idlePayload);
 
     expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it('delivers identical ids from different projects independently (no cross-project suppression)', () => {
+    const callbackA = vi.fn();
+    const callbackB = vi.fn();
+    browserApi.addNotificationListener('/test/project', callbackA);
+    browserApi.addNotificationListener('/test/other-project', callbackB);
+
+    // Same id delivered to two different projects
+    emitEvent('notification', makeNotification('shared-id', '/test/project'));
+    emitEvent('notification', makeNotification('shared-id', '/test/other-project'));
+
+    expect(callbackA).toHaveBeenCalledTimes(1);
+    expect(callbackB).toHaveBeenCalledTimes(1);
+
+    // Redelivery within each project is still suppressed by (baseDir, id)
+    emitEvent('notification', makeNotification('shared-id', '/test/project'));
+    emitEvent('notification', makeNotification('shared-id', '/test/other-project'));
+
+    expect(callbackA).toHaveBeenCalledTimes(1);
+    expect(callbackB).toHaveBeenCalledTimes(1);
   });
 
   it('never suppresses malformed wire payloads (no throw aborts dispatch)', () => {

--- a/src/renderer/src/api/browser-api.ts
+++ b/src/renderer/src/api/browser-api.ts
@@ -86,6 +86,8 @@ import { io, Socket } from 'socket.io-client';
 import { compareBaseDirs } from '@common/utils';
 import { v4 as uuidv4 } from 'uuid';
 
+import { createNotificationDeduplicator } from '@/utils/notification-dedup';
+
 type EventDataMap = {
   'settings-updated': SettingsData;
   'response-chunk': ResponseChunkData;
@@ -154,6 +156,7 @@ export class BrowserApi implements ApplicationAPI {
   };
   private readonly apiClient: AxiosInstance;
   private appOS: OS | null = null;
+  private readonly notificationDeduplicator = createNotificationDeduplicator();
 
   constructor() {
     // Allow overriding the API port via query param (e.g. when opening the dev renderer in a browser against a dev server)
@@ -251,9 +254,19 @@ export class BrowserApi implements ApplicationAPI {
     this.socket.on('event', (eventData: { type: string; data: unknown }) => {
       const { type, data } = eventData;
       const eventType = type as keyof EventDataMap;
+
+      // Suppress redelivered notifications (reconnect re-subscription / duplicate broadcast) by stable id.
+      // Runs BEFORE the listener-exists check so a notification delivered while no `notification`
+      // listener is registered still records its id — otherwise it could be redelivered later
+      // (e.g., after fix-up/re-subscription) and play twice.
+      if (eventType === 'notification' && this.notificationDeduplicator.isDuplicate(data)) {
+        return;
+      }
+
       const eventListeners = this.listeners[eventType];
       if (eventListeners) {
         const typedData = data as EventDataMap[typeof eventType];
+
         eventListeners.forEach((entry) => {
           const baseDir = (typedData as { baseDir?: string })?.baseDir;
           const taskId = (typedData as { taskId?: string })?.taskId;
@@ -1432,7 +1445,8 @@ export class BrowserApi implements ApplicationAPI {
 
   addNotificationListener(baseDir: string, callback: (data: NotificationData) => void): () => void {
     return this.addListener('notification', (data: NotificationData) => {
-      if (data.baseDir === baseDir) {
+      // Optional chaining: raw socket wire data may be malformed
+      if ((data as NotificationData | null | undefined)?.baseDir === baseDir) {
         callback(data);
       }
     });

--- a/src/renderer/src/api/browser-api.ts
+++ b/src/renderer/src/api/browser-api.ts
@@ -255,10 +255,10 @@ export class BrowserApi implements ApplicationAPI {
       const { type, data } = eventData;
       const eventType = type as keyof EventDataMap;
 
-      // Suppress redelivered notifications (reconnect re-subscription / duplicate broadcast) by stable id.
-      // Runs BEFORE the listener-exists check so a notification delivered while no `notification`
-      // listener is registered still records its id — otherwise it could be redelivered later
-      // (e.g., after fix-up/re-subscription) and play twice.
+      // Suppress redelivered notifications (reconnect re-subscription / duplicate broadcast) by
+      // per-project (baseDir + id) key. Runs BEFORE the listener-exists check so a notification
+      // delivered while no `notification` listener is registered still records its id — otherwise
+      // it could be redelivered later (e.g., after fix-up/re-subscription) and play twice.
       if (eventType === 'notification' && this.notificationDeduplicator.isDuplicate(data)) {
         return;
       }

--- a/src/renderer/src/utils/__tests__/notification-dedup.test.ts
+++ b/src/renderer/src/utils/__tests__/notification-dedup.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createNotificationDeduplicator } from '../notification-dedup';
+
+describe('notification-dedup', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('allows a notification the first time it is seen', () => {
+    const deduplicator = createNotificationDeduplicator();
+
+    expect(deduplicator.isDuplicate({ id: 'n-1' })).toBe(false);
+  });
+
+  it('suppresses a redelivered id within the window', () => {
+    const deduplicator = createNotificationDeduplicator();
+
+    deduplicator.isDuplicate({ id: 'n-1' });
+    expect(deduplicator.isDuplicate({ id: 'n-1' })).toBe(true);
+  });
+
+  it('never considers notifications without an id duplicates (backward compatibility)', () => {
+    const deduplicator = createNotificationDeduplicator();
+
+    expect(deduplicator.isDuplicate({ id: '' })).toBe(false);
+    expect(deduplicator.isDuplicate({ id: '' })).toBe(false);
+  });
+
+  it('never throws and treats nullish or malformed payloads as fresh (must not abort event dispatch)', () => {
+    const deduplicator = createNotificationDeduplicator();
+
+    expect(deduplicator.isDuplicate(null)).toBe(false);
+    expect(deduplicator.isDuplicate(undefined)).toBe(false);
+    expect(deduplicator.isDuplicate('garbage' as unknown as { id: string })).toBe(false);
+    expect(deduplicator.isDuplicate({} as unknown as { id: string })).toBe(false);
+    expect(deduplicator.isDuplicate({ id: 42 as unknown as string })).toBe(false);
+
+    // Still functional after malformed input
+    expect(deduplicator.isDuplicate({ id: 'n-1' })).toBe(false);
+    expect(deduplicator.isDuplicate({ id: 'n-1' })).toBe(true);
+  });
+
+  it('treats distinct ids as independent notifications', () => {
+    const deduplicator = createNotificationDeduplicator();
+
+    deduplicator.isDuplicate({ id: 'n-1' });
+    expect(deduplicator.isDuplicate({ id: 'n-2' })).toBe(false);
+  });
+
+  it('allows the same id again after the dedup window elapses', () => {
+    const now = Date.now();
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(now);
+    const deduplicator = createNotificationDeduplicator(10 * 60 * 1000);
+
+    deduplicator.isDuplicate({ id: 'n-1' });
+
+    nowSpy.mockReturnValue(now + 9 * 60 * 1000);
+    expect(deduplicator.isDuplicate({ id: 'n-1' })).toBe(true);
+
+    nowSpy.mockReturnValue(now + 10 * 60 * 1000);
+    // Eviction only happens strictly after the window (now - timestamp > windowMs)
+    expect(deduplicator.isDuplicate({ id: 'n-1' })).toBe(true);
+
+    nowSpy.mockReturnValue(now + 10 * 60 * 1000 + 1);
+    expect(deduplicator.isDuplicate({ id: 'n-1' })).toBe(false);
+  });
+
+  it('evicts expired entries before checking for duplicates', () => {
+    const now = Date.now();
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(now);
+    const deduplicator = createNotificationDeduplicator(1000, 10);
+
+    deduplicator.isDuplicate({ id: 'old' });
+
+    nowSpy.mockReturnValue(now + 2000);
+    // 'old' expired: evicted before the check, so 'new' is accepted and 'old' treated as fresh again
+    expect(deduplicator.isDuplicate({ id: 'new' })).toBe(false);
+    expect(deduplicator.isDuplicate({ id: 'old' })).toBe(false);
+    expect(deduplicator.isDuplicate({ id: 'new' })).toBe(true);
+  });
+
+  it('evicts the oldest tracked id when maxTrackedIds is exceeded', () => {
+    const deduplicator = createNotificationDeduplicator(10 * 60 * 1000, 2);
+
+    deduplicator.isDuplicate({ id: 'a' });
+    deduplicator.isDuplicate({ id: 'b' });
+
+    // 'c' pushes out 'a' (oldest insertion in Map order)
+    expect(deduplicator.isDuplicate({ id: 'c' })).toBe(false);
+
+    expect(deduplicator.isDuplicate({ id: 'b' })).toBe(true);
+    expect(deduplicator.isDuplicate({ id: 'c' })).toBe(true);
+    expect(deduplicator.isDuplicate({ id: 'a' })).toBe(false);
+  });
+
+  it('uses default window and capacity when no arguments are provided', () => {
+    const now = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    const deduplicator = createNotificationDeduplicator();
+
+    const ids = Array.from({ length: 200 }, (_, i) => `id-${i}`);
+    ids.forEach((id) => expect(deduplicator.isDuplicate({ id })).toBe(false));
+
+    // The 201st insertion evicts the oldest tracked id
+    expect(deduplicator.isDuplicate({ id: 'id-200' })).toBe(false);
+
+    expect(deduplicator.isDuplicate({ id: ids[1] })).toBe(true);
+    expect(deduplicator.isDuplicate({ id: ids[0] })).toBe(false);
+  });
+
+  it('refreshes recency without refreshing eviction order when a duplicate is suppressed', () => {
+    const deduplicator = createNotificationDeduplicator(10 * 60 * 1000, 2);
+
+    deduplicator.isDuplicate({ id: 'a' });
+    deduplicator.isDuplicate({ id: 'b' });
+
+    // A suppressed redelivery of 'b' must not refresh 'a' out of position:
+    // next insertion evicts 'a' (insertion order), but 'b' remains tracked.
+    deduplicator.isDuplicate({ id: 'b' });
+    deduplicator.isDuplicate({ id: 'c' });
+
+    expect(deduplicator.isDuplicate({ id: 'b' })).toBe(true);
+    expect(deduplicator.isDuplicate({ id: 'a' })).toBe(false);
+  });
+});

--- a/src/renderer/src/utils/__tests__/notification-dedup.test.ts
+++ b/src/renderer/src/utils/__tests__/notification-dedup.test.ts
@@ -48,6 +48,39 @@ describe('notification-dedup', () => {
     expect(deduplicator.isDuplicate({ id: 'n-2' })).toBe(false);
   });
 
+  it('isolates identical ids across different projects (per baseDir + id key)', () => {
+    const deduplicator = createNotificationDeduplicator();
+
+    // First project sees the id
+    expect(deduplicator.isDuplicate({ baseDir: '/projects/a', id: 'n-1' })).toBe(false);
+    // A different project with the same id must NOT be suppressed
+    expect(deduplicator.isDuplicate({ baseDir: '/projects/b', id: 'n-1' })).toBe(false);
+
+    // Redelivery within each project is still suppressed
+    expect(deduplicator.isDuplicate({ baseDir: '/projects/a', id: 'n-1' })).toBe(true);
+    expect(deduplicator.isDuplicate({ baseDir: '/projects/b', id: 'n-1' })).toBe(true);
+
+    // A third project with the same id is still fresh
+    expect(deduplicator.isDuplicate({ baseDir: '/projects/c', id: 'n-1' })).toBe(false);
+  });
+
+  it('treats a differing baseDir as a different dedup key even when ids collide', () => {
+    const deduplicator = createNotificationDeduplicator();
+
+    deduplicator.isDuplicate({ baseDir: '/projects/a', id: 'shared' });
+    expect(deduplicator.isDuplicate({ baseDir: '/projects/ab', id: 'shared' })).toBe(false);
+    expect(deduplicator.isDuplicate({ baseDir: '/projects/ab2', id: 'shared' })).toBe(false);
+  });
+
+  it('falls back to the id-only key when baseDir is absent or malformed', () => {
+    const deduplicator = createNotificationDeduplicator();
+
+    expect(deduplicator.isDuplicate({ id: 'n-1' })).toBe(false);
+    expect(deduplicator.isDuplicate({ id: 'n-1' })).toBe(true);
+    expect(deduplicator.isDuplicate({ baseDir: 42 as unknown as string, id: 'n-2' })).toBe(false);
+    expect(deduplicator.isDuplicate({ baseDir: 42 as unknown as string, id: 'n-2' })).toBe(true);
+  });
+
   it('allows the same id again after the dedup window elapses', () => {
     const now = Date.now();
     const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(now);

--- a/src/renderer/src/utils/notification-dedup.ts
+++ b/src/renderer/src/utils/notification-dedup.ts
@@ -1,0 +1,80 @@
+/**
+ * Deduplication utility for the `notification` browser event.
+ *
+ * The Socket.IO transport delivers notifications over the auto-reconnecting
+ * events connection. On reconnect the browser-client re-subscribes, and in rare
+ * scenarios (server failover, duplicate broadcast) the same notification may be
+ * delivered more than once. The notification contract carries a stable `id`
+ * (plus `timestamp`), which this utility uses to suppress redeliveries
+ * within a bounded window, so each notification sound/alert plays once.
+ *
+ * Notifications without an `id` (produced by older servers) are never
+ * considered duplicates to preserve backward compatibility.
+ */
+
+const DEFAULT_DEDUP_WINDOW_MS = 10 * 60 * 1000; // 10 minutes
+const DEFAULT_MAX_TRACKED_IDS = 200;
+
+export type NotificationDedupInput = unknown;
+
+export interface NotificationDeduplicator {
+  /**
+   * Returns true if a notification with the same `id` was already seen within
+   * the dedup window. Records the id on first sight.
+   *
+   * Parameter is `unknown` because callers feed raw, untrusted wire data; unknown,
+   * malformed, or nullish payloads are never duplicates and must
+   * never throw — a throw here would abort dispatch to the notification
+   * listeners in the socket 'event' callback.
+   */
+  isDuplicate: (notification: NotificationDedupInput) => boolean;
+}
+
+export const createNotificationDeduplicator = (
+  windowMs: number = DEFAULT_DEDUP_WINDOW_MS,
+  maxTrackedIds: number = DEFAULT_MAX_TRACKED_IDS,
+): NotificationDeduplicator => {
+  const seen = new Map<string, number>();
+
+  const evictExpired = (now: number) => {
+    for (const [id, timestamp] of seen) {
+      if (now - timestamp > windowMs) {
+        seen.delete(id);
+      }
+    }
+  };
+
+  return {
+    isDuplicate: (notification: unknown): boolean => {
+      // Never throw on malformed payloads: the caller feeds raw wire data, and a
+      // throw inside the socket 'event' callback would abort dispatch to the
+      // remaining notification listeners.
+      if (!notification || typeof notification !== 'object') {
+        return false;
+      }
+
+      const id = (notification as { id?: unknown }).id;
+      if (typeof id !== 'string' || !id) {
+        // Backward compatibility: notifications without a stable id are always fresh
+        return false;
+      }
+
+      const now = Date.now();
+      evictExpired(now);
+
+      if (seen.has(id)) {
+        return true;
+      }
+
+      seen.set(id, now);
+      if (seen.size > maxTrackedIds) {
+        const oldestId = seen.keys().next().value;
+        if (oldestId !== undefined) {
+          seen.delete(oldestId);
+        }
+      }
+
+      return false;
+    },
+  };
+};

--- a/src/renderer/src/utils/notification-dedup.ts
+++ b/src/renderer/src/utils/notification-dedup.ts
@@ -8,6 +8,10 @@
  * (plus `timestamp`), which this utility uses to suppress redeliveries
  * within a bounded window, so each notification sound/alert plays once.
  *
+ * The dedup key combines the notification's `baseDir` with its `id`, so
+ * notifications from different projects that happen to carry the same `id`
+ * never suppress each other.
+ *
  * Notifications without an `id` (produced by older servers) are never
  * considered duplicates to preserve backward compatibility.
  */
@@ -19,8 +23,8 @@ export type NotificationDedupInput = unknown;
 
 export interface NotificationDeduplicator {
   /**
-   * Returns true if a notification with the same `id` was already seen within
-   * the dedup window. Records the id on first sight.
+   * Returns true if a notification with the same project `baseDir` + `id` pair
+   * was already seen within the dedup window. Records the pair on first sight.
    *
    * Parameter is `unknown` because callers feed raw, untrusted wire data; unknown,
    * malformed, or nullish payloads are never duplicates and must
@@ -59,18 +63,23 @@ export const createNotificationDeduplicator = (
         return false;
       }
 
+      // Include baseDir in the dedup key so identical ids from different projects
+      // stay independent (the browser client is a global event bus for all projects).
+      const baseDir = (notification as { baseDir?: unknown }).baseDir;
+      const key = typeof baseDir === 'string' && baseDir ? `${baseDir}:${id}` : id;
+
       const now = Date.now();
       evictExpired(now);
 
-      if (seen.has(id)) {
+      if (seen.has(key)) {
         return true;
       }
 
-      seen.set(id, now);
+      seen.set(key, now);
       if (seen.size > maxTrackedIds) {
-        const oldestId = seen.keys().next().value;
-        if (oldestId !== undefined) {
-          seen.delete(oldestId);
+        const oldestKey = seen.keys().next().value;
+        if (oldestKey !== undefined) {
+          seen.delete(oldestKey);
         }
       }
 


### PR DESCRIPTION
NotificationData now carries id, timestamp, and kind, populated at the EventManager delivery boundary so every transport sees a consistent contract.

A new onNotification extension hook can modify or block delivery; dispatch is bounded by timeout, serialized per project, and merges partial hook results field-by-field.

The renderer deduplicates notification redeliveries by id across Socket.IO reconnects. Extension author docs for the hook and notification event types are updated.
