### PR TITLE
fix(extensions): speed up extension loading

### DIFF
--- a/src/main/extensions/__tests__/extension-fetcher.test.ts
+++ b/src/main/extensions/__tests__/extension-fetcher.test.ts
@@ -6,6 +6,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import { ExtensionFetcher } from '../extension-fetcher';
 
+vi.mock('typescript', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('typescript')>();
+  return {
+    ...actual,
+    createProgram: vi.fn(),
+  };
+});
+
 // Mock the shell utility
 vi.mock('@/utils/shell', () => ({
   execWithShellPath: vi.fn(),
@@ -45,8 +53,8 @@ describe('ExtensionFetcher', () => {
       try {
         const testFetcher = new ExtensionFetcher();
         // Access private method via type assertion
-        const getStaticMetadata = (testFetcher as unknown as { getStaticMetadata: (filePath: string) => unknown }).getStaticMetadata.bind(testFetcher);
-        return getStaticMetadata(extFile);
+        const getStaticMetadata = (testFetcher as unknown as { getStaticMetadata: (filePath: string) => Promise<unknown> }).getStaticMetadata.bind(testFetcher);
+        return await getStaticMetadata(extFile);
       } finally {
         await fsPromises.rm(realTempDir, { recursive: true, force: true });
       }
@@ -283,8 +291,8 @@ describe('ExtensionFetcher', () => {
 
       try {
         const testFetcher = new ExtensionFetcher();
-        const getStaticMetadata = (testFetcher as unknown as { getStaticMetadata: (filePath: string) => unknown }).getStaticMetadata.bind(testFetcher);
-        const metadata = getStaticMetadata(extFile);
+        const getStaticMetadata = (testFetcher as unknown as { getStaticMetadata: (filePath: string) => Promise<unknown> }).getStaticMetadata.bind(testFetcher);
+        const metadata = await getStaticMetadata(extFile);
 
         expect(metadata).toEqual({
           name: 'JS Extension',
@@ -294,6 +302,49 @@ describe('ExtensionFetcher', () => {
       } finally {
         await fsPromises.rm(realTempDir, { recursive: true, force: true });
       }
+    });
+
+    it('should parse with createSourceFile instead of createProgram', async () => {
+      const { createProgram } = (await import('typescript')) as unknown as { createProgram: ReturnType<typeof vi.fn> };
+
+      const mockFileContent = `
+        export class ParseModeExtension implements Extension {
+          static metadata = {
+            name: 'Parse Mode Extension',
+            version: '1.0.0',
+            capabilities: ['tools'],
+          };
+        }
+      `;
+
+      const metadata = await createAndTestMetadata(mockFileContent);
+
+      expect(metadata).toEqual({
+        name: 'Parse Mode Extension',
+        version: '1.0.0',
+        capabilities: ['tools'],
+      });
+      expect(createProgram).not.toHaveBeenCalled();
+    });
+
+    it('should extract metadata from a standalone file without TypeScript program resolution', async () => {
+      const mockFileContent = `
+        export class IndependentExtension implements Extension {
+          static metadata = {
+            name: 'Independent Extension',
+            version: '1.0.0',
+            capabilities: ['commands'],
+          };
+        }
+      `;
+
+      const metadata = await createAndTestMetadata(mockFileContent);
+
+      expect(metadata).toEqual({
+        name: 'Independent Extension',
+        version: '1.0.0',
+        capabilities: ['commands'],
+      });
     });
   });
 

--- a/src/main/extensions/extension-fetcher.ts
+++ b/src/main/extensions/extension-fetcher.ts
@@ -348,7 +348,7 @@ export class ExtensionFetcher {
 
   private async extractMetadataFromLocalFile(filePath: string): Promise<ExtensionMetadata | null> {
     try {
-      const metadata = this.getStaticMetadata(filePath);
+      const metadata = await this.getStaticMetadata(filePath);
 
       if (!metadata) {
         logger.error(`[ExtensionFetcher] No metadata found in ${filePath}`);
@@ -362,17 +362,9 @@ export class ExtensionFetcher {
     }
   }
 
-  private getStaticMetadata(filePath: string): ExtensionMetadata | null {
-    const program = ts.createProgram([filePath], {
-      allowJs: true,
-      target: ts.ScriptTarget.ESNext,
-      module: ts.ModuleKind.ESNext,
-    });
-
-    const sourceFile = program.getSourceFile(filePath);
-    if (!sourceFile) {
-      return null;
-    }
+  private async getStaticMetadata(filePath: string): Promise<ExtensionMetadata | null> {
+    const fileContent = await fs.readFile(filePath, 'utf-8');
+    const sourceFile = ts.createSourceFile(filePath, fileContent, ts.ScriptTarget.ESNext, true);
 
     let metadata: ExtensionMetadata | null = null;
     const enumValues = this.collectEnumValues(sourceFile);


### PR DESCRIPTION
Replaces per-file TypeScript `createProgram` parsing in the extension fetcher with `ts.createSourceFile`, eliminating full compiler-program construction for every extension entry file during gallery loading.