### PR TITLE
feat: add copy task id to task menu

### DIFF
--- a/packages/common/src/locales/en.json
+++ b/packages/common/src/locales/en.json
@@ -1880,6 +1880,8 @@
     "untitled": "[Untitled]",
     "exportAsMarkdown": "Export as markdown",
     "copyAsMarkdown": "Copy as markdown",
+    "copyTaskId": "Copy task id",
+    "copyTaskIdFailed": "Failed to copy task id",
     "copiedAsMarkdown": "Copied as Markdown",
     "exportAsImage": "Export as image",
     "taskIdCopied": "Task ID {{taskId}} copied to clipboard",

--- a/packages/common/src/locales/ko.json
+++ b/packages/common/src/locales/ko.json
@@ -1848,6 +1848,8 @@
     "untitled": "[제목 없음]",
     "exportAsMarkdown": "마크다운으로 내보내기",
     "copyAsMarkdown": "마크다운으로 복사",
+    "copyTaskId": "작업 ID 복사",
+    "copyTaskIdFailed": "작업 ID 복사 실패",
     "copiedAsMarkdown": "마크다운으로 복사됨",
     "exportAsImage": "이미지로 내보내기",
     "taskIdCopied": "작업 ID {{taskId}}이(가) 클립보드에 복사되었습니다",

--- a/packages/common/src/locales/ru.json
+++ b/packages/common/src/locales/ru.json
@@ -1870,6 +1870,8 @@
     "untitled": "[Без названия]",
     "exportAsMarkdown": "Экспортировать как Markdown",
     "copyAsMarkdown": "Копировать как Markdown",
+    "copyTaskId": "Копировать ID задачи",
+    "copyTaskIdFailed": "Не удалось скопировать ID задачи",
     "copiedAsMarkdown": "Скопировано как Markdown",
     "exportAsImage": "Экспортировать как изображение",
     "taskIdCopied": "Идентификатор задачи {{taskId}} скопирован в буфер обмена",

--- a/packages/common/src/locales/zh.json
+++ b/packages/common/src/locales/zh.json
@@ -1888,6 +1888,8 @@
     "untitled": "[未命名]",
     "exportAsMarkdown": "导出为 Markdown",
     "copyAsMarkdown": "复制为 Markdown",
+    "copyTaskId": "复制任务 ID",
+    "copyTaskIdFailed": "复制任务 ID 失败",
     "copiedAsMarkdown": "已复制为 Markdown",
     "exportAsImage": "导出为图片",
     "taskIdCopied": "任务 ID {{taskId}} 已复制到剪贴板",

--- a/src/renderer/src/components/project/TaskSidebar/TaskMenuButton.tsx
+++ b/src/renderer/src/components/project/TaskSidebar/TaskMenuButton.tsx
@@ -12,6 +12,8 @@ import { clsx } from 'clsx';
 
 import { useClickOutside } from '@/hooks/useClickOutside';
 import { getTaskStateLabel } from '@/components/common/TaskStateChip';
+import { showInfoNotification, showWarningNotification } from '@/utils/notifications';
+import { useOptionalApi } from '@/contexts/ApiContext';
 
 type Props = {
   task: TaskData;
@@ -46,6 +48,7 @@ export const TaskMenuButton = memo(
     isPinned,
   }: Props) => {
     const { t } = useTranslation();
+    const api = useOptionalApi();
     const isNewTask = !task.createdAt;
     const [isMenuOpen, setIsMenuOpen] = useState(false);
     const [isStateSubmenuOpen, setIsStateSubmenuOpen] = useState(false);
@@ -108,6 +111,23 @@ export const TaskMenuButton = memo(
     const handleCopyAsMarkdownClick = (e: MouseEvent) => {
       e.stopPropagation();
       onCopyAsMarkdown?.();
+      setIsMenuOpen(false);
+    };
+
+    const handleCopyTaskIdClick = async (e: MouseEvent) => {
+      e.stopPropagation();
+      try {
+        if (api) {
+          await api.writeToClipboard(task.id);
+        } else {
+          await navigator.clipboard.writeText(task.id);
+        }
+        showInfoNotification(t('taskSidebar.taskIdCopied', { taskId: task.id }));
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error('Failed to copy task id:', error);
+        showWarningNotification(t('taskSidebar.copyTaskIdFailed'));
+      }
       setIsMenuOpen(false);
     };
 
@@ -217,6 +237,13 @@ export const TaskMenuButton = memo(
                     <span className="whitespace-nowrap">{t('taskSidebar.copyAsMarkdown')}</span>
                   </li>
                 )}
+                <li
+                  className="flex items-center gap-2 px-2 py-1 text-2xs text-text-primary hover:bg-bg-tertiary cursor-pointer transition-colors"
+                  onClick={handleCopyTaskIdClick}
+                >
+                  <BiCopy className="w-4 h-4" />
+                  <span className="whitespace-nowrap">{t('taskSidebar.copyTaskId')}</span>
+                </li>
                 {onExportToMarkdown && (
                   <li
                     className="flex items-center gap-2 px-2 py-1 text-2xs text-text-primary hover:bg-bg-tertiary cursor-pointer transition-colors"


### PR DESCRIPTION
Adds a "Copy task id" item to the task sidebar "..." menu that writes the task's id to the clipboard. Uses the IPC clipboard API with a navigator.clipboard fallback, and shows a warning notification when copying fails.