### PR TITLE
refactor(providers): extract shared provider kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 - added distinct "Create subtask" label when creating subtasks in the create task tool message
 - added git actions to the command palette with configurable hotkeys
 - fixed worktree integration checks failing when worktree directory no longer exists
+- improved provider model catalog enrichment so it now applies consistently to all simple/OpenAI-compatible providers, including token limits and input/output pricing where models.dev metadata is available (previously some descriptor-based providers missed these fields); enrichment now looks up models by the provider profile's canonical id first, taking precedence over the profile's name when both catalog entries exist, so a catalog provider whose id matches no longer loses its pricing and token limits to another provider whose name happens to match
+- improved zai-plan model discovery to use the ZAI_API_KEY environment variable instead of OPENAI_API_KEY (the Aider environment mapping still passes the key to the Aider process as OPENAI_API_KEY); users relying on OPENAI_API_KEY for zai-plan model discovery should rename it
+- improved Vertex AI model discovery to use the VERTEXAI_PROJECT/VERTEXAI_LOCATION environment variables instead of VERTEX_PROJECT/VERTEX_LOCATION, aligning with LLM configuration and the Aider environment mapping; users relying on the old variable names should rename them
+- improved LM Studio model discovery to use the LMSTUDIO_API_BASE environment variable instead of LM_STUDIO_API_BASE, aligning with provider creation and settings; users relying on LM_STUDIO_API_BASE for model discovery should rename it (the Aider environment mapping continues to output LM_STUDIO_API_BASE, which remains supported for provider settings)
 
 ## [0.81.0]
 

--- a/packages/common/src/extensions.ts
+++ b/packages/common/src/extensions.ts
@@ -175,10 +175,10 @@ export interface ExtensionProviderStrategy {
 
   getAiderMapping?: (provider: ProviderProfile, modelId: string, settings: SettingsData, projectDir: string) => AiderModelMapping;
   getUsageReport?: (task: unknown, provider: ProviderProfile, model: Model, usage: unknown, providerMetadata?: unknown) => UsageReportData;
-  getProviderOptions?: (model: Model, reasoning?: Reasoning) => Record<string, Record<string, JSONValue | undefined>> | undefined;
-  getCacheControl?: (model: Model) => CacheControl | undefined;
-  getProviderTools?: (model: Model) => Record<string, Tool> | Promise<Record<string, Tool>>;
-  getProviderParameters?: (model: Model, reasoning?: Reasoning) => Record<string, unknown>;
+  getProviderOptions?: (model: Model, reasoning?: Reasoning, profile?: ProviderProfile) => Record<string, Record<string, JSONValue | undefined>> | undefined;
+  getCacheControl?: (model: Model, profile?: ProviderProfile) => CacheControl | undefined;
+  getProviderTools?: (model: Model, profile?: ProviderProfile) => Record<string, Tool> | Promise<Record<string, Tool>>;
+  getProviderParameters?: (model: Model, reasoning?: Reasoning, profile?: ProviderProfile) => Record<string, unknown>;
   createVoiceSession?: (profile: ProviderProfile, settings: SettingsData) => Promise<VoiceSession>;
   isRetryable?: (error: unknown) => boolean;
 }

--- a/src/main/__tests__/open-url.test.ts
+++ b/src/main/__tests__/open-url.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Generic URL redaction (audit 179b6197 LOW): redactTokenQueryParam only
+ * masked the literal `token=` query parameter, so generic
+ * ExtensionContext.openUrl callers could log URLs carrying userinfo or other
+ * credential-like query parameters (`key=`, `auth=`, `secret=`, ...). The
+ * redactor applies to log strings only — dispatched URLs and rethrown errors
+ * never pass through it.
+ */
+import { execFileSync, spawnSync } from 'child_process';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/logger', () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('@/app', () => ({ isElectron: () => false }));
+
+// Pin the headless dispatch path: execFileSync would otherwise really invoke
+// the system browser opener in the test environment.
+vi.mock('child_process', () => ({ execFileSync: vi.fn(), spawnSync: vi.fn() }));
+
+import logger from '@/logger';
+import { openUrl, redactErrorForLog, redactTokenQueryParam } from '@/utils/open-url';
+
+describe('redactTokenQueryParam', () => {
+  it('redacts the extension review-server token query parameter', () => {
+    expect(redactTokenQueryParam('http://localhost:4173/?token=super-secret&port=4173')).toBe('http://localhost:4173/?token=<hidden>&port=4173');
+    // repeated occurrences and # fragment positions stay covered
+    expect(redactTokenQueryParam('http://h/?token=a&x=1#p?token=b')).toBe('http://h/?token=<hidden>&x=1#p?token=<hidden>');
+  });
+
+  it('redacts credential-like query parameters across common spellings', () => {
+    expect(redactTokenQueryParam('https://api.example.com/v1?key=K&auth=A&secret=S&password=P&api_key=AK&access_token=AT&id_token=IT')).toBe(
+      'https://api.example.com/v1?key=<hidden>&auth=<hidden>&secret=<hidden>&password=<hidden>&api_key=<hidden>&access_token=<hidden>&id_token=<hidden>',
+    );
+    expect(redactTokenQueryParam('https://a.example/?Token=T')).toBe('https://a.example/?Token=<hidden>');
+  });
+
+  it('redacts URL userinfo (including the token-as-username basic-auth idiom)', () => {
+    expect(redactTokenQueryParam('https://user:pass@example.com/path')).toBe('https://<hidden>@example.com/path');
+    expect(redactTokenQueryParam('https://apikey@api.example.com/v1')).toBe('https://<hidden>@api.example.com/v1');
+  });
+
+  it('does not over-redact ordinary URLs', () => {
+    const ordinary = 'https://example.com/docs/page?a=1&b=2#section';
+    expect(redactTokenQueryParam(ordinary)).toBe(ordinary);
+    // names that merely CONTAIN a credential word are not matches; values
+    // that mention such words stay visible in ordinary parameters
+    const neighbours = 'https://example.com/?monkey=1&sort=key&q=auth&id=7';
+    expect(redactTokenQueryParam(neighbours)).toBe(neighbours);
+  });
+
+  it('redacts through the error-log helper', () => {
+    const error = new Error('spawn failed: xdg-open "http://localhost:4173/?token=leak&k=v"');
+    const redacted = redactErrorForLog(error);
+    expect(redacted).not.toContain('leak');
+    expect(redacted).toBe('spawn failed: xdg-open "http://localhost:4173/?token=<hidden>&k=v"');
+    // non-Error throws are stringified, then redacted too
+    expect(redactErrorForLog('http://u:p@h/?secret=s')).toBe('http://<hidden>@h/?secret=<hidden>');
+  });
+});
+
+describe('openUrl logging keeps redaction on every path', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.AIDER_DESK_BROWSER;
+    delete process.env.BROWSER;
+  });
+
+  const dispatches = (): unknown[][] => vi.mocked(execFileSync).mock.calls.map((call) => call as unknown[]);
+
+  it('logs the redacted URL in headless external dispatch and never logs the secret', async () => {
+    await openUrl('http://localhost:4173/?token=super-secret&key=value', 'external');
+
+    const debugArgs = vi.mocked(logger.debug).mock.calls.flat().join('\n');
+    const errorArgs = vi.mocked(logger.error).mock.calls.flat().join('\n');
+    expect(debugArgs).not.toContain('super-secret');
+    expect(errorArgs).not.toContain('super-secret');
+    expect(debugArgs).toContain('token=<hidden>');
+    expect(debugArgs).toContain('key=<hidden>');
+    // the dispatched URL must remain the raw, unredacted one
+    expect(dispatches()[0]?.[1]).toContain('http://localhost:4173/?token=super-secret&key=value');
+  });
+
+  it('dispatches a URL containing shell command substitution as a raw argv element without a shell (audit: shell injection)', async () => {
+    const evil = 'http://localhost:4173/?token=t&x=$(touch /tmp/pwned)&y=`id`';
+    await openUrl(evil, 'external');
+
+    expect(execFileSync).toHaveBeenCalledTimes(1);
+    const [program, args] = dispatches()[0] as [string, string[]];
+    // xdg-open receives the URL unmodified as a single argument; no shell
+    // string is ever constructed, so $(...) and backticks stay literal data.
+    expect(program).toBe('xdg-open');
+    expect(args).toEqual([evil]);
+  });
+
+  it('prefers a configured browser binary and still passes the URL raw', async () => {
+    process.env.AIDER_DESK_BROWSER = 'chromium-browser';
+    const url = 'http://localhost:4173/?token=s';
+    await openUrl(url, 'external');
+
+    const [program, args] = dispatches()[0] as [string, string[]];
+    expect(program).toBe('chromium-browser');
+    expect(args).toEqual([url]);
+  });
+
+  it('uses `open -a <browser> <url>` argument arrays on macOS with AIDER_DESK_BROWSER', async () => {
+    const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    process.env.AIDER_DESK_BROWSER = 'Firefox Developer Edition';
+    try {
+      const url = 'http://h/?token=s';
+      await openUrl(url, 'external');
+      const [program, args] = dispatches()[0] as [string, string[]];
+      expect(program).toBe('open');
+      expect(args).toEqual(['-a', 'Firefox Developer Edition', url]);
+    } finally {
+      if (platformDescriptor) {
+        Object.defineProperty(process, 'platform', platformDescriptor);
+      }
+    }
+  });
+
+  it('dispatches via cmd.exe start with quoted arguments on Windows', async () => {
+    const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    process.env.AIDER_DESK_BROWSER = 'C:\\Tools\\browser.exe';
+    try {
+      const url = 'http://h/?a=1&b=2';
+      await openUrl(url, 'external');
+      expect(execFileSync).not.toHaveBeenCalled();
+      const [program, args] = vi.mocked(spawnSync).mock.calls[0] as unknown as [string, string[]];
+      expect(program).toBe('cmd.exe');
+      expect(args).toEqual(['/d', '/s', '/c', 'start', '', '"C:\\Tools\\browser.exe"', '"http://h/?a=1&b=2"']);
+    } finally {
+      if (platformDescriptor) {
+        Object.defineProperty(process, 'platform', platformDescriptor);
+      }
+    }
+  });
+
+  it('logs a redacted failure and rethrows the unchanged error when dispatch fails', async () => {
+    const failure = new Error('Command failed: xdg-open http://localhost:4173/?token=leak-me');
+    vi.mocked(execFileSync).mockImplementationOnce(() => {
+      throw failure;
+    });
+
+    await expect(openUrl('http://localhost:4173/?token=leak-me', 'external')).rejects.toBe(failure);
+
+    const errorArgs = vi.mocked(logger.error).mock.calls.flat().join('\n');
+    expect(errorArgs).not.toContain('leak-me');
+    expect(errorArgs).toContain('token=<hidden>');
+    expect(errorArgs).toContain('xdg-open');
+  });
+});

--- a/src/main/extensions/__tests__/extension-context.open-url.test.ts
+++ b/src/main/extensions/__tests__/extension-context.open-url.test.ts
@@ -41,7 +41,9 @@ describe('ExtensionContextImpl.openUrl token redaction', () => {
     // to assert the logged line; openUrlUtil (external/window) is untouched.
     await context.openUrl('http://localhost:4173/?token=super-secret&port=4173', 'modal-overlay');
 
-    expect(logger.info).toHaveBeenCalledWith('[Extension:Review Extension] Opening URL: http://localhost:4173/?token=<hidden>&port=4173 (target: modal-overlay)');
+    expect(logger.info).toHaveBeenCalledWith(
+      '[Extension:Review Extension] Opening URL: http://localhost:4173/?token=<hidden>&port=4173 (target: modal-overlay)',
+    );
     expect(logger.info).not.toHaveBeenCalledWith(expect.stringContaining('super-secret'));
   });
 
@@ -77,11 +79,7 @@ describe('delegated openUrl token redaction (audit 8d04f2a2 LOW)', () => {
   it('passes the raw, un-redacted URL to the actual dispatch', async () => {
     await openUrlUtil('http://localhost:4173/?token=super-secret', 'external');
 
-    expect(execFileSync).toHaveBeenCalledWith(
-      'xdg-open',
-      [expect.stringContaining('token=super-secret')],
-      expect.objectContaining({ stdio: 'ignore' }),
-    );
+    expect(execFileSync).toHaveBeenCalledWith('xdg-open', [expect.stringContaining('token=super-secret')], expect.objectContaining({ stdio: 'ignore' }));
   });
 });
 

--- a/src/main/extensions/__tests__/extension-context.open-url.test.ts
+++ b/src/main/extensions/__tests__/extension-context.open-url.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Focused test for audit-687c3c3c LOW: ExtensionContextImpl.openUrl logged the
+ * URL verbatim, including credential query parameters such as the
+ * `?token=...` auth token of an extension-provided review server. The logged
+ * line must redact the token
+ * while the URL itself is dispatched unchanged.
+ */
+import { execFileSync } from 'child_process';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/logger', () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// open-url's delegated paths branch on Electron; pin the headless branch so
+// the dispatch goes through the child_process-driven external browser opener.
+vi.mock('child_process', () => ({ execFileSync: vi.fn(), spawnSync: vi.fn() }));
+vi.mock('@/app', () => ({ isElectron: () => false }));
+
+import { DisposableStore } from '../disposable-store';
+import { ExtensionContextImpl } from '../extension-context';
+
+import logger from '@/logger';
+import { openUrl as openUrlUtil } from '@/utils/open-url';
+
+describe('ExtensionContextImpl.openUrl token redaction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('redacts the token query parameter in the logged URL without altering dispatch', async () => {
+    const context = new ExtensionContextImpl('review-extension', 'Review Extension', new DisposableStore('Review Extension'));
+
+    // modal-overlay without an eventManager logs the URL and then warns — enough
+    // to assert the logged line; openUrlUtil (external/window) is untouched.
+    await context.openUrl('http://localhost:4173/?token=super-secret&port=4173', 'modal-overlay');
+
+    expect(logger.info).toHaveBeenCalledWith('[Extension:Review Extension] Opening URL: http://localhost:4173/?token=<hidden>&port=4173 (target: modal-overlay)');
+    expect(logger.info).not.toHaveBeenCalledWith(expect.stringContaining('super-secret'));
+  });
+
+  it('leaves URLs without a token parameter unchanged in the log', async () => {
+    const context = new ExtensionContextImpl('ext', 'Ext', new DisposableStore('Ext'));
+
+    await context.openUrl('https://example.com/page?ref=docs', 'modal-overlay');
+
+    expect(logger.info).toHaveBeenCalledWith('[Extension:Ext] Opening URL: https://example.com/page?ref=docs (target: modal-overlay)');
+  });
+});
+
+describe('delegated openUrl token redaction (audit 8d04f2a2 LOW)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('redacts the token in the delegated openUrl debug log for external target', async () => {
+    await openUrlUtil('http://localhost:4173/?token=super-secret&port=4173', 'external');
+
+    expect(logger.debug).toHaveBeenCalledWith('[openUrl] Opening URL: http://localhost:4173/?token=<hidden>&port=4173 (position: external)');
+    expect(logger.debug).not.toHaveBeenCalledWith(expect.stringContaining('super-secret'));
+  });
+
+  it('redacts the token in the delegated openUrl debug log for window target', async () => {
+    await openUrlUtil('http://localhost:4173/?token=super-secret', 'window');
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.not.stringContaining('super-secret'));
+    expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('token=<hidden>'));
+    expect(logger.debug).not.toHaveBeenCalledWith(expect.stringContaining('super-secret'));
+  });
+
+  it('passes the raw, un-redacted URL to the actual dispatch', async () => {
+    await openUrlUtil('http://localhost:4173/?token=super-secret', 'external');
+
+    expect(execFileSync).toHaveBeenCalledWith(
+      'xdg-open',
+      [expect.stringContaining('token=super-secret')],
+      expect.objectContaining({ stdio: 'ignore' }),
+    );
+  });
+});
+
+describe('external-open failure path token redaction (audit 811fa488 MEDIUM)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // execFileSync errors embed the whole command — including the raw token-bearing
+  // URL — in their message; the failure-path log must redact it.
+  const failureMessage = 'Command failed: "/bin/browser" "http://localhost:4173/#token=super-secret"';
+
+  const assertNoSecretInLogs = (): void => {
+    for (const logFn of [logger.info, logger.warn, logger.error, logger.debug]) {
+      for (const call of vi.mocked(logFn).mock.calls) {
+        expect(JSON.stringify(call), JSON.stringify(call)).not.toContain('super-secret');
+      }
+    }
+  };
+
+  it('redacts the token in the failed external-open error log and rethrows the original error', async () => {
+    const failure = Object.assign(new Error(failureMessage), { status: 1 });
+    vi.mocked(execFileSync).mockImplementation(() => {
+      throw failure;
+    });
+
+    await expect(openUrlUtil('http://localhost:4173/#token=super-secret', 'external')).rejects.toBe(failure);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      '[openUrl] Failed to open URL in external browser:',
+      // the redactor consumes up to the next ?& or # — including the trailing
+      // quote of the embedded command — which is fine for a log line
+      'Command failed: "/bin/browser" "http://localhost:4173/#token=<hidden>',
+    );
+    assertNoSecretInLogs();
+    vi.mocked(execFileSync).mockReset();
+  });
+
+  it('redacts the token when ExtensionContextImpl logs a failed delegated openUrl', async () => {
+    vi.mocked(execFileSync).mockImplementation(() => {
+      throw new Error(failureMessage);
+    });
+    const context = new ExtensionContextImpl('review-extension', 'Review Extension', new DisposableStore('Review Extension'));
+
+    // The rethrown error keeps its raw message (not a log sink), but nothing
+    // the context logs may carry the secret.
+    await expect(context.openUrl('http://localhost:4173/#token=super-secret', 'external')).rejects.toThrow(/super-secret/);
+
+    assertNoSecretInLogs();
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Failed to open URL'));
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('token=<hidden>'));
+    vi.mocked(execFileSync).mockReset();
+  });
+
+  it('keeps URLs without token parameters verbatim in the failure log', async () => {
+    const failure = new Error('Command failed: "/bin/browser" "https://example.com/page?ref=docs"');
+    vi.mocked(execFileSync).mockImplementation(() => {
+      throw failure;
+    });
+
+    await expect(openUrlUtil('https://example.com/page?ref=docs', 'external')).rejects.toBe(failure);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      '[openUrl] Failed to open URL in external browser:',
+      'Command failed: "/bin/browser" "https://example.com/page?ref=docs"',
+    );
+    vi.mocked(execFileSync).mockReset();
+  });
+});

--- a/src/main/extensions/extension-context.ts
+++ b/src/main/extensions/extension-context.ts
@@ -14,7 +14,7 @@ import type { Task } from '@/task';
 
 import logger from '@/logger';
 import { truncateToolResult } from '@/agent/utils';
-import { openUrl as openUrlUtil } from '@/utils/open-url';
+import { openUrl as openUrlUtil, redactErrorForLog, redactTokenQueryParam } from '@/utils/open-url';
 
 export class ExtensionContextImpl implements ExtensionContext {
   private readonly taskContext: TaskContext | null;
@@ -179,7 +179,7 @@ export class ExtensionContextImpl implements ExtensionContext {
   }
 
   async openUrl(url: string, target: 'external' | 'window' | 'modal-overlay' = 'window'): Promise<void> {
-    this.log(`Opening URL: ${url} (target: ${target})`);
+    this.log(`Opening URL: ${redactTokenQueryParam(url)} (target: ${target})`);
     try {
       if (target === 'modal-overlay') {
         if (!this.eventManager) {
@@ -191,7 +191,10 @@ export class ExtensionContextImpl implements ExtensionContext {
         await openUrlUtil(url, target);
       }
     } catch (error) {
-      this.log(`Failed to open URL: ${error}`, 'error');
+      // Errors from the external-browser dispatch (execSync) embed the full
+      // command — including any token-bearing URL — in their message. Redact
+      // the log string only; the original error is rethrown untouched.
+      this.log(`Failed to open URL: ${redactErrorForLog(error)}`, 'error');
       throw error;
     }
   }

--- a/src/main/models/model-manager.ts
+++ b/src/main/models/model-manager.ts
@@ -999,16 +999,18 @@ export class ModelManager {
             | LanguageModel
             | Promise<LanguageModel>,
         getUsageReport: provider.strategy.getUsageReport || getDefaultUsageReport,
+        // All four callbacks pass the registered profile as the trailing argument so
+        // extensions have access to the same context the core strategies receive.
         getProviderOptions: provider.strategy.getProviderOptions
-          ? (_provider, model, reasoning) => provider.strategy.getProviderOptions!(model, reasoning)
+          ? (_provider, model, reasoning) => provider.strategy.getProviderOptions!(model, reasoning, profile)
           : undefined,
         getProviderTools: provider.strategy.getProviderTools
-          ? (_provider, model) => provider.strategy.getProviderTools!(model) as ToolSet | Promise<ToolSet>
+          ? (_provider, model) => provider.strategy.getProviderTools!(model, profile) as ToolSet | Promise<ToolSet>
           : undefined,
         getProviderParameters: provider.strategy.getProviderParameters
-          ? (_provider, model, reasoning) => provider.strategy.getProviderParameters!(model, reasoning)
+          ? (_provider, model, reasoning) => provider.strategy.getProviderParameters!(model, reasoning, profile)
           : undefined,
-        getCacheControl: provider.strategy.getCacheControl ? (_provider, model) => provider.strategy.getCacheControl!(model) : undefined,
+        getCacheControl: provider.strategy.getCacheControl ? (_provider, model) => provider.strategy.getCacheControl!(model, profile) : undefined,
         hasEnvVars: () => false,
         getAiderMapping: provider.strategy.getAiderMapping
           ? provider.strategy.getAiderMapping

--- a/src/main/models/providers/__tests__/aider-mapping-snapshots.test.ts
+++ b/src/main/models/providers/__tests__/aider-mapping-snapshots.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Phase 0 behavior-locking tests for get<L>AiderMapping: modelName prefixes and
+ * environmentVariables contents. Every provider configured with an explicit
+ * provider.apiKey (so no env resolution should take place beyond silence).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ProviderProfile, SettingsData } from '@common/types';
+
+import { groqProviderStrategy } from '../groq';
+import { cerebrasProviderStrategy } from '../cerebras';
+import { mistralProviderStrategy } from '../mistral';
+import { deepseekProviderStrategy } from '../deepseek';
+import { openaiProviderStrategy } from '../openai';
+import { openaiCompatibleProviderStrategy } from '../openai-compatible';
+import { anthropicProviderStrategy } from '../anthropic';
+import { anthropicCompatibleProviderStrategy } from '../anthropic-compatible';
+import { azureProviderStrategy } from '../azure';
+import { bedrockProviderStrategy } from '../bedrock';
+import { vertexAiProviderStrategy } from '../vertex-ai';
+import { geminiProviderStrategy } from '../gemini';
+import { minimaxProviderStrategy } from '../minimax';
+import { neuralwattProviderStrategy } from '../neuralwatt';
+import { syntheticProviderStrategy } from '../synthetic';
+import { zaiPlanProviderStrategy } from '../zai-plan';
+import { alibabaPlanProviderStrategy } from '../alibaba-plan';
+import { kimiPlanProviderStrategy } from '../kimi-plan';
+import { litellmProviderStrategy } from '../litellm';
+import { gpustackProviderStrategy } from '../gpustack';
+import { clinePassProviderStrategy } from '../clinepass';
+import { opencodeProviderStrategy } from '../opencode';
+import { opencodeGoProviderStrategy } from '../opencode-go';
+import { openrouterProviderStrategy } from '../openrouter';
+import { requestyProviderStrategy } from '../requesty';
+import { ollamaProviderStrategy } from '../ollama';
+import { lmStudioProviderStrategy } from '../lm-studio';
+
+import { envMock, profileFor, settings } from './test-utils';
+
+vi.mock('@/logger');
+
+vi.mock('@/utils/environment', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/environment')>();
+  const { envMock } = await import('./test-utils');
+  return { ...actual, getEffectiveEnvironmentVariable: envMock.getEffectiveEnvironmentVariable };
+});
+
+beforeEach(() => {
+  envMock.reset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+type MappingRow = {
+  name: string;
+  getAiderMapping: (
+    profile: ProviderProfile,
+    modelId: string,
+    settings: SettingsData,
+    projectDir: string,
+  ) => { modelName: string; environmentVariables: Record<string, string> };
+  provider: Record<string, unknown>;
+  /** model id passed to the mapping (defaults to 'm1') */
+  modelId?: string;
+  modelName: string;
+  environmentVariables: Record<string, string>;
+};
+
+const rows: MappingRow[] = [
+  {
+    name: 'groq',
+    getAiderMapping: groqProviderStrategy.getAiderMapping!,
+    provider: { name: 'groq', apiKey: 'sk-groq' },
+    modelName: 'groq/m1',
+    environmentVariables: { GROQ_API_KEY: 'sk-groq' },
+  },
+  {
+    name: 'cerebras',
+    getAiderMapping: cerebrasProviderStrategy.getAiderMapping!,
+    provider: { name: 'cerebras', apiKey: 'sk-cer' },
+    modelName: 'cerebras/m1',
+    environmentVariables: { CEREBRAS_API_KEY: 'sk-cer' },
+  },
+  {
+    name: 'mistral',
+    getAiderMapping: mistralProviderStrategy.getAiderMapping!,
+    provider: { name: 'mistral', apiKey: 'sk-mistral' },
+    modelName: 'mistral/m1',
+    environmentVariables: { MISTRAL_API_KEY: 'sk-mistral' },
+  },
+  {
+    name: 'deepseek',
+    getAiderMapping: deepseekProviderStrategy.getAiderMapping!,
+    provider: { name: 'deepseek', apiKey: 'sk-ds' },
+    modelName: 'deepseek/m1',
+    environmentVariables: { DEEPSEEK_API_KEY: 'sk-ds' },
+  },
+  {
+    name: 'openai',
+    getAiderMapping: openaiProviderStrategy.getAiderMapping!,
+    provider: { name: 'openai', apiKey: 'sk-oai' },
+    modelName: 'openai/m1',
+    environmentVariables: { OPENAI_API_BASE: '', OPENAI_API_KEY: 'sk-oai' },
+  },
+  {
+    name: 'openai-compatible',
+    getAiderMapping: openaiCompatibleProviderStrategy.getAiderMapping!,
+    provider: { name: 'custom-vllm', apiKey: 'sk-c', baseUrl: 'https://vllm.example/v1' },
+    modelName: 'openai/m1',
+    environmentVariables: { OPENAI_API_KEY: 'sk-c', OPENAI_API_BASE: 'https://vllm.example/v1' },
+  },
+  {
+    name: 'anthropic',
+    getAiderMapping: anthropicProviderStrategy.getAiderMapping!,
+    provider: { name: 'anthropic', apiKey: 'sk-ant' },
+    modelName: 'anthropic/m1',
+    environmentVariables: { ANTHROPIC_API_KEY: 'sk-ant' },
+  },
+  {
+    name: 'anthropic-compatible',
+    getAiderMapping: anthropicCompatibleProviderStrategy.getAiderMapping!,
+    provider: { name: 'anthropic-compatible', apiKey: 'sk-antc', baseUrl: 'https://api.example.com/v1' },
+    modelName: 'anthropic/m1',
+    environmentVariables: { ANTHROPIC_API_KEY: 'sk-antc', ANTHROPIC_BASE_URL: 'https://api.example.com' },
+  },
+  {
+    name: 'azure',
+    getAiderMapping: azureProviderStrategy.getAiderMapping!,
+    provider: { name: 'azure', apiKey: 'sk-az', resourceName: 'my-resource', apiVersion: '2024-12-01-preview' },
+    modelName: 'azure/m1',
+    environmentVariables: {
+      AZURE_API_KEY: 'sk-az',
+      AZURE_API_BASE: 'https://my-resource.openai.azure.com/',
+      AZURE_API_VERSION: '2024-12-01-preview',
+    },
+  },
+  {
+    name: 'bedrock',
+    getAiderMapping: bedrockProviderStrategy.getAiderMapping!,
+    provider: {
+      name: 'bedrock',
+      accessKeyId: 'AKIA-TEST',
+      secretAccessKey: 'secret',
+      region: 'us-east-1',
+      sessionToken: 'token',
+    },
+    modelName: 'bedrock/m1',
+    environmentVariables: {
+      AWS_ACCESS_KEY_ID: 'AKIA-TEST',
+      AWS_SECRET_ACCESS_KEY: 'secret',
+      AWS_DEFAULT_REGION: 'us-east-1',
+      AWS_SESSION_TOKEN: 'token',
+    },
+  },
+  {
+    name: 'vertex-ai',
+    getAiderMapping: vertexAiProviderStrategy.getAiderMapping!,
+    provider: { name: 'vertex-ai', project: 'my-project', location: 'us-central1', googleCloudCredentialsJson: '{"json":true}' },
+    modelName: 'vertex_ai/m1',
+    environmentVariables: {
+      VERTEXAI_PROJECT: 'my-project',
+      VERTEXAI_LOCATION: 'us-central1',
+      GOOGLE_APPLICATION_CREDENTIALS_JSON: '{"json":true}',
+    },
+  },
+  {
+    name: 'gemini',
+    getAiderMapping: geminiProviderStrategy.getAiderMapping!,
+    provider: { name: 'gemini', apiKey: 'sk-gem', customBaseUrl: 'https://gemini.example' },
+    modelName: 'gemini/m1',
+    environmentVariables: { GEMINI_API_KEY: 'sk-gem', GEMINI_API_BASE: 'https://gemini.example' },
+  },
+  {
+    name: 'minimax',
+    getAiderMapping: minimaxProviderStrategy.getAiderMapping!,
+    provider: { name: 'minimax', apiKey: 'sk-mmx' },
+    modelName: 'openai/m1',
+    environmentVariables: { OPENAI_API_BASE: 'https://api.minimax.io/v1', OPENAI_API_KEY: 'sk-mmx' },
+  },
+  {
+    name: 'neuralwatt',
+    getAiderMapping: neuralwattProviderStrategy.getAiderMapping!,
+    provider: { name: 'neuralwatt', apiKey: 'sk-nw' },
+    modelName: 'openai/m1',
+    environmentVariables: { OPENAI_API_KEY: 'sk-nw', OPENAI_API_BASE: 'https://api.neuralwatt.com/v1' },
+  },
+  {
+    name: 'synthetic',
+    getAiderMapping: syntheticProviderStrategy.getAiderMapping!,
+    provider: { name: 'synthetic', apiKey: 'sk-syn' },
+    modelName: 'openai/m1',
+    environmentVariables: { OPENAI_API_KEY: 'sk-syn', OPENAI_API_BASE: 'https://api.synthetic.new/openai/v1' },
+  },
+  {
+    name: 'zai-plan',
+    getAiderMapping: zaiPlanProviderStrategy.getAiderMapping!,
+    provider: { name: 'zai-plan', apiKey: 'sk-zai' },
+    modelName: 'openai/m1',
+    environmentVariables: { OPENAI_API_KEY: 'sk-zai', OPENAI_API_BASE: 'https://api.z.ai/api/coding/paas/v4' },
+  },
+  {
+    name: 'alibaba-plan',
+    getAiderMapping: alibabaPlanProviderStrategy.getAiderMapping!,
+    provider: { name: 'alibaba-plan', apiKey: 'sk-ali' },
+    modelName: 'openai/m1',
+    environmentVariables: { OPENAI_API_KEY: 'sk-ali', OPENAI_API_BASE: 'https://coding-intl.dashscope.aliyuncs.com/v1' },
+  },
+  {
+    name: 'kimi-plan',
+    getAiderMapping: kimiPlanProviderStrategy.getAiderMapping!,
+    provider: { name: 'kimi-plan', apiKey: 'sk-kimi' },
+    modelName: 'anthropic/m1',
+    environmentVariables: { ANTHROPIC_API_KEY: 'sk-kimi', ANTHROPIC_BASE_URL: 'https://api.kimi.com/coding' },
+  },
+  {
+    name: 'litellm',
+    getAiderMapping: litellmProviderStrategy.getAiderMapping!,
+    provider: { name: 'litellm', apiKey: 'sk-lite', baseUrl: 'https://proxy.example/' },
+    modelName: 'litellm/m1',
+    environmentVariables: { LITELLM_API_KEY: 'sk-lite', LITELLM_API_BASE: 'https://proxy.example' },
+  },
+  {
+    name: 'gpustack',
+    getAiderMapping: gpustackProviderStrategy.getAiderMapping!,
+    provider: { name: 'gpustack', apiKey: 'sk-gpu', baseUrl: 'https://gpu.example' },
+    modelName: 'openai/m1',
+    environmentVariables: { OPENAI_API_KEY: 'sk-gpu', OPENAI_API_BASE: 'https://gpu.example/v1-openai' },
+  },
+  {
+    name: 'clinepass',
+    getAiderMapping: clinePassProviderStrategy.getAiderMapping!,
+    provider: { name: 'clinepass', apiKey: 'sk-cline' },
+    modelName: 'openai/cline-pass/m1',
+    environmentVariables: { OPENAI_API_BASE: 'https://api.cline.bot/api/v1', OPENAI_API_KEY: 'sk-cline' },
+  },
+  {
+    name: 'opencode',
+    getAiderMapping: opencodeProviderStrategy.getAiderMapping!,
+    provider: { name: 'opencode', apiKey: 'sk-zen' },
+    modelName: 'openai/m1',
+    environmentVariables: { OPENAI_API_KEY: 'sk-zen', OPENAI_API_BASE: 'https://opencode.ai/zen/v1' },
+  },
+  {
+    name: 'opencode-go (openai endpoint)',
+    getAiderMapping: opencodeGoProviderStrategy.getAiderMapping!,
+    provider: { name: 'opencode-go', apiKey: 'sk-zengo' },
+    modelName: 'openai/m1',
+    environmentVariables: { OPENAI_API_KEY: 'sk-zengo', OPENAI_API_BASE: 'https://opencode.ai/zen/go/v1' },
+  },
+  {
+    name: 'opencode-go (anthropic endpoint)',
+    getAiderMapping: opencodeGoProviderStrategy.getAiderMapping!,
+    provider: { name: 'opencode-go', apiKey: 'sk-zengo' },
+    modelId: 'minimax-m3',
+    modelName: 'anthropic/minimax-m3',
+    environmentVariables: { ANTHROPIC_API_KEY: 'sk-zengo', ANTHROPIC_BASE_URL: 'https://opencode.ai/zen/go' },
+  },
+  {
+    name: 'openrouter',
+    getAiderMapping: openrouterProviderStrategy.getAiderMapping!,
+    provider: { name: 'openrouter', apiKey: 'sk-or' },
+    modelName: 'openrouter/m1',
+    environmentVariables: { OPENROUTER_API_KEY: 'sk-or' },
+  },
+  {
+    name: 'requesty',
+    getAiderMapping: requestyProviderStrategy.getAiderMapping!,
+    provider: { name: 'requesty', apiKey: 'sk-req' },
+    modelName: 'openai/m1',
+    environmentVariables: { OPENAI_API_BASE: 'https://router.requesty.ai/v1', OPENAI_API_KEY: 'sk-req' },
+  },
+  {
+    name: 'ollama',
+    getAiderMapping: ollamaProviderStrategy.getAiderMapping!,
+    provider: { name: 'ollama', baseUrl: 'http://localhost:11434/api' },
+    modelName: 'ollama_chat/m1',
+    environmentVariables: { OLLAMA_API_BASE: 'http://localhost:11434' },
+  },
+  {
+    name: 'lm-studio',
+    getAiderMapping: lmStudioProviderStrategy.getAiderMapping!,
+    provider: { name: 'lmstudio', baseUrl: 'http://localhost:1234/v1' },
+    modelName: 'lm_studio/m1',
+    environmentVariables: { LM_STUDIO_API_BASE: 'http://localhost:1234/v1', LM_STUDIO_API_KEY: 'dummy-api-key' },
+  },
+];
+
+describe.each(rows)('$name getAiderMapping', (row) => {
+  it('locks the modelName prefix and environmentVariables (explicit apiKey)', () => {
+    expect(row.getAiderMapping(profileFor(row.provider), row.modelId ?? 'm1', settings, '/proj')).toEqual({
+      modelName: row.modelName,
+      environmentVariables: row.environmentVariables,
+    });
+  });
+});
+
+describe('edge cases', () => {
+  it('openai mapping clears OPENAI_API_BASE even without an apiKey', () => {
+    const mapping = openaiProviderStrategy.getAiderMapping!(profileFor({ name: 'openai' }), 'm1', settings, '/proj');
+    expect(mapping).toEqual({ modelName: 'openai/m1', environmentVariables: { OPENAI_API_BASE: '' } });
+  });
+
+  it('anthropic-compatible appends /v1 removal only: bare baseUrl passed through untouched', () => {
+    const mapping = anthropicCompatibleProviderStrategy.getAiderMapping!(
+      profileFor({ name: 'anthropic-compatible', apiKey: 'sk-antc', baseUrl: 'https://api.example.com' }),
+      'm1',
+      settings,
+      '/proj',
+    );
+    expect(mapping.environmentVariables.ANTHROPIC_BASE_URL).toBe('https://api.example.com');
+  });
+
+  it('opencode-go selects the anthropic shape purely from the model id', () => {
+    const mapping = opencodeGoProviderStrategy.getAiderMapping!(profileFor({ name: 'opencode-go', apiKey: 'sk-zengo' }), 'gpt-5.6-luna', settings, '/proj');
+    expect(mapping.modelName).toBe('openai/gpt-5.6-luna');
+    expect(mapping.environmentVariables).toEqual({
+      OPENAI_API_KEY: 'sk-zengo',
+      OPENAI_API_BASE: 'https://opencode.ai/zen/go/v1',
+    });
+  });
+
+  it('providers with no credential in the mapping produce no env key (no throw)', () => {
+    const mapping = groqProviderStrategy.getAiderMapping!(profileFor({ name: 'groq' }), 'm1', settings, '/proj');
+    expect(mapping).toEqual({ modelName: 'groq/m1', environmentVariables: {} });
+    expect(envMock.lookups).toEqual([]);
+  });
+
+  // Each provider name maps to its own strategy object so every it.each iteration
+  // genuinely exercises that provider's getAiderMapping (previously all five
+  // iterations ran the synthetic strategy, leaving the other four untested).
+  const strategiesWithEnvFallback = {
+    synthetic: syntheticProviderStrategy,
+    'zai-plan': zaiPlanProviderStrategy,
+    'kimi-plan': kimiPlanProviderStrategy,
+    'alibaba-plan': alibabaPlanProviderStrategy,
+    minimax: minimaxProviderStrategy,
+  };
+
+  it.each(['synthetic', 'zai-plan', 'kimi-plan', 'alibaba-plan', 'minimax'] as const)('%s: explicit provider.apiKey wins over the env fallback', (name) => {
+    // No env mock value is queued: with an explicit provider key these strategies
+    // must not consult the env fallback at all, so a mockReturnValueOnce would
+    // pile up unused. The absence of any env lookup is asserted via envMock.lookups.
+    const mapping = strategiesWithEnvFallback[name].getAiderMapping!(profileFor({ name, apiKey: 'sk-explicit' }), 'm1', settings, '/proj');
+
+    const keyEnvVar = Object.entries(mapping.environmentVariables).find(([key]) => /API_KEY/.test(key))!;
+    expect(keyEnvVar[1]).toBe('sk-explicit');
+    // with an explicit key the env fallback must not even be consulted
+    expect(envMock.lookups).toEqual([]);
+  });
+
+  it('kills the trailing /api from ollama base URLs', () => {
+    const mapping = ollamaProviderStrategy.getAiderMapping!(profileFor({ name: 'ollama', baseUrl: 'http://host:11434' }), 'm1', settings, '/proj');
+    expect(mapping.environmentVariables).toEqual({ OLLAMA_API_BASE: 'http://host:11434' });
+  });
+});

--- a/src/main/models/providers/__tests__/create-llm-snapshots.test.ts
+++ b/src/main/models/providers/__tests__/create-llm-snapshots.test.ts
@@ -1,0 +1,695 @@
+/**
+ * Phase 0 behavior-locking tests for create<L>Llm credential resolution and SDK factory args.
+ *
+ * These tests snapshot the CURRENT behavior of every simple/compatible provider's createLlm:
+ *  - explicit profile.provider.apiKey is forwarded to the SDK factory, with profile.headers
+ *  - missing apiKey falls back to the provider-specific env var via getEffectiveEnvironmentVariable
+ *  - no credential at all throws the current (exact) API-key error message
+ *  - baseUrl/customBaseUrl/endpoint dispatch behavior is locked as-is (no normalization yet)
+ *
+ * One known inconsistency is still intentionally locked (see the azure Phase 0
+ * resource-name note below) so a refactor must either preserve it or update that
+ * test deliberately.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Model, ProviderProfile, SettingsData } from '@common/types';
+
+import { groqProviderStrategy } from '../groq';
+import { cerebrasProviderStrategy } from '../cerebras';
+import { mistralProviderStrategy } from '../mistral';
+import { deepseekProviderStrategy } from '../deepseek';
+import { openaiProviderStrategy } from '../openai';
+import { openaiCompatibleProviderStrategy } from '../openai-compatible';
+import { anthropicProviderStrategy } from '../anthropic';
+import { anthropicCompatibleProviderStrategy } from '../anthropic-compatible';
+import { azureProviderStrategy } from '../azure';
+import { geminiProviderStrategy } from '../gemini';
+import { minimaxProviderStrategy } from '../minimax';
+import { neuralwattProviderStrategy } from '../neuralwatt';
+import { syntheticProviderStrategy } from '../synthetic';
+import { zaiPlanProviderStrategy } from '../zai-plan';
+import { alibabaPlanProviderStrategy } from '../alibaba-plan';
+import { kimiPlanProviderStrategy } from '../kimi-plan';
+import { gpustackProviderStrategy } from '../gpustack';
+import { clinePassProviderStrategy } from '../clinepass';
+import { opencodeProviderStrategy } from '../opencode';
+import { opencodeGoProviderStrategy } from '../opencode-go';
+import { openrouterProviderStrategy } from '../openrouter';
+import { requestyProviderStrategy } from '../requesty';
+import { litellmProviderStrategy } from '../litellm';
+import { ollamaProviderStrategy } from '../ollama';
+import { lmStudioProviderStrategy } from '../lm-studio';
+
+import { envMock, model, profileFor, sdkMock, settings } from './test-utils';
+
+vi.mock('@/logger');
+
+vi.mock('@/utils/environment', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/environment')>();
+  const { envMock } = await import('./test-utils');
+  return {
+    ...actual,
+    getEffectiveEnvironmentVariable: envMock.getEffectiveEnvironmentVariable,
+  };
+});
+
+// ---------------------------------------------------------------------------
+// SDK factory mocks — every factory records (callArgs, modelId, call kind)
+// and returns a sentinel object so tests can assert identity through the
+// whole chain (factory -> provider instance -> model call).
+// ---------------------------------------------------------------------------
+vi.mock('@ai-sdk/openai', async () => {
+  const { sdkMock } = await import('./test-utils');
+  return { createOpenAI: sdkMock.provider('createOpenAI') };
+});
+vi.mock('@ai-sdk/anthropic', async () => {
+  const { sdkMock } = await import('./test-utils');
+  return { createAnthropic: sdkMock.provider('createAnthropic') };
+});
+vi.mock('@ai-sdk/google', async () => {
+  const { sdkMock } = await import('./test-utils');
+  return {
+    createGoogle: sdkMock.provider('createGoogle'),
+    google: { tools: { googleSearch: () => ({}) } },
+  };
+});
+vi.mock('@ai-sdk/groq', async () => {
+  const { sdkMock } = await import('./test-utils');
+  return { createGroq: sdkMock.provider('createGroq') };
+});
+vi.mock('@ai-sdk/cerebras', async () => {
+  const { sdkMock } = await import('./test-utils');
+  return { createCerebras: sdkMock.provider('createCerebras') };
+});
+vi.mock('@ai-sdk/mistral', async () => {
+  const { sdkMock } = await import('./test-utils');
+  return { createMistral: sdkMock.provider('createMistral') };
+});
+vi.mock('@ai-sdk/deepseek', async () => {
+  const { sdkMock } = await import('./test-utils');
+  return { createDeepSeek: sdkMock.provider('createDeepSeek') };
+});
+vi.mock('@ai-sdk/azure', async () => {
+  const { sdkMock } = await import('./test-utils');
+  return { createAzure: sdkMock.provider('createAzure') };
+});
+vi.mock('@ai-sdk/alibaba', async () => {
+  const { sdkMock } = await import('./test-utils');
+  return { createAlibaba: sdkMock.provider('createAlibaba') };
+});
+vi.mock('@ai-sdk/openai-compatible', async () => {
+  const { sdkMock } = await import('./test-utils');
+  return { createOpenAICompatible: sdkMock.provider('createOpenAICompatible') };
+});
+vi.mock('@openrouter/ai-sdk-provider', async () => {
+  const { sdkMock } = await import('./test-utils');
+  return { createOpenRouter: sdkMock.provider('createOpenRouter') };
+});
+vi.mock('@requesty/ai-sdk', async () => {
+  const { sdkMock } = await import('./test-utils');
+  return { createRequesty: sdkMock.provider('createRequesty') };
+});
+vi.mock('ollama-ai-provider-v2', async () => {
+  const { sdkMock } = await import('./test-utils');
+  return { createOllama: sdkMock.provider('createOllama') };
+});
+vi.mock('ai', () => ({
+  wrapLanguageModel: ({ model }: { model: unknown }) => ({ wrapped: model }),
+  simulateStreamingMiddleware: () => ({ simulate: true }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+const makeProfile = (provider: Record<string, unknown>): ProviderProfile => profileFor(provider, { 'X-Test': 'hdr' });
+
+const call = (factory: string, kind = 'model') => {
+  const matches = sdkMock.calls.filter((c) => c.factory === factory && c.kind === kind);
+  expect(matches, `expected exactly one ${factory} ${kind} call`).toHaveLength(1);
+  return matches[0];
+};
+
+beforeEach(() => {
+  sdkMock.reset();
+  envMock.reset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+type ApiKeyRow = {
+  name: string;
+  createLlm: (profile: ProviderProfile, model: Model, settings: SettingsData, projectDir: string) => unknown;
+  provider: Record<string, unknown>;
+  /** expected subset of the args passed to the SDK factory (on the explicit-apiKey path) */
+  callArgs: Record<string, unknown>;
+  factory: string;
+  kind?: 'model' | 'responses' | 'chat';
+  /** env var consulted when provider.apiKey is missing */
+  envKey: string;
+  /** expected model id on the factory call (defaults to 'm1') */
+  modelCall?: string;
+  /** env lookups expected on the explicit-apiKey path (defaults to none) */
+  expectedLookups?: string[];
+  /** exact error when no credential exists anywhere */
+  error: string;
+};
+
+// Standard "apiKey in provider -> env -> throw" providers.
+const apiKeyRows: ApiKeyRow[] = [
+  {
+    name: 'groq',
+    createLlm: groqProviderStrategy.createLlm,
+    provider: { name: 'groq', apiKey: 'sk-groq' },
+    callArgs: { apiKey: 'sk-groq' },
+    factory: 'createGroq',
+    envKey: 'GROQ_API_KEY',
+    error: 'Groq API key is required in Providers settings or Aider environment variables (GROQ_API_KEY)',
+  },
+  {
+    name: 'cerebras',
+    createLlm: cerebrasProviderStrategy.createLlm,
+    provider: { name: 'cerebras', apiKey: 'sk-cer' },
+    callArgs: { apiKey: 'sk-cer' },
+    factory: 'createCerebras',
+    envKey: 'CEREBRAS_API_KEY',
+    error: 'Cerebras API key is required in Providers settings or Aider environment variables (CEREBRAS_API_KEY)',
+  },
+  {
+    name: 'mistral',
+    createLlm: mistralProviderStrategy.createLlm,
+    provider: { name: 'mistral', apiKey: 'sk-mistral' },
+    callArgs: { apiKey: 'sk-mistral' },
+    factory: 'createMistral',
+    envKey: 'MISTRAL_API_KEY',
+    error: 'Mistral API key is required in Providers settings or Aider environment variables (MISTRAL_API_KEY)',
+  },
+  {
+    name: 'deepseek',
+    createLlm: deepseekProviderStrategy.createLlm,
+    provider: { name: 'deepseek', apiKey: 'sk-ds' },
+    callArgs: { apiKey: 'sk-ds' },
+    factory: 'createDeepSeek',
+    envKey: 'DEEPSEEK_API_KEY',
+    error: 'Deepseek API key is required in Providers settings or Aider environment variables (DEEPSEEK_API_KEY)',
+  },
+  {
+    name: 'openai',
+    createLlm: openaiProviderStrategy.createLlm,
+    provider: { name: 'openai', apiKey: 'sk-oai' },
+    callArgs: { apiKey: 'sk-oai' },
+    factory: 'createOpenAI',
+    envKey: 'OPENAI_API_KEY',
+    error: 'OpenAI API key is required in Providers settings or Aider environment variables (OPENAI_API_KEY)',
+  },
+  {
+    name: 'anthropic',
+    createLlm: anthropicProviderStrategy.createLlm,
+    provider: { name: 'anthropic', apiKey: 'sk-ant' },
+    callArgs: { apiKey: 'sk-ant' },
+    factory: 'createAnthropic',
+    envKey: 'ANTHROPIC_API_KEY',
+    error: 'Anthropic API key is required in Providers settings or Aider environment variables (ANTHROPIC_API_KEY)',
+  },
+  {
+    name: 'azure',
+    createLlm: azureProviderStrategy.createLlm,
+    provider: { name: 'azure', apiKey: 'sk-az', resourceName: 'test-resource' },
+    callArgs: { apiKey: 'sk-az', resourceName: 'test-resource' },
+    factory: 'createAzure',
+    kind: 'responses',
+    envKey: 'AZURE_API_KEY',
+    error: 'Azure OpenAI API key is required in Providers settings or Aider environment variables (AZURE_API_KEY)',
+  },
+  {
+    name: 'gemini',
+    createLlm: geminiProviderStrategy.createLlm,
+    provider: { name: 'gemini', apiKey: 'sk-gem' },
+    callArgs: { apiKey: 'sk-gem', baseURL: undefined },
+    factory: 'createGoogle',
+    envKey: 'GEMINI_API_KEY',
+    expectedLookups: ['GEMINI_API_BASE_URL'],
+    error: 'Gemini API key is required in Providers settings or Aider environment variables (GEMINI_API_KEY)',
+  },
+  {
+    name: 'minimax',
+    createLlm: minimaxProviderStrategy.createLlm,
+    provider: { name: 'minimax', apiKey: 'sk-mmx' },
+    callArgs: { apiKey: 'sk-mmx', baseURL: 'https://api.minimax.io/anthropic/v1' },
+    factory: 'createAnthropic',
+    envKey: 'MINIMAX_API_KEY',
+    error: 'Minimax API key is required in Providers settings or Aider environment variables (MINIMAX_API_KEY)',
+  },
+  {
+    name: 'neuralwatt',
+    createLlm: neuralwattProviderStrategy.createLlm,
+    provider: { name: 'neuralwatt', apiKey: 'sk-nw' },
+    callArgs: { name: 'neuralwatt', apiKey: 'sk-nw', baseURL: 'https://api.neuralwatt.com/v1' },
+    factory: 'createOpenAICompatible',
+    envKey: 'NEURALWATT_API_KEY',
+    error: 'Neuralwatt API key is required in Providers settings or Aider environment variables (NEURALWATT_API_KEY)',
+  },
+  {
+    name: 'synthetic',
+    createLlm: syntheticProviderStrategy.createLlm,
+    provider: { name: 'synthetic', apiKey: 'sk-syn' },
+    callArgs: { name: 'synthetic', apiKey: 'sk-syn', baseURL: 'https://api.synthetic.new/openai/v1' },
+    factory: 'createOpenAICompatible',
+    envKey: 'SYNTHETIC_API_KEY',
+    error: 'API key is required for synthetic. Check Providers settings or Aider environment variables (SYNTHETIC_API_KEY).',
+  },
+  {
+    name: 'zai-plan',
+    createLlm: zaiPlanProviderStrategy.createLlm,
+    provider: { name: 'zai-plan', apiKey: 'sk-zai' },
+    callArgs: { name: 'zai-plan', apiKey: 'sk-zai', baseURL: 'https://api.z.ai/api/coding/paas/v4' },
+    factory: 'createOpenAICompatible',
+    envKey: 'ZAI_API_KEY',
+    error: 'API key is required for zai-plan. Check Providers settings or Aider environment variables (ZAI_API_KEY).',
+  },
+  {
+    name: 'alibaba-plan',
+    createLlm: alibabaPlanProviderStrategy.createLlm,
+    provider: { name: 'alibaba-plan', apiKey: 'sk-ali' },
+    callArgs: { apiKey: 'sk-ali', baseURL: 'https://coding-intl.dashscope.aliyuncs.com/v1' },
+    factory: 'createAlibaba',
+    envKey: 'ALIBABA_PLAN_API_KEY',
+    error: 'API key is required for alibaba-plan. Check Providers settings or Aider environment variables (ALIBABA_PLAN_API_KEY).',
+  },
+  {
+    name: 'kimi-plan',
+    createLlm: kimiPlanProviderStrategy.createLlm,
+    provider: { name: 'kimi-plan', apiKey: 'sk-kimi' },
+    callArgs: { apiKey: 'sk-kimi', baseURL: 'https://api.kimi.com/coding/v1' },
+    factory: 'createAnthropic',
+    envKey: 'KIMI_PLAN_API_KEY',
+    error: 'API key is required for kimi-plan. Check Providers settings or Aider environment variables (KIMI_PLAN_API_KEY).',
+  },
+  {
+    name: 'gpustack',
+    createLlm: gpustackProviderStrategy.createLlm,
+    provider: { name: 'gpustack', apiKey: 'sk-gpu', baseUrl: 'https://gpu.example' },
+    callArgs: { name: 'gpustack', apiKey: 'sk-gpu', baseURL: 'https://gpu.example/v1-openai' },
+    factory: 'createOpenAICompatible',
+    envKey: 'GPUSTACK_API_KEY',
+    error: 'API key is required for gpustack. Check Providers settings or Aider environment variables (GPUSTACK_API_KEY).',
+  },
+  {
+    name: 'clinepass',
+    createLlm: clinePassProviderStrategy.createLlm,
+    provider: { name: 'clinepass', apiKey: 'sk-cline' },
+    callArgs: { name: 'clinepass', apiKey: 'sk-cline', baseURL: 'https://api.cline.bot/api/v1' },
+    factory: 'createOpenAICompatible',
+    modelCall: 'cline-pass/m1',
+    envKey: 'CLINE_API_KEY',
+    // resolveApiKey always consults CLINE_API_KEY, even with an explicit apiKey set
+    expectedLookups: ['CLINE_API_KEY'],
+    error: 'ClinePass API key is required in Providers settings or Aider environment variables (CLINE_API_KEY)',
+  },
+  {
+    name: 'opencode',
+    createLlm: opencodeProviderStrategy.createLlm,
+    provider: { name: 'opencode', apiKey: 'sk-zen' },
+    callArgs: { name: 'opencode', apiKey: 'sk-zen' },
+    factory: 'createOpenAICompatible',
+    envKey: 'OPENCODE_API_KEY',
+    error: 'OpenCode API key is required in Providers settings or Aider environment variables (OPENCODE_API_KEY)',
+  },
+  {
+    name: 'opencode-go',
+    createLlm: opencodeGoProviderStrategy.createLlm,
+    provider: { name: 'opencode-go', apiKey: 'sk-zengo' },
+    callArgs: { name: 'opencode-go', apiKey: 'sk-zengo' },
+    factory: 'createOpenAICompatible',
+    envKey: 'OPENCODE_GO_API_KEY',
+    error: 'OpenCode Go API key is required in Providers settings or Aider environment variables (OPENCODE_GO_API_KEY)',
+  },
+  {
+    name: 'openrouter',
+    createLlm: openrouterProviderStrategy.createLlm,
+    provider: { name: 'openrouter', apiKey: 'sk-or' },
+    callArgs: { apiKey: 'sk-or', compatibility: 'strict' },
+    factory: 'createOpenRouter',
+    kind: 'chat',
+    envKey: 'OPENROUTER_API_KEY',
+    error: 'OpenRouter API key is required in Providers settings or Aider environment variables (OPENROUTER_API_KEY)',
+  },
+  {
+    name: 'requesty',
+    createLlm: requestyProviderStrategy.createLlm,
+    provider: { name: 'requesty', apiKey: 'sk-req' },
+    callArgs: { apiKey: 'sk-req', compatibility: 'strict' },
+    factory: 'createRequesty',
+    envKey: 'REQUESTY_API_KEY',
+    error: 'Requesty API key is required in Providers settings or Aider environment variables (REQUESTY_API_KEY)',
+  },
+  {
+    name: 'anthropic-compatible',
+    createLlm: anthropicCompatibleProviderStrategy.createLlm,
+    provider: { name: 'anthropic-compatible', apiKey: 'sk-antc', baseUrl: 'https://api.example.com' },
+    callArgs: { apiKey: 'sk-antc', baseURL: 'https://api.example.com/v1' },
+    factory: 'createAnthropic',
+    envKey: 'ANTHROPIC_API_KEY',
+    error: 'API key is required for anthropic-compatible. Check Providers settings or Aider environment variables (ANTHROPIC_API_KEY).',
+  },
+];
+
+describe.each(apiKeyRows)('$name createLlm', (row) => {
+  it('forwards explicit apiKey, profile headers and model id to the SDK factory', () => {
+    const result = row.createLlm(makeProfile(row.provider), model(), settings, '/proj');
+
+    const c = call(row.factory, row.kind ?? 'model');
+    const modelId = row.modelCall ?? 'm1';
+    expect(c.model).toBe(modelId);
+    expect(c.callArgs).toMatchObject({ ...row.callArgs, headers: { 'X-Test': 'hdr' } });
+    expect(result).toEqual(
+      row.kind && row.kind !== 'model' ? { sentinel: `${row.factory}:${row.kind}:${modelId}` } : { sentinel: `${row.factory}:${modelId}` },
+    );
+
+    // explicit apiKey must short-circuit credential env resolution
+    expect(envMock.lookups).toEqual(row.expectedLookups ?? []);
+  });
+
+  it('falls back to the provider env var when apiKey is missing', () => {
+    envMock.vars.set(row.envKey, { value: 'env-key', source: 'environment' });
+    const provider = { ...row.provider, apiKey: undefined };
+
+    row.createLlm(makeProfile(provider), model(), settings, '/proj');
+
+    expect(envMock.lookups[0]).toBe(row.envKey);
+    const c = call(row.factory, row.kind ?? 'model');
+    expect(c.callArgs).toMatchObject({ ...row.callArgs, apiKey: 'env-key' });
+  });
+
+  it(`throws the current error when no credential exists: "${row.name}"`, () => {
+    const provider = { ...row.provider, apiKey: undefined };
+    expect(() => row.createLlm(makeProfile(provider), model(), settings, '/proj')).toThrow(row.error);
+  });
+});
+
+describe('baseUrl forwarding (current behavior)', () => {
+  it('gemini forwards customBaseUrl to createGoogle baseURL', () => {
+    geminiProviderStrategy.createLlm(makeProfile({ name: 'gemini', apiKey: 'sk-gem', customBaseUrl: 'https://gemini.example' }), model(), settings, '/proj');
+
+    const c = call('createGoogle');
+    expect(c.callArgs).toMatchObject({ apiKey: 'sk-gem', baseURL: 'https://gemini.example' });
+  });
+
+  it('anthropic-compatible appends /v1 to bare base URLs', () => {
+    anthropicCompatibleProviderStrategy.createLlm(
+      makeProfile({ name: 'anthropic-compatible', apiKey: 'sk-antc', baseUrl: 'https://api.example.com' }),
+      model(),
+      settings,
+      '/proj',
+    );
+
+    expect(call('createAnthropic').callArgs).toMatchObject({ baseURL: 'https://api.example.com/v1' });
+  });
+
+  it('anthropic-compatible does not double-append /v1', () => {
+    anthropicCompatibleProviderStrategy.createLlm(
+      makeProfile({ name: 'anthropic-compatible', apiKey: 'sk-antc', baseUrl: 'https://api.example.com/v1' }),
+      model(),
+      settings,
+      '/proj',
+    );
+
+    expect(call('createAnthropic').callArgs).toMatchObject({ baseURL: 'https://api.example.com/v1' });
+  });
+
+  it('gpustack appends /v1-openai to the configured baseUrl', () => {
+    gpustackProviderStrategy.createLlm(makeProfile({ name: 'gpustack', apiKey: 'sk-gpu', baseUrl: 'https://gpu.example' }), model(), settings, '/proj');
+
+    expect(call('createOpenAICompatible').callArgs).toMatchObject({ baseURL: 'https://gpu.example/v1-openai' });
+  });
+});
+
+describe('openai-compatible createLlm', () => {
+  const create = (provider: Record<string, unknown>) => openaiCompatibleProviderStrategy.createLlm!(makeProfile(provider), model(), settings, '/proj');
+
+  it('forwards provider name, apiKey, baseUrl and includeUsage to createOpenAICompatible', () => {
+    const provider = { name: 'my-vllm', apiKey: 'sk-c', baseUrl: 'https://vllm.example/v1', trackTokenUsage: false };
+    const result = create(provider);
+
+    const c = call('createOpenAICompatible');
+    expect(c.model).toBe('m1');
+    expect(c.callArgs).toMatchObject({
+      name: 'my-vllm',
+      apiKey: 'sk-c',
+      baseURL: 'https://vllm.example/v1',
+      includeUsage: false,
+      headers: { 'X-Test': 'hdr' },
+    });
+    expect(result).toEqual({ sentinel: 'createOpenAICompatible:m1' });
+  });
+
+  it('defaults includeUsage to true when trackTokenUsage is unset', () => {
+    create({ name: 'my-vllm', apiKey: 'sk-c', baseUrl: 'https://vllm.example/v1' });
+    expect(call('createOpenAICompatible').callArgs).toMatchObject({ includeUsage: true });
+  });
+
+  it('resolves OPENAI_API_KEY and OPENAI_API_BASE from the environment', () => {
+    envMock.vars.set('OPENAI_API_KEY', { value: 'env-oai', source: 'environment' });
+    envMock.vars.set('OPENAI_API_BASE', { value: 'https://env-vllm/v1', source: 'environment' });
+
+    create({ name: 'my-vllm' });
+
+    expect(envMock.lookups).toEqual(['OPENAI_API_KEY', 'OPENAI_API_BASE']);
+    expect(call('createOpenAICompatible').callArgs).toMatchObject({ apiKey: 'env-oai', baseURL: 'https://env-vllm/v1' });
+  });
+
+  it('does not throw when only the API key is missing (apiKey is optional)', () => {
+    expect(() => create({ name: 'my-vllm', baseUrl: 'https://vllm.example/v1' })).not.toThrow();
+  });
+
+  it('throws the current error when no baseUrl exists', () => {
+    expect(() => create({ name: 'my-vllm' })).toThrow(
+      'Base URL is required for my-vllm provider. Set it in Providers settings or via the OPENAI_API_BASE environment variable.',
+    );
+  });
+
+  it('rejects an explicitly empty OPENAI_API_BASE env value like the pre-refactor !baseUrl check did', () => {
+    // Regression: the generated descriptor strategy used to only reject an *absent*
+    // base URL, so OPENAI_API_BASE='' reached the SDK factory as baseURL: ''.
+    envMock.vars.set('OPENAI_API_BASE', { value: '', source: 'environment' });
+    expect(() => create({ name: 'my-vllm' })).toThrow(
+      'Base URL is required for my-vllm provider. Set it in Providers settings or via the OPENAI_API_BASE environment variable.',
+    );
+  });
+
+  it('rejects an explicitly empty provider baseUrl field', () => {
+    expect(() => create({ name: 'my-vllm', baseUrl: '' })).toThrow(
+      'Base URL is required for my-vllm provider. Set it in Providers settings or via the OPENAI_API_BASE environment variable.',
+    );
+  });
+});
+
+describe('litellm createLlm', () => {
+  const create = (provider: Record<string, unknown>) => litellmProviderStrategy.createLlm!(makeProfile(provider), model(), settings, '/proj');
+
+  it('forwards LITELLM_API_KEY env-fallback and stripped baseUrl', () => {
+    envMock.vars.set('LITELLM_API_KEY', { value: 'env-lite', source: 'environment' });
+    envMock.vars.set('LITELLM_API_BASE', { value: 'https://proxy.example', source: 'environment' });
+
+    create({ name: 'litellm' });
+
+    expect(envMock.lookups).toEqual(['LITELLM_API_KEY', 'LITELLM_API_BASE']);
+    const c = call('createOpenAICompatible');
+    expect(c.callArgs).toMatchObject({ name: 'litellm', apiKey: 'env-lite', baseURL: 'https://proxy.example', includeUsage: true });
+  });
+
+  it('keeps a trailing slash from a provider-configured baseUrl intact in createLlm (set only stripped in the Aider mapping)', () => {
+    create({ name: 'litellm', apiKey: 'sk-lite', baseUrl: 'https://proxy.example/' });
+    expect(call('createOpenAICompatible').callArgs).toMatchObject({ baseURL: 'https://proxy.example/' });
+  });
+
+  it('throws the current error when no baseUrl exists', () => {
+    expect(() => create({ name: 'litellm', apiKey: 'sk-lite' })).toThrow('Base URL is required for LiteLLM provider');
+  });
+});
+
+describe('ollama createLlm', () => {
+  it('normalizes the base URL with a trailing /api and strips trailing slashes', () => {
+    const result = ollamaProviderStrategy.createLlm!(makeProfile({ name: 'ollama', baseUrl: 'http://localhost:11434/' }), model(), settings, '/proj');
+
+    const c = call('createOllama');
+    expect(c.callArgs).toMatchObject({ baseURL: 'http://localhost:11434/api', headers: { 'X-Test': 'hdr' } });
+    expect(result).toEqual({ wrapped: { sentinel: 'createOllama:m1' } });
+  });
+
+  it('does not double-append /api', () => {
+    ollamaProviderStrategy.createLlm!(makeProfile({ name: 'ollama', baseUrl: 'http://localhost:11434/api' }), model(), settings, '/proj');
+    expect(call('createOllama').callArgs).toMatchObject({ baseURL: 'http://localhost:11434/api' });
+  });
+
+  it('resolves OLLAMA_API_BASE env var and throws the current error when missing', () => {
+    expect(() => ollamaProviderStrategy.createLlm!(makeProfile({ name: 'ollama' }), model(), settings, '/proj')).toThrow(
+      'Base URL is required for Ollama provider. Set it in Providers settings or via the OLLAMA_API_BASE environment variable.',
+    );
+
+    envMock.vars.set('OLLAMA_API_BASE', { value: 'http://env-ollama:11434', source: 'environment' });
+    envMock.lookups.length = 0;
+    ollamaProviderStrategy.createLlm!(makeProfile({ name: 'ollama' }), model(), settings, '/proj');
+    expect(envMock.lookups).toEqual(['OLLAMA_API_BASE']);
+    expect(call('createOllama').callArgs).toMatchObject({ baseURL: 'http://env-ollama:11434/api' });
+  });
+});
+
+describe('lm-studio createLlm', () => {
+  it('forwards baseUrl with the lmstudio name and includeUsage true', () => {
+    lmStudioProviderStrategy.createLlm!(makeProfile({ name: 'lmstudio', baseUrl: 'http://localhost:1234/v1' }), model(), settings, '/proj');
+    expect(call('createOpenAICompatible').callArgs).toMatchObject({
+      name: 'lmstudio',
+      baseURL: 'http://localhost:1234/v1',
+      includeUsage: true,
+    });
+  });
+
+  it('resolves LMSTUDIO_API_BASE env var and throws the current error when missing', () => {
+    expect(() => lmStudioProviderStrategy.createLlm!(makeProfile({ name: 'lmstudio' }), model(), settings, '/proj')).toThrow(
+      'Base URL is required for LMStudio provider. Set it in Providers settings or via the LMSTUDIO_API_BASE environment variable.',
+    );
+
+    envMock.vars.set('LMSTUDIO_API_BASE', { value: 'http://env-lms/v1', source: 'environment' });
+    envMock.lookups.length = 0;
+    lmStudioProviderStrategy.createLlm!(makeProfile({ name: 'lmstudio' }), model(), settings, '/proj');
+    expect(envMock.lookups).toEqual(['LMSTUDIO_API_BASE']);
+    expect(call('createOpenAICompatible').callArgs).toMatchObject({ baseURL: 'http://env-lms/v1' });
+  });
+});
+
+describe('clinepass model id prefixing', () => {
+  it('prefixes the model id with cline-pass/', () => {
+    clinePassProviderStrategy.createLlm!(makeProfile({ name: 'clinepass', apiKey: 'sk-cline' }), model('kimi-k2.6'), settings, '/proj');
+
+    const c = call('createOpenAICompatible');
+    expect(c.model).toBe('cline-pass/kimi-k2.6');
+    expect(c.callArgs).toMatchObject({ name: 'clinepass', baseURL: 'https://api.cline.bot/api/v1' });
+  });
+});
+
+describe('opencode endpoint dispatch', () => {
+  const create = (modelId: string) =>
+    opencodeProviderStrategy.createLlm!(makeProfile({ name: 'opencode', apiKey: 'sk-zen' }), model(modelId), settings, '/proj');
+
+  it('dispatches gpt-* model ids to createOpenAI', () => {
+    expect(create('gpt-5.2')).toEqual({ sentinel: 'createOpenAI:gpt-5.2' });
+    expect(call('createOpenAI').callArgs).toMatchObject({ apiKey: 'sk-zen', baseURL: 'https://opencode.ai/zen/v1' });
+  });
+
+  it('dispatches claude-* model ids to createAnthropic', () => {
+    expect(create('claude-sonnet-4-5')).toEqual({ sentinel: 'createAnthropic:claude-sonnet-4-5' });
+    expect(call('createAnthropic').callArgs).toMatchObject({ apiKey: 'sk-zen', baseURL: 'https://opencode.ai/zen/v1' });
+  });
+
+  it('dispatches gemini-* model ids to createGoogle', () => {
+    expect(create('gemini-3-flash')).toEqual({ sentinel: 'createGoogle:gemini-3-flash' });
+    expect(call('createGoogle').callArgs).toMatchObject({ apiKey: 'sk-zen', baseURL: 'https://opencode.ai/zen/v1' });
+  });
+
+  it('falls back to createOpenAICompatible for other model ids', () => {
+    expect(create('qwen3-coder')).toEqual({ sentinel: 'createOpenAICompatible:qwen3-coder' });
+    expect(call('createOpenAICompatible').callArgs).toMatchObject({ name: 'opencode', apiKey: 'sk-zen', baseURL: 'https://opencode.ai/zen/v1' });
+  });
+});
+
+describe('opencode-go endpoint dispatch', () => {
+  const create = (modelId: string) =>
+    opencodeGoProviderStrategy.createLlm!(makeProfile({ name: 'opencode-go', apiKey: 'sk-zengo' }), model(modelId), settings, '/proj');
+
+  it('uses the OpenAI responses endpoint for documented openai-responses models', () => {
+    expect(create('grok-4.5')).toEqual({ sentinel: 'createOpenAI:responses:grok-4.5' });
+    expect(call('createOpenAI', 'responses').callArgs).toMatchObject({ apiKey: 'sk-zengo', baseURL: 'https://opencode.ai/zen/go/v1' });
+  });
+
+  it('falls back to openai-responses for unknown gpt-* model ids', () => {
+    expect(create('gpt-9-beta')).toEqual({ sentinel: 'createOpenAI:responses:gpt-9-beta' });
+    expect(call('createOpenAI', 'responses').model).toBe('gpt-9-beta');
+  });
+
+  it('uses the Anthropic endpoint for documented anthropic models', () => {
+    expect(create('minimax-m3')).toEqual({ sentinel: 'createAnthropic:minimax-m3' });
+    expect(call('createAnthropic').callArgs).toMatchObject({ apiKey: 'sk-zengo', baseURL: 'https://opencode.ai/zen/go/v1' });
+  });
+
+  it('falls back to Anthropic for unknown minimax-*/qwen* model ids', () => {
+    expect(create('minimax-m9')).toEqual({ sentinel: 'createAnthropic:minimax-m9' });
+  });
+
+  it('falls back to createOpenAICompatible for everything else', () => {
+    expect(create('glmv-demo')).toEqual({ sentinel: 'createOpenAICompatible:glmv-demo' });
+    expect(call('createOpenAICompatible').callArgs).toMatchObject({ name: 'opencode-go', baseURL: 'https://opencode.ai/zen/go/v1' });
+  });
+});
+
+describe('openrouter createLlm', () => {
+  it('adds AiderDesk referer/title headers and calls the chat endpoint with usage tracking', () => {
+    const result = openrouterProviderStrategy.createLlm!(makeProfile({ name: 'openrouter', apiKey: 'sk-or' }), model(), settings, '/proj');
+
+    const c = call('createOpenRouter', 'chat');
+    expect(c.callArgs).toMatchObject({
+      apiKey: 'sk-or',
+      compatibility: 'strict',
+      headers: {
+        'X-Test': 'hdr',
+        'HTTP-Referer': expect.any(String),
+        'X-Title': expect.any(String),
+      },
+      extraBody: { provider: expect.any(Object) },
+    });
+    expect(c.options).toEqual({ usage: { include: true } });
+    expect(result).toEqual({ sentinel: 'createOpenRouter:chat:m1' });
+  });
+});
+
+describe('zai-plan credential resolution (unified on ZAI_API_KEY — Phase 1 fix)', () => {
+  it('resolves ZAI_API_KEY in createLlm the same way loadModels and the Aider mapping do', () => {
+    envMock.vars.set('ZAI_API_KEY', { value: 'env-zai', source: 'environment' });
+
+    zaiPlanProviderStrategy.createLlm!(makeProfile({ name: 'zai-plan' }), model(), settings, '/proj');
+
+    expect(envMock.lookups).toEqual(['ZAI_API_KEY']);
+    expect(call('createOpenAICompatible').callArgs).toMatchObject({ apiKey: 'env-zai' });
+  });
+
+  it('ignores OPENAI_API_KEY and throws the ZAI_API_KEY error when no key exists', () => {
+    envMock.vars.clear();
+    envMock.lookups.length = 0;
+    envMock.vars.set('OPENAI_API_KEY', { value: 'env-oai', source: 'environment' });
+    expect(() => zaiPlanProviderStrategy.createLlm!(makeProfile({ name: 'zai-plan' }), model(), settings, '/proj')).toThrow(
+      'API key is required for zai-plan. Check Providers settings or Aider environment variables (ZAI_API_KEY).',
+    );
+  });
+});
+
+describe('azure createLlm', () => {
+  it('resolves the resource name from AZURE_API_BASE env var and uses the responses endpoint', () => {
+    envMock.vars.set('AZURE_API_KEY', { value: 'env-az', source: 'environment' });
+    envMock.vars.set('AZURE_API_BASE', { value: 'https://env-resource.openai.azure', source: 'environment' });
+
+    azureProviderStrategy.createLlm!(makeProfile({ name: 'azure' }), model(), settings, '/proj');
+
+    expect(envMock.lookups).toEqual(['AZURE_API_KEY', 'AZURE_API_BASE']);
+    const c = call('createAzure', 'responses');
+    expect(c.callArgs).toMatchObject({ apiKey: 'env-az', resourceName: 'env-resource' });
+  });
+
+  it('currently fails to extract the resource name from standard *.openai.azure.com endpoints (Phase 0 lock)', () => {
+    // extractResourceNameFromEndpoint only matches hostnames ending in '.openai.azure'
+    // exactly (no TLD), so the common <resource>.openai.azure.com form does NOT resolve.
+    envMock.vars.set('AZURE_API_KEY', { value: 'env-az', source: 'environment' });
+    envMock.vars.set('AZURE_API_BASE', { value: 'https://env-resource.openai.azure.com/', source: 'environment' });
+
+    expect(() => azureProviderStrategy.createLlm!(makeProfile({ name: 'azure' }), model(), settings, '/proj')).toThrow(
+      'Azure OpenAI resource name is required in Providers settings or Aider environment variables (AZURE_API_BASE)',
+    );
+  });
+
+  it('throws the current error when the resource name is missing', () => {
+    const provider = { name: 'azure', apiKey: 'sk-az' };
+    expect(() => azureProviderStrategy.createLlm!(makeProfile(provider), model(), settings, '/proj')).toThrow(
+      'Azure OpenAI resource name is required in Providers settings or Aider environment variables (AZURE_API_BASE)',
+    );
+  });
+});

--- a/src/main/models/providers/__tests__/descriptor-validation.test.ts
+++ b/src/main/models/providers/__tests__/descriptor-validation.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Pins the intentional fail-fast contract of `createStrategyFromDescriptor`:
+ * every provider file constructs its strategy at module import time, so an
+ * invalid descriptor aborts startup immediately instead of quietly producing a
+ * broken strategy. This documents the accepted blast radius (see audit finding
+ * F4): these are compile-time-static constants, and types guard most of the
+ * descriptor shape, so a throw here means a programming error that should be
+ * loud. If this contract is ever revisited, replace these with tests for the
+ * new controlled-point validation.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import { createStrategyFromDescriptor, ProviderDescriptor } from '../strategy-factory';
+
+vi.mock('@/logger');
+
+const validDescriptor = (): ProviderDescriptor => ({
+  name: 'test-provider',
+  label: 'Test Provider',
+  sdkFactory: (): never => {
+    throw new Error('not used in this test');
+  },
+  modelsLoader: { type: 'static', items: () => [] },
+  aider: { prefix: 'test', apiKeyEnv: 'TEST_API_KEY' },
+});
+
+describe('createStrategyFromDescriptor fail-fast descriptor validation', () => {
+  it('rejects a descriptor with neither modelsLoader nor overrides.loadModels', () => {
+    const descriptor = validDescriptor();
+    delete (descriptor as Partial<ProviderDescriptor>).modelsLoader;
+
+    expect(() => createStrategyFromDescriptor(descriptor)).toThrow(/needs modelsLoader or overrides\.loadModels/);
+  });
+
+  it('rejects a descriptor with neither aider nor overrides.getAiderMapping', () => {
+    const descriptor = validDescriptor();
+    delete (descriptor as Partial<ProviderDescriptor>).aider;
+
+    expect(() => createStrategyFromDescriptor(descriptor)).toThrow(/needs aider config or overrides\.getAiderMapping/);
+  });
+
+  it('rejects a descriptor with both aider and overrides.getAiderMapping', () => {
+    const descriptor = validDescriptor();
+    descriptor.overrides = {
+      getAiderMapping: () => ({ modelName: 'x', environmentVariables: {} }),
+    };
+
+    expect(() => createStrategyFromDescriptor(descriptor)).toThrow(/must not set both aider and overrides\.getAiderMapping/);
+  });
+});

--- a/src/main/models/providers/__tests__/load-models-snapshots.test.ts
+++ b/src/main/models/providers/__tests__/load-models-snapshots.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Phase 0 behavior-locking tests for load<L>Models: request URLs, auth headers,
+ * response mappers, and the {models, success, error} result shapes.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ProviderProfile, SettingsData } from '@common/types';
+
+import { loadGroqModels } from '../groq';
+import { loadCerebrasModels } from '../cerebras';
+import { loadMistralModels } from '../mistral';
+import { loadDeepseekModels } from '../deepseek';
+import { neuralwattProviderStrategy } from '../neuralwatt';
+import { syntheticProviderStrategy } from '../synthetic';
+import { zaiPlanProviderStrategy } from '../zai-plan';
+import { opencodeProviderStrategy } from '../opencode';
+import { opencodeGoProviderStrategy } from '../opencode-go';
+import { openrouterProviderStrategy } from '../openrouter';
+import { requestyProviderStrategy } from '../requesty';
+import { gpustackProviderStrategy } from '../gpustack';
+
+import { envMock, profileFor, settings } from './test-utils';
+
+vi.mock('@/logger');
+
+vi.mock('@/utils/environment', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/environment')>();
+  const { envMock } = await import('./test-utils');
+  return { ...actual, getEffectiveEnvironmentVariable: envMock.getEffectiveEnvironmentVariable };
+});
+
+const mockFetch = (payload: unknown, init?: { ok?: boolean; status?: number; statusText?: string; text?: string }) => {
+  const response = {
+    ok: init?.ok ?? true,
+    status: init?.status ?? 200,
+    statusText: init?.statusText ?? 'OK',
+    text: async () => init?.text ?? 'body',
+    json: async () => payload,
+  };
+  (global.fetch as any) = vi.fn().mockResolvedValue(response);
+  return global.fetch as any;
+};
+
+type Row = {
+  name: string;
+  loadModels: (profile: ProviderProfile, settings: SettingsData) => Promise<{ models: unknown[]; success: boolean; error?: string }>;
+  provider: Record<string, unknown>;
+  apiKey: string;
+  url: string;
+  payload: unknown;
+  /** env var consulted when provider.apiKey is missing */
+  envKey: string;
+  /** expected ids of returned models */
+  ids: string[];
+  /** extra assertions on the first returned model */
+  firstModel?: Record<string, unknown>;
+};
+
+const rows: Row[] = [
+  {
+    name: 'groq',
+    loadModels: loadGroqModels,
+    provider: { name: 'groq', apiKey: 'sk-groq' },
+    apiKey: 'sk-groq',
+    url: 'https://api.groq.com/openai/v1/models',
+    payload: { data: [{ id: 'llama-3' }, { id: 'mixtral' }] },
+    envKey: 'GROQ_API_KEY',
+    ids: ['llama-3', 'mixtral'],
+  },
+  {
+    name: 'cerebras',
+    loadModels: loadCerebrasModels,
+    provider: { name: 'cerebras', apiKey: 'sk-cer' },
+    apiKey: 'sk-cer',
+    url: 'https://api.cerebras.ai/v1/models',
+    payload: { data: [{ id: 'llama3.1', max_context_length: 128000 }] },
+    envKey: 'CEREBRAS_API_KEY',
+    ids: ['llama3.1'],
+    firstModel: { maxInputTokens: 128000 },
+  },
+  {
+    name: 'mistral',
+    loadModels: loadMistralModels,
+    provider: { name: 'mistral', apiKey: 'sk-mistral' },
+    apiKey: 'sk-mistral',
+    url: 'https://api.mistral.ai/v1/models',
+    payload: { data: [{ id: 'mistral-large' }, { id: 'mistral-large' }] },
+    envKey: 'MISTRAL_API_KEY',
+    ids: ['mistral-large'],
+    firstModel: { temperature: 0.7 },
+  },
+  {
+    name: 'deepseek',
+    loadModels: loadDeepseekModels,
+    provider: { name: 'deepseek', apiKey: 'sk-ds' },
+    apiKey: 'sk-ds',
+    url: 'https://api.deepseek.com/v1/models',
+    payload: { data: [{ id: 'deepseek-chat' }] },
+    envKey: 'DEEPSEEK_API_KEY',
+    ids: ['deepseek-chat'],
+  },
+  {
+    name: 'neuralwatt',
+    loadModels: neuralwattProviderStrategy.loadModels,
+    provider: { name: 'neuralwatt', apiKey: 'sk-nw' },
+    apiKey: 'sk-nw',
+    url: 'https://api.neuralwatt.com/v1/models',
+    payload: { data: [{ id: 'nw-model' }] },
+    envKey: 'NEURALWATT_API_KEY',
+    ids: ['nw-model'],
+  },
+  {
+    name: 'synthetic',
+    loadModels: syntheticProviderStrategy.loadModels,
+    provider: { name: 'synthetic', apiKey: 'sk-syn' },
+    apiKey: 'sk-syn',
+    url: 'https://api.synthetic.new/openai/v1/models',
+    payload: { data: [{ id: 'hf:zai-org' }] },
+    envKey: 'SYNTHETIC_API_KEY',
+    ids: ['hf:zai-org'],
+  },
+  {
+    name: 'opencode',
+    loadModels: opencodeProviderStrategy.loadModels,
+    provider: { name: 'opencode', apiKey: 'sk-zen' },
+    apiKey: 'sk-zen',
+    url: 'https://opencode.ai/zen/v1/models',
+    payload: { object: 'list', data: [{ id: 'claude-sonnet-4' }] },
+    envKey: 'OPENCODE_API_KEY',
+    ids: ['claude-sonnet-4'],
+  },
+  {
+    name: 'opencode-go',
+    loadModels: opencodeGoProviderStrategy.loadModels,
+    provider: { name: 'opencode-go', apiKey: 'sk-zengo' },
+    apiKey: 'sk-zengo',
+    url: 'https://opencode.ai/zen/go/v1/models',
+    payload: { object: 'list', data: [{ id: 'minimax-m3' }] },
+    envKey: 'OPENCODE_GO_API_KEY',
+    ids: ['minimax-m3'],
+  },
+  {
+    name: 'requesty',
+    loadModels: requestyProviderStrategy.loadModels,
+    provider: { name: 'requesty', apiKey: 'sk-req' },
+    apiKey: 'sk-req',
+    url: 'https://router.requesty.ai/v1/models',
+    payload: {
+      data: [
+        {
+          id: 'openai/gpt-5',
+          created: 1,
+          owned_by: 'openai',
+          input_price: 0.0000015,
+          caching_price: 0.0000019,
+          cached_price: 0.0000002,
+          output_price: 0.000006,
+          max_output_tokens: 16384,
+          context_window: 400000,
+          supports_caching: true,
+          supports_vision: true,
+          supports_computer_use: false,
+          supports_reasoning: true,
+          description: 'test',
+        },
+      ],
+    },
+    envKey: 'REQUESTY_API_KEY',
+    ids: ['openai/gpt-5'],
+    firstModel: { maxInputTokens: 400000, inputCostPerToken: 0.0000015, outputCostPerToken: 0.000006 },
+  },
+  {
+    name: 'openrouter',
+    loadModels: openrouterProviderStrategy.loadModels,
+    provider: { name: 'openrouter', apiKey: 'sk-or' },
+    apiKey: 'sk-or',
+    url: 'https://openrouter.ai/api/v1/models',
+    payload: {
+      data: [
+        {
+          id: 'anthropic/claude-sonnet-4',
+          name: 'Claude',
+          created: 1,
+          description: 'test',
+          top_provider: { is_moderated: true, context_length: 200000, max_completion_tokens: 64000 },
+          pricing: { prompt: '0.000003', completion: '0.000015', input_cache_read: '0.0000003', input_cache_write: '0.00000375' },
+          context_length: 200000,
+        },
+      ],
+    },
+    envKey: 'OPENROUTER_API_KEY',
+    ids: ['anthropic/claude-sonnet-4'],
+    firstModel: {
+      maxInputTokens: 200000,
+      maxOutputTokensLimit: 64000,
+      inputCostPerToken: 0.000003,
+      outputCostPerToken: 0.000015,
+      cacheReadInputTokenCost: 0.0000003,
+      cacheWriteInputTokenCost: 0.00000375,
+    },
+  },
+];
+
+describe.each(rows)('$name loadModels', (row) => {
+  beforeEach(() => {
+    envMock.vars.clear();
+  });
+
+  it('requests the expected URL with the provider apiKey as Bearer token and maps models', async () => {
+    const fetchMock = mockFetch(row.payload);
+
+    const result = await row.loadModels(profileFor(row.provider), settings);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe(row.url);
+    expect(fetchMock.mock.calls[0][1]?.headers).toEqual({ Authorization: `Bearer ${row.apiKey}` });
+
+    expect(result.success).toBe(true);
+    expect(result.models.map((m) => (m as { id: string }).id)).toEqual(row.ids);
+    expect(result.models[0]).toMatchObject({ id: row.ids[0], providerId: 'p1', ...(row.firstModel ?? {}) });
+  });
+
+  it('falls back to the env var when apiKey is missing', async () => {
+    envMock.vars.set(row.envKey, { value: 'env-key', source: 'environment' });
+    const fetchMock = mockFetch(row.payload);
+
+    const result = await row.loadModels(profileFor({ ...row.provider, apiKey: undefined }), settings);
+
+    expect(fetchMock.mock.calls[0][1]?.headers).toEqual({ Authorization: 'Bearer env-key' });
+    expect(result.success).toBe(true);
+  });
+
+  it('returns {models: [], success: false, error} on non-OK responses', async () => {
+    mockFetch({}, { ok: false, status: 401, statusText: 'Unauthorized', text: 'denied' });
+
+    const result = await row.loadModels(profileFor(row.provider), settings);
+
+    expect(result.models).toEqual([]);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('401');
+  });
+
+  it('returns {models: [], success: false} with no error and no request when no credential exists', async () => {
+    const fetchMock = vi.fn();
+    (global.fetch as any) = fetchMock;
+
+    const result = await row.loadModels(profileFor({ ...row.provider, apiKey: undefined }), settings);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ models: [], success: false });
+  });
+});
+
+describe('zai-plan loadModels credential resolution (unified on ZAI_API_KEY — Phase 1 fix)', () => {
+  it('does not consult OPENAI_API_KEY for loadModels anymore', async () => {
+    envMock.vars.set('OPENAI_API_KEY', { value: 'env-oai', source: 'environment' });
+    const fetchMock = mockFetch({ data: [{ id: 'glm-4.6' }] });
+
+    const result = await zaiPlanProviderStrategy.loadModels(profileFor({ name: 'zai-plan' }), settings);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ models: [], success: false });
+  });
+
+  it('resolves credentials via ZAI_API_KEY like createLlm and the Aider mapping', async () => {
+    envMock.vars.set('ZAI_API_KEY', { value: 'env-zai', source: 'environment' });
+    const fetchMock = mockFetch({ data: [{ id: 'glm-4.6' }] });
+
+    const result = await zaiPlanProviderStrategy.loadModels(profileFor({ name: 'zai-plan' }), settings);
+
+    expect(fetchMock.mock.calls[0][0]).toBe('https://api.z.ai/api/paas/v4/models');
+    expect(fetchMock.mock.calls[0][1]?.headers).toEqual({ Authorization: 'Bearer env-zai' });
+    expect(result).toEqual({ models: [{ id: 'glm-4.6', providerId: 'p1', temperature: 0.7 }], success: true });
+  });
+});
+
+describe('gpustack loadModels', () => {
+  it('maps data.items[].name (not data.data[].id) and requests ${baseUrl}/v1/models', async () => {
+    const fetchMock = mockFetch({ items: [{ name: 'qwen2.5', meta: { max_model_len: 32768 } }, { name: 'llama3' }] });
+    envMock.vars.clear();
+
+    const result = await gpustackProviderStrategy.loadModels(profileFor({ name: 'gpustack', apiKey: 'sk-gpu', baseUrl: 'https://gpu.example' }), settings);
+
+    expect(fetchMock.mock.calls[0][0]).toBe('https://gpu.example/v1/models');
+    expect(fetchMock.mock.calls[0][1]?.headers).toEqual({ Authorization: 'Bearer sk-gpu' });
+    expect(result).toEqual({
+      success: true,
+      models: [
+        { id: 'qwen2.5', providerId: 'p1', maxInputTokens: 32768 },
+        { id: 'llama3', providerId: 'p1', maxInputTokens: undefined },
+      ],
+    });
+  });
+
+  it('returns the error shape on failure', async () => {
+    mockFetch({}, { ok: false, status: 500, statusText: 'Server Error', text: 'boom' });
+
+    const result = await gpustackProviderStrategy.loadModels(profileFor({ name: 'gpustack', apiKey: 'sk-gpu', baseUrl: 'https://gpu.example' }), settings);
+
+    expect(result.models).toEqual([]);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('500');
+  });
+});
+
+afterEach(() => {
+  envMock.vars.clear();
+  vi.restoreAllMocks();
+});

--- a/src/main/models/providers/__tests__/minimax-pricing.test.ts
+++ b/src/main/models/providers/__tests__/minimax-pricing.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Pricing-parity lock for the shared MiniMax-M3 entry: the minimax strategy and
+ * the ClinePass vendor catalog must expose exactly the same shared pricing
+ * (MINIMAX_M3_MODEL_PRICING), while keeping their provider-specific ids.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import { clinePassProviderStrategy } from '../clinepass';
+import { minimaxProviderStrategy, MINIMAX_M3_MODEL_PRICING } from '../minimax';
+
+import { profileFor, settings } from './test-utils';
+
+vi.mock('@/logger');
+
+vi.mock('@/utils/environment', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/environment')>();
+  const { envMock } = await import('./test-utils');
+  return { ...actual, getEffectiveEnvironmentVariable: envMock.getEffectiveEnvironmentVariable };
+});
+
+const loadStaticClinePassModels = async (): Promise<{ id: string }[]> => {
+  // no apiKey anywhere -> ClinePass falls back to its static catalog
+  const result = await clinePassProviderStrategy.loadModels!(profileFor({ name: 'clinepass' }), settings);
+  expect(result.success).toBe(true);
+  return result.models as { id: string }[];
+};
+
+const loadMinimaxModels = async (): Promise<{ id: string }[]> => {
+  const result = await minimaxProviderStrategy.loadModels!(profileFor({ name: 'minimax' }), settings);
+  expect(result.success).toBe(true);
+  return result.models as { id: string }[];
+};
+
+describe('MiniMax-M3 shared pricing parity', () => {
+  it('minimax and clinepass expose identical shared pricing for MiniMax M3', async () => {
+    const minimaxM3 = (await loadMinimaxModels()).find((m) => m.id === 'MiniMax-M3');
+    const clinepassM3 = (await loadStaticClinePassModels()).find((m) => m.id === 'minimax-m3');
+
+    expect(minimaxM3).toBeDefined();
+    expect(clinepassM3).toBeDefined();
+
+    // both spread the same shared pricing entry, including cache-write cost
+    expect(minimaxM3).toMatchObject(MINIMAX_M3_MODEL_PRICING);
+    expect(clinepassM3).toMatchObject(MINIMAX_M3_MODEL_PRICING);
+
+    // ids and provider-specific catalog metadata stay independent
+    expect(minimaxM3!.id).toBe('MiniMax-M3');
+    expect(clinepassM3!.id).toBe('minimax-m3');
+  });
+});

--- a/src/main/models/providers/__tests__/model-info.test.ts
+++ b/src/main/models/providers/__tests__/model-info.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Regression test for the descriptor factory dropping the default getModelInfo:
+ * the pre-refactor cerebras/groq/deepseek/mistral/neuralwatt/clinepass strategies
+ * each declared `getModelInfo: getDefaultModelInfo`; createStrategyFromDescriptor
+ * silently omitted it, so model-manager.enrichWithModelInfo (which gates on
+ * `if (strategy.getModelInfo)`) skipped enrichment and those providers' models
+ * lost limits/pricing metadata (zero-cost usage reports).
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { ModelInfo, ProviderProfile } from '@common/types';
+
+import { createStrategyFromDescriptor, ProviderDescriptor } from '../strategy-factory';
+import { getDefaultModelInfo } from '../default';
+import { cerebrasProviderStrategy } from '../cerebras';
+import { groqProviderStrategy } from '../groq';
+import { deepseekProviderStrategy } from '../deepseek';
+import { mistralProviderStrategy } from '../mistral';
+import { neuralwattProviderStrategy } from '../neuralwatt';
+import { clinePassProviderStrategy } from '../clinepass';
+import { syntheticProviderStrategy } from '../synthetic';
+import { zaiPlanProviderStrategy } from '../zai-plan';
+import { openaiCompatibleProviderStrategy } from '../openai-compatible';
+
+import type { LlmProviderStrategy } from '@/models';
+
+vi.mock('@/logger');
+
+const minimalDescriptor: ProviderDescriptor = {
+  name: 'test-provider',
+  label: 'Test Provider',
+  sdkFactory: (): never => {
+    throw new Error('not used in this test');
+  },
+  modelsLoader: { type: 'static', items: () => [] },
+  aider: { prefix: 'test', apiKeyEnv: 'TEST_API_KEY' },
+};
+
+describe('createStrategyFromDescriptor model info', () => {
+  it('generated strategy exposes the default getModelInfo', () => {
+    const strategy = createStrategyFromDescriptor(minimalDescriptor);
+    expect(strategy.getModelInfo).toBe(getDefaultModelInfo);
+  });
+
+  it('default getModelInfo resolves provider.id/modelId first, then provider.name/modelId', () => {
+    const provider = { id: 'p1', name: 'my-profile', provider: {} } as unknown as ProviderProfile;
+    const modelInfoByName = { id: 'info-by-name' } as unknown as ModelInfo;
+    const modelInfoById = { id: 'info-by-id' } as unknown as ModelInfo;
+
+    // canonical identity (profile id) wins
+    let found = getDefaultModelInfo(provider, 'm1', { 'p1/m1': modelInfoById, 'my-profile/m1': modelInfoByName });
+    expect(found).toBe(modelInfoById);
+
+    // falls back to the profile name only when the canonical id has no entry
+    found = getDefaultModelInfo(provider, 'm1', { 'my-profile/m1': modelInfoByName });
+    expect(found).toBe(modelInfoByName);
+
+    // nothing found
+    expect(getDefaultModelInfo(provider, 'm1', {})).toBeUndefined();
+  });
+
+  it('a user-facing profile name never shadows a matching canonical id', () => {
+    // Profile whose display name equals another catalog provider slug ("google"):
+    // its models must be enriched with ITS OWN provider's metadata, not Google's.
+    const provider = { id: 'openai', name: 'google', provider: {} } as unknown as ProviderProfile;
+    const openaiInfo = { maxInputTokens: 128000 } as unknown as ModelInfo;
+    const googleInfo = { maxInputTokens: 1000000 } as unknown as ModelInfo;
+
+    expect(getDefaultModelInfo(provider, 'gemini-2.0-flash', { 'openai/gemini-2.0-flash': openaiInfo, 'google/gemini-2.0-flash': googleInfo })).toBe(
+      openaiInfo,
+    );
+  });
+
+  it('generated strategy getModelInfo enriches models via modelsInfo lookup', () => {
+    const strategy = createStrategyFromDescriptor(minimalDescriptor);
+    const provider = { id: 'p1', name: 'my-profile', provider: {} } as unknown as ProviderProfile;
+    const info = { maxInputTokens: 8192, inputCostPerToken: 0.1, outputCostPerToken: 0.2 } as unknown as ModelInfo;
+
+    expect(strategy.getModelInfo?.(provider, 'llama-3', { 'my-profile/llama-3': info })).toBe(info);
+  });
+
+  // Characterization (intentional widening): the pre-refactor openai-compatible strategy
+  // had NO getModelInfo, so enrichWithModelInfo skipped it entirely. The generated
+  // descriptor strategy now exposes the default lookup, giving openai-compatible the
+  // same modelsInfo metadata (token limits / pricing) as every other simple provider.
+  it('openai-compatible descriptor strategy exposes default getModelInfo and returns model metadata', () => {
+    expect(openaiCompatibleProviderStrategy.getModelInfo).toBe(getDefaultModelInfo);
+
+    const profile = { id: 'p1', name: 'my-profile', provider: { name: 'my-vllm' } } as unknown as ProviderProfile;
+    const info = { maxInputTokens: 32768, inputCostPerToken: 0.000001, outputCostPerToken: 0.000002 } as unknown as ModelInfo;
+
+    expect(openaiCompatibleProviderStrategy.getModelInfo?.(profile, 'llama-3', { 'my-profile/llama-3': info })).toBe(info);
+    expect(openaiCompatibleProviderStrategy.getModelInfo?.(profile, 'unknown-model', {})).toBeUndefined();
+  });
+
+  it.each([
+    ['cerebras', cerebrasProviderStrategy],
+    ['groq', groqProviderStrategy],
+    ['deepseek', deepseekProviderStrategy],
+    ['mistral', mistralProviderStrategy],
+    ['neuralwatt', neuralwattProviderStrategy],
+    ['clinepass', clinePassProviderStrategy],
+  ])('%s descriptor strategy keeps getModelInfo for enrichment', (_name, strategy: LlmProviderStrategy) => {
+    expect(strategy.getModelInfo).toBe(getDefaultModelInfo);
+  });
+
+  it.each([
+    ['synthetic', syntheticProviderStrategy, 'synthetic'],
+    ['zai-plan', zaiPlanProviderStrategy, 'zai-coding-plan'],
+  ])('%s bespoke getModelInfo override still wins over the default', (_name, strategy: LlmProviderStrategy, prefix: string) => {
+    expect(strategy.getModelInfo).not.toBe(getDefaultModelInfo);
+    const provider = { id: 'p1', name: 'my-profile', provider: {} } as unknown as ProviderProfile;
+    const info = { id: 'override-info' } as unknown as ModelInfo;
+    expect(strategy.getModelInfo?.(provider, 'm1', { [`${prefix}/m1`]: info })).toBe(info);
+  });
+});

--- a/src/main/models/providers/__tests__/reasoning-overrides.test.ts
+++ b/src/main/models/providers/__tests__/reasoning-overrides.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, it, vi } from 'vitest';
-import { AlibabaPlanProvider, AnthropicCompatibleProvider, AnthropicProvider, AzureProvider, DeepseekProvider, MinimaxProvider } from '@common/agent';
+import {
+  AlibabaPlanProvider,
+  AnthropicCompatibleProvider,
+  AnthropicProvider,
+  AzureProvider,
+  DeepseekProvider,
+  GeminiProvider,
+  MinimaxProvider,
+  NeuralwattProvider,
+  OpenAiCompatibleProvider,
+  OpenAiProvider,
+  VertexAiProvider,
+  ZaiPlanProvider,
+} from '@common/agent';
 import { Model, ReasoningEffort } from '@common/types';
 
 import { alibabaPlanProviderStrategy } from '../alibaba-plan';
@@ -7,7 +20,13 @@ import { getAnthropicProviderOptions } from '../anthropic';
 import { getAnthropicCompatibleProviderOptions } from '../anthropic-compatible';
 import { azureProviderStrategy } from '../azure';
 import { deepseekProviderStrategy } from '../deepseek';
+import { geminiProviderStrategy } from '../gemini';
 import { getMinimaxProviderOptions } from '../minimax';
+import { neuralwattProviderStrategy } from '../neuralwatt';
+import { getOpenAiProviderOptions } from '../openai';
+import { openaiCompatibleProviderStrategy } from '../openai-compatible';
+import { vertexAiProviderStrategy } from '../vertex-ai';
+import { zaiPlanProviderStrategy } from '../zai-plan';
 
 vi.mock('@/logger');
 
@@ -79,6 +98,257 @@ describe('provider reasoning overrides', () => {
     expect(deepseekProviderStrategy.getProviderParameters?.(provider, model, 'high')).toEqual({
       temperature: undefined,
       topP: undefined,
+    });
+  });
+
+  it('model.providerOverrides win over conflicting provider-level deepseek options', () => {
+    const provider: DeepseekProvider = {
+      name: 'deepseek',
+      apiKey: 'test',
+      thinkingEnabled: true,
+    };
+
+    // no override on the model -> the provider-level value applies (thinking enabled)
+    expect(deepseekProviderStrategy.getProviderOptions?.(provider, model, 'provider-default')).toEqual({
+      deepseek: {
+        thinking: { type: 'enabled' },
+        reasoningEffort: 'high',
+      },
+    });
+
+    // conflicting model-level override wins over the provider-level value
+    const overriddenModel = {
+      ...model,
+      // matches the runtime cast: model.providerOverrides is Record<string, unknown> on Model
+      providerOverrides: { thinkingEnabled: false } as unknown as Partial<DeepseekProvider>,
+    } as Model;
+
+    expect(deepseekProviderStrategy.getProviderOptions?.(provider, overriddenModel, 'provider-default')).toEqual({
+      deepseek: {
+        thinking: { type: 'disabled' },
+      },
+    });
+  });
+
+  it('maps OpenAI reasoning effort to provider options', () => {
+    const provider: OpenAiProvider = {
+      name: 'openai',
+      apiKey: 'test',
+      useWebSearch: false,
+      reasoningEffort: ReasoningEffort.High,
+    };
+
+    // With a top-level reasoning parameter set, only the summary stays (portable reasoning)
+    expect(getOpenAiProviderOptions(provider, model, 'high')).toEqual({
+      openai: {
+        reasoningSummary: 'auto',
+      },
+    });
+
+    // provider-default: map the configured reasoningEffort
+    expect(getOpenAiProviderOptions(provider, model, 'provider-default')).toEqual({
+      openai: {
+        reasoningSummary: 'auto',
+        reasoningEffort: 'high',
+      },
+    });
+
+    // explicit None maps to no reasoningEffort at all
+    provider.reasoningEffort = ReasoningEffort.None;
+    expect(getOpenAiProviderOptions(provider, model, 'provider-default')).toBeUndefined();
+  });
+
+  it('maps Azure reasoning effort to provider options', () => {
+    const provider: AzureProvider = {
+      name: 'azure',
+      apiKey: 'test',
+      resourceName: 'test',
+      reasoningEffort: ReasoningEffort.High,
+    };
+
+    expect(azureProviderStrategy.getProviderOptions?.(provider, model, 'high')).toEqual({
+      openai: {
+        reasoningSummary: 'auto',
+      },
+    });
+
+    expect(azureProviderStrategy.getProviderOptions?.(provider, model, 'provider-default')).toEqual({
+      openai: {
+        reasoningSummary: 'auto',
+        reasoningEffort: 'high',
+      },
+    });
+
+    provider.reasoningEffort = ReasoningEffort.None;
+    expect(azureProviderStrategy.getProviderOptions?.(provider, model, 'provider-default')).toBeUndefined();
+  });
+
+  it('passes extraBody through openai-compatible provider options', () => {
+    const provider = {
+      name: 'openai-compatible',
+      apiKey: 'test',
+      reasoningEffort: ReasoningEffort.High,
+      extraBody: { my_extension: { temperature: { min: 0 } } },
+    } as unknown as OpenAiCompatibleProvider;
+
+    // provider-default: reasoningEffort mapped AND extraBody merged
+    expect(openaiCompatibleProviderStrategy.getProviderOptions?.(provider, model, 'provider-default')).toEqual({
+      'openai-compatible': {
+        reasoningEffort: 'high',
+        my_extension: { temperature: { min: 0 } },
+      },
+    });
+
+    // With portable reasoning, reasoningEffort is omitted but extraBody is kept
+    expect(openaiCompatibleProviderStrategy.getProviderOptions?.(provider, model, 'high')).toEqual({
+      'openai-compatible': {
+        my_extension: { temperature: { min: 0 } },
+      },
+    });
+
+    // No options configured -> undefined
+    expect(
+      openaiCompatibleProviderStrategy.getProviderOptions?.({ name: 'openai-compatible' } as OpenAiCompatibleProvider, model, 'provider-default'),
+    ).toBeUndefined();
+  });
+
+  it('maps zai-plan thinking branches to zaiPlan provider options', () => {
+    const provider: ZaiPlanProvider = {
+      name: 'zai-plan',
+      apiKey: 'test',
+      thinkingEnabled: true,
+    };
+
+    // provider-default: reasoningEffort (default Max) + tool_stream kept
+    expect(zaiPlanProviderStrategy.getProviderOptions?.(provider, model, 'provider-default')).toEqual({
+      zaiPlan: {
+        reasoningEffort: 'max',
+        tool_stream: true,
+      },
+    });
+
+    // top-level reasoning set: thinking omitted, tool_stream kept
+    expect(zaiPlanProviderStrategy.getProviderOptions?.(provider, model, 'high')).toEqual({
+      zaiPlan: {
+        tool_stream: true,
+      },
+    });
+
+    // 'none' explicitly disables thinking
+    expect(zaiPlanProviderStrategy.getProviderOptions?.(provider, model, 'none')).toEqual({
+      zaiPlan: {
+        thinking: { type: 'disabled' },
+        tool_stream: true,
+      },
+    });
+
+    // thinkingEnabled: false explicitly disables thinking
+    const disabled: ZaiPlanProvider = { name: 'zai-plan', apiKey: 'test', thinkingEnabled: false };
+    expect(zaiPlanProviderStrategy.getProviderOptions?.(disabled, model, 'provider-default')).toEqual({
+      zaiPlan: {
+        thinking: { type: 'disabled' },
+        tool_stream: true,
+      },
+    });
+
+    // tool call streaming disabled -> tool_stream option dropped
+    const noStream: ZaiPlanProvider = { name: 'zai-plan', apiKey: 'test', thinkingEnabled: true, disableToolCallStreaming: true };
+    expect(zaiPlanProviderStrategy.getProviderOptions?.(noStream, model, 'provider-default')).toEqual({
+      zaiPlan: {
+        reasoningEffort: 'max',
+      },
+    });
+    expect(zaiPlanProviderStrategy.getProviderOptions?.(noStream, model, 'high')).toBeUndefined();
+  });
+
+  it('maps neuralwatt reasoning effort to neuralwatt provider options', () => {
+    const provider: NeuralwattProvider = {
+      name: 'neuralwatt',
+      apiKey: 'test',
+      reasoningEffort: ReasoningEffort.High,
+    };
+
+    expect(neuralwattProviderStrategy.getProviderOptions?.(provider, model, 'provider-default')).toEqual({
+      neuralwatt: {
+        reasoningEffort: 'high',
+      },
+    });
+
+    // portable reasoning takes over
+    expect(neuralwattProviderStrategy.getProviderOptions?.(provider, model, 'high')).toBeUndefined();
+    expect(neuralwattProviderStrategy.getProviderOptions?.(provider, model, 'none')).toBeUndefined();
+
+    // no effort configured -> undefined
+    expect(
+      neuralwattProviderStrategy.getProviderOptions?.({ name: 'neuralwatt', apiKey: 'test' } as NeuralwattProvider, model, 'provider-default'),
+    ).toBeUndefined();
+  });
+
+  it('maps gemini thinking to the google metadata key', () => {
+    const provider: GeminiProvider = {
+      name: 'gemini',
+      apiKey: 'test',
+      includeThoughts: true,
+      thinkingBudget: 1024,
+      useSearchGrounding: false,
+    };
+    const strategy = geminiProviderStrategy;
+
+    expect(strategy.getProviderOptions?.(provider, model, 'provider-default')).toEqual({
+      google: {
+        thinkingConfig: {
+          includeThoughts: true,
+          thinkingBudget: 1024,
+        },
+      },
+    });
+
+    // includeThoughts survives portable reasoning, thinkingBudget does not
+    expect(strategy.getProviderOptions?.(provider, model, 'high')).toEqual({
+      google: {
+        thinkingConfig: {
+          includeThoughts: true,
+        },
+      },
+    });
+
+    // budget without thoughts -> includeThoughts false, budget kept
+    const budgetOnly: GeminiProvider = { name: 'gemini', apiKey: 'test', thinkingBudget: 4096, includeThoughts: false, useSearchGrounding: false };
+    expect(strategy.getProviderOptions?.(budgetOnly, model, 'provider-default')).toEqual({
+      google: {
+        thinkingConfig: {
+          includeThoughts: false,
+          thinkingBudget: 4096,
+        },
+      },
+    });
+  });
+
+  it('maps vertex-ai thinking to the vertex metadata key', () => {
+    const provider: VertexAiProvider = {
+      name: 'vertex-ai',
+      project: 'test',
+      location: 'test',
+      includeThoughts: true,
+      thinkingBudget: 1024,
+    };
+    const strategy = vertexAiProviderStrategy;
+
+    expect(strategy.getProviderOptions?.(provider, model, 'provider-default')).toEqual({
+      vertex: {
+        thinkingConfig: {
+          includeThoughts: true,
+          thinkingBudget: 1024,
+        },
+      },
+    });
+
+    expect(strategy.getProviderOptions?.(provider, model, 'high')).toEqual({
+      vertex: {
+        thinkingConfig: {
+          includeThoughts: true,
+        },
+      },
     });
   });
 });

--- a/src/main/models/providers/__tests__/test-utils.ts
+++ b/src/main/models/providers/__tests__/test-utils.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared mock harness for the provider snapshot tests: a configurable
+ * `getEffectiveEnvironmentVariable` mock and a recording SDK-factory harness.
+ *
+ * Import the helpers from inside `vi.mock` factories via `await import` —
+ * vi.mock factories are hoisted above static imports and cannot reference
+ * test-file bindings, but dynamically imported helper modules resolve fine.
+ */
+import { vi } from 'vitest';
+import { Model, ProviderProfile, SettingsData } from '@common/types';
+
+export type SdkCall = { factory: string; kind: string; model: string; callArgs: unknown; options: unknown };
+
+export const envMock = {
+  /** every env key consulted via getEffectiveEnvironmentVariable */
+  lookups: [] as string[],
+  vars: new Map<string, { value: string; source: string }>(),
+  getEffectiveEnvironmentVariable: vi.fn((key: string) => {
+    envMock.lookups.push(key);
+    return envMock.vars.get(key);
+  }),
+  reset: () => {
+    envMock.lookups.length = 0;
+    envMock.vars.clear();
+  },
+};
+
+// ---------------------------------------------------------------------------
+// SDK factory mocks — every factory records (callArgs, modelId, call kind)
+// and returns a sentinel object so tests can assert identity through the
+// whole chain (factory -> provider instance -> model call).
+// ---------------------------------------------------------------------------
+export const sdkMock = {
+  calls: [] as SdkCall[],
+  provider: (factory: string) => (callArgs: unknown) => {
+    const call = (kind: string) => (model: string, options?: unknown) => {
+      sdkMock.calls.push({ factory, kind, model, callArgs, options });
+      return { sentinel: kind === 'model' ? `${factory}:${model}` : `${factory}:${kind}:${model}` };
+    };
+    return Object.assign(call('model'), { responses: call('responses'), chat: call('chat') });
+  },
+  reset: () => {
+    sdkMock.calls.length = 0;
+  },
+};
+
+export const settings = { aider: { environmentVariables: '', options: '' } } as unknown as SettingsData;
+
+export const profileFor = (provider: Record<string, unknown>, headers?: Record<string, string>): ProviderProfile =>
+  ({ id: 'p1', name: 'test-profile', provider, headers }) as unknown as ProviderProfile;
+
+export const model = (id = 'm1') => ({ id, providerId: 'p1' }) as unknown as Model;

--- a/src/main/models/providers/alibaba-plan.ts
+++ b/src/main/models/providers/alibaba-plan.ts
@@ -1,14 +1,13 @@
-import { Model, ProviderProfile, Reasoning, SettingsData } from '@common/types';
-import { isAlibabaPlanProvider, AlibabaPlanProvider, LlmProvider } from '@common/agent';
+import { isAlibabaPlanProvider, LlmProvider } from '@common/agent';
 import { createAlibaba } from '@ai-sdk/alibaba';
+import { Model, ProviderProfile, Reasoning } from '@common/types';
 
 import type { SharedV4ProviderOptions } from '@ai-sdk/provider';
-import type { LanguageModel } from 'ai';
 
-import { AiderModelMapping, LlmProviderStrategy, LoadModelsResponse } from '@/models';
+import { LlmProviderStrategy } from '@/models';
 import logger from '@/logger';
-import { getEffectiveEnvironmentVariable } from '@/utils';
-import { getDefaultUsageReport } from '@/models/providers/default';
+import { createStrategyFromDescriptor } from '@/models/providers/strategy-factory';
+import { mergeModelProps } from '@/models/providers/shared';
 
 const ALIBABA_PLAN_BASE_URL = 'https://coding-intl.dashscope.aliyuncs.com/v1';
 
@@ -23,93 +22,17 @@ const ALIBABA_PLAN_MODELS = [
   { id: 'kimi-k2.5', maxInputTokens: 262144, maxOutputTokensLimit: 32768 },
 ];
 
-const loadAlibabaPlanModels = async (profile: ProviderProfile, settings: SettingsData): Promise<LoadModelsResponse> => {
-  if (!isAlibabaPlanProvider(profile.provider)) {
-    return { models: [], success: false };
-  }
-
-  const provider = profile.provider as AlibabaPlanProvider;
-  const apiKey = provider.apiKey || '';
-  const apiKeyEnv = getEffectiveEnvironmentVariable('ALIBABA_PLAN_API_KEY', settings);
-  const effectiveApiKey = apiKey || apiKeyEnv?.value;
-
-  if (!effectiveApiKey) {
-    return { models: [], success: false };
-  }
-
-  const models: Model[] = ALIBABA_PLAN_MODELS.map((model) => ({
-    id: model.id,
-    providerId: profile.id,
-    maxInputTokens: model.maxInputTokens,
-    maxOutputTokensLimit: model.maxOutputTokensLimit,
-  }));
-
-  logger.info(`Loaded ${models.length} Alibaba plan models for profile ${profile.id}`);
-  return { models, success: true };
-};
-
-const hasAlibabaPlanEnvVars = (settings: SettingsData): boolean => {
-  return !!getEffectiveEnvironmentVariable('ALIBABA_PLAN_API_KEY', settings, undefined)?.value;
-};
-
-const getAlibabaPlanAiderMapping = (provider: ProviderProfile, modelId: string, settings: SettingsData, projectDir: string): AiderModelMapping => {
-  const alibabaPlanProvider = provider.provider as AlibabaPlanProvider;
-  const envVars: Record<string, string> = {};
-
-  let apiKey = alibabaPlanProvider.apiKey;
-
-  if (!apiKey) {
-    const effectiveVar = getEffectiveEnvironmentVariable('ALIBABA_PLAN_API_KEY', settings, projectDir);
-    if (effectiveVar) {
-      apiKey = effectiveVar.value;
-    }
-  }
-
-  if (apiKey) {
-    envVars.OPENAI_API_KEY = apiKey;
-  }
-  envVars.OPENAI_API_BASE = ALIBABA_PLAN_BASE_URL;
-
-  return {
-    modelName: `openai/${modelId}`,
-    environmentVariables: envVars,
-  };
-};
-
-const createAlibabaPlanLlm = (profile: ProviderProfile, model: Model, settings: SettingsData, projectDir: string): LanguageModel => {
-  const provider = profile.provider as AlibabaPlanProvider;
-  let apiKey = provider.apiKey;
-
-  if (!apiKey) {
-    const effectiveVar = getEffectiveEnvironmentVariable('ALIBABA_PLAN_API_KEY', settings, projectDir);
-    if (effectiveVar) {
-      apiKey = effectiveVar.value;
-      logger.debug(`Loaded ALIBABA_PLAN_API_KEY from ${effectiveVar.source}`);
-    }
-  }
-
-  if (!apiKey) {
-    throw new Error(`API key is required for ${provider.name}. Check Providers settings or Aider environment variables (ALIBABA_PLAN_API_KEY).`);
-  }
-
-  const alibabaPlanProvider = createAlibaba({
-    apiKey,
-    baseURL: ALIBABA_PLAN_BASE_URL,
-    headers: profile.headers,
-  });
-  return alibabaPlanProvider(model.id);
-};
+const alibabaPlanStaticModels = (profile: ProviderProfile): Model[] => ALIBABA_PLAN_MODELS.map((model) => ({ ...model, providerId: profile.id }));
 
 const getAlibabaPlanProviderOptions = (llmProvider: LlmProvider, model: Model, reasoning?: Reasoning): SharedV4ProviderOptions | undefined => {
   if (isAlibabaPlanProvider(llmProvider)) {
-    const providerOverrides = model.providerOverrides as Partial<AlibabaPlanProvider> | undefined;
-
     if (reasoning && reasoning !== 'provider-default') {
       return undefined;
     }
 
-    const thinkingEnabled = providerOverrides?.thinkingEnabled ?? llmProvider.thinkingEnabled ?? true;
-    const thinkingBudget = providerOverrides?.thinkingBudget ?? llmProvider.thinkingBudget ?? 8192;
+    const overrides = mergeModelProps(model, llmProvider, ['thinkingEnabled', 'thinkingBudget']);
+    const thinkingEnabled = overrides.thinkingEnabled ?? true;
+    const thinkingBudget = overrides.thinkingBudget ?? 8192;
 
     logger.info(`Alibaba Plan provider options: thinkingEnabled=${thinkingEnabled}, thinkingBudget=${thinkingBudget}`);
 
@@ -124,11 +47,21 @@ const getAlibabaPlanProviderOptions = (llmProvider: LlmProvider, model: Model, r
   return undefined;
 };
 
-export const alibabaPlanProviderStrategy: LlmProviderStrategy = {
-  createLlm: createAlibabaPlanLlm,
-  getUsageReport: getDefaultUsageReport,
-  loadModels: loadAlibabaPlanModels,
-  hasEnvVars: hasAlibabaPlanEnvVars,
-  getAiderMapping: getAlibabaPlanAiderMapping,
-  getProviderOptions: getAlibabaPlanProviderOptions,
-};
+export const alibabaPlanProviderStrategy: LlmProviderStrategy = createStrategyFromDescriptor({
+  name: 'alibaba-plan',
+  label: 'Alibaba Plan',
+  sdkFactory: createAlibaba,
+  apiKeyEnv: 'ALIBABA_PLAN_API_KEY',
+  apiKeyRequired: (provider) => `API key is required for ${provider.name}. Check Providers settings or Aider environment variables (ALIBABA_PLAN_API_KEY).`,
+  fixedBaseURL: ALIBABA_PLAN_BASE_URL,
+  isProvider: isAlibabaPlanProvider,
+  modelsLoader: { type: 'static', apiKeyEnv: 'ALIBABA_PLAN_API_KEY', items: alibabaPlanStaticModels },
+  aider: {
+    prefix: 'openai',
+    apiKeyEnv: 'OPENAI_API_KEY',
+    sourceEnvKey: 'ALIBABA_PLAN_API_KEY',
+    readEnvFallback: true,
+    upstreamBaseUrl: ALIBABA_PLAN_BASE_URL,
+  },
+  overrides: { getProviderOptions: getAlibabaPlanProviderOptions },
+});

--- a/src/main/models/providers/anthropic-compatible.ts
+++ b/src/main/models/providers/anthropic-compatible.ts
@@ -1,21 +1,18 @@
-import { Model, ProviderProfile, Reasoning, SettingsData, TlsPolicyRegistrar } from '@common/types';
-import { isAnthropicCompatibleProvider, AnthropicCompatibleProvider, LlmProvider } from '@common/agent';
+import { isAnthropicCompatibleProvider, LlmProvider, AnthropicCompatibleProvider } from '@common/agent';
 import { createAnthropic } from '@ai-sdk/anthropic';
+import { Model, Reasoning, ProviderProfile, SettingsData, TlsPolicyRegistrar } from '@common/types';
 
-import type { LanguageModel, ToolSet } from 'ai';
 import type { SharedV4ProviderOptions } from '@ai-sdk/provider';
 
 import { AiderModelMapping, LlmProviderStrategy, LoadModelsResponse } from '@/models';
 import logger from '@/logger';
 import { getEffectiveEnvironmentVariable } from '@/utils';
-import { getAnthropicCacheControl } from '@/models/providers/anthropic';
-import { getDefaultUsageReport } from '@/models/providers/default';
 import { syncProviderTlsRule } from '@/models/utils';
+import { getAnthropicAdaptiveThinkingOptions, ensureV1Suffix, normalizeError, stripV1Suffix } from '@/models/providers/shared';
+import { getAnthropicCacheControl } from '@/models/providers/anthropic';
+import { createStrategyFromDescriptor } from '@/models/providers/strategy-factory';
 
-const ensureV1Suffix = (baseUrl: string): string => {
-  return baseUrl.endsWith('/v1') ? baseUrl : `${baseUrl}/v1`;
-};
-
+// loadModels keeps its Anthropic-specific fetch: x-api-key + anthropic-version headers
 const loadAnthropicCompatibleModels = async (
   profile: ProviderProfile,
   settings: SettingsData,
@@ -66,16 +63,10 @@ const loadAnthropicCompatibleModels = async (
     logger.info(`Loaded ${models.length} Anthropic-compatible models for profile ${profile.id}`);
     return { models, success: true };
   } catch (error) {
-    const errorMsg = typeof error === 'string' ? error : error instanceof Error ? error.message : 'Unknown error loading Anthropic-compatible models';
+    const errorMsg = normalizeError(error, 'Unknown error loading Anthropic-compatible models');
     logger.warn('Failed to fetch Anthropic-compatible models via API:', error);
     return { models: [], success: false, error: errorMsg };
   }
-};
-
-const hasAnthropicCompatibleEnvVars = (settings: SettingsData): boolean => {
-  const hasApiKey = !!getEffectiveEnvironmentVariable('ANTHROPIC_API_KEY', settings, undefined)?.value;
-  const hasBaseUrl = !!getEffectiveEnvironmentVariable('ANTHROPIC_API_BASE', settings, undefined)?.value;
-  return hasApiKey || hasBaseUrl;
 };
 
 const getAnthropicCompatibleAiderMapping = (provider: ProviderProfile, modelId: string, settings: SettingsData, projectDir: string): AiderModelMapping => {
@@ -103,7 +94,7 @@ const getAnthropicCompatibleAiderMapping = (provider: ProviderProfile, modelId: 
     envVars.ANTHROPIC_API_KEY = apiKey;
   }
   if (baseUrl) {
-    envVars.ANTHROPIC_BASE_URL = baseUrl.endsWith('/v1') ? baseUrl.slice(0, -3) : baseUrl;
+    envVars.ANTHROPIC_BASE_URL = stripV1Suffix(baseUrl);
   }
 
   // Use anthropic prefix for Anthropic-compatible providers
@@ -113,84 +104,34 @@ const getAnthropicCompatibleAiderMapping = (provider: ProviderProfile, modelId: 
   };
 };
 
-// === LLM Creation Functions ===
-const createAnthropicCompatibleLlm = (
-  profile: ProviderProfile,
-  model: Model,
-  settings: SettingsData,
-  projectDir: string,
-  _toolSet?: ToolSet,
-  _systemPrompt?: string,
-  _providerMetadata?: unknown,
-  tlsRegistrar?: TlsPolicyRegistrar,
-): LanguageModel => {
-  const provider = profile.provider as AnthropicCompatibleProvider;
-  let apiKey = provider.apiKey;
-  let baseUrl = provider.baseUrl;
-
-  if (!apiKey) {
-    const effectiveVar = getEffectiveEnvironmentVariable('ANTHROPIC_API_KEY', settings, projectDir);
-    if (effectiveVar) {
-      apiKey = effectiveVar.value;
-      logger.debug(`Loaded ANTHROPIC_API_KEY from ${effectiveVar.source}`);
-    }
-  }
-
-  if (!apiKey) {
-    throw new Error(`API key is required for ${provider.name}. Check Providers settings or Aider environment variables (ANTHROPIC_API_KEY).`);
-  }
-
-  if (!baseUrl) {
-    const effectiveVar = getEffectiveEnvironmentVariable('ANTHROPIC_API_BASE', settings, projectDir);
-    if (effectiveVar) {
-      baseUrl = effectiveVar.value;
-      logger.debug(`Loaded ANTHROPIC_API_BASE from ${effectiveVar.source}`);
-    }
-  }
-
-  if (!baseUrl) {
-    throw new Error(`Base URL is required for ${provider.name} provider. Set it in Providers settings or via the ANTHROPIC_API_BASE environment variable.`);
-  }
-
-  syncProviderTlsRule(tlsRegistrar, baseUrl, provider.sslVerify, provider.caCertPath);
-
-  // Use createAnthropic with custom baseURL to get a provider instance, then get the model.
-  // The @ai-sdk/anthropic SDK only appends `/messages` to the baseURL, so it must include `/v1`.
-  const anthropicProvider = createAnthropic({
-    apiKey,
-    baseURL: ensureV1Suffix(baseUrl),
-    headers: profile.headers,
-  });
-  return anthropicProvider(model.id);
-};
-
 export const getAnthropicCompatibleProviderOptions = (llmProvider: LlmProvider, _model: Model, reasoning?: Reasoning): SharedV4ProviderOptions | undefined => {
   if (!isAnthropicCompatibleProvider(llmProvider) || (reasoning && reasoning !== 'provider-default')) {
     return undefined;
   }
 
-  // Explicitly request adaptive thinking with summarized display so reasoning/thinking
-  // text is returned via thinking_delta events. Without this, newer Claude models (opus-4-7+)
-  // default to 'omitted' display and return empty thinking blocks.
-  return {
-    anthropic: {
-      thinking: { type: 'adaptive', display: 'summarized' },
-    },
-  } satisfies SharedV4ProviderOptions;
+  return getAnthropicAdaptiveThinkingOptions();
 };
 
-// === Complete Strategy Implementation ===
-export const anthropicCompatibleProviderStrategy: LlmProviderStrategy = {
-  // Core LLM functions
-  createLlm: createAnthropicCompatibleLlm,
-  getUsageReport: getDefaultUsageReport,
-
-  // Model discovery functions
-  loadModels: loadAnthropicCompatibleModels,
-  hasEnvVars: hasAnthropicCompatibleEnvVars,
-  getAiderMapping: getAnthropicCompatibleAiderMapping,
-
-  // Cache control
-  getCacheControl: getAnthropicCacheControl,
-  getProviderOptions: getAnthropicCompatibleProviderOptions,
-};
+export const anthropicCompatibleProviderStrategy: LlmProviderStrategy = createStrategyFromDescriptor({
+  name: 'anthropic-compatible',
+  label: 'Anthropic-compatible',
+  sdkFactory: createAnthropic,
+  apiKeyEnv: 'ANTHROPIC_API_KEY',
+  apiKeyRequired: (provider) => `API key is required for ${provider.name}. Check Providers settings or Aider environment variables (ANTHROPIC_API_KEY).`,
+  baseUrl: {
+    envKey: 'ANTHROPIC_API_BASE',
+    required: (provider) =>
+      `Base URL is required for ${provider.name} provider. Set it in Providers settings or via the ANTHROPIC_API_BASE environment variable.`,
+    // The @ai-sdk/anthropic SDK only appends `/messages` to the baseURL, so it must include /v1
+    transform: ensureV1Suffix,
+  },
+  tlsSync: true,
+  isProvider: isAnthropicCompatibleProvider,
+  hasEnvKeys: ['ANTHROPIC_API_KEY', 'ANTHROPIC_API_BASE'],
+  overrides: {
+    loadModels: loadAnthropicCompatibleModels,
+    getAiderMapping: getAnthropicCompatibleAiderMapping,
+    getCacheControl: getAnthropicCacheControl,
+    getProviderOptions: getAnthropicCompatibleProviderOptions,
+  },
+});

--- a/src/main/models/providers/anthropic.ts
+++ b/src/main/models/providers/anthropic.ts
@@ -5,11 +5,11 @@ import { Model, ProviderProfile, Reasoning, SettingsData } from '@common/types';
 import type { LanguageModel } from 'ai';
 import type { SharedV4ProviderOptions } from '@ai-sdk/provider';
 
-import logger from '@/logger';
 import { AiderModelMapping, CacheControl, LlmProviderStrategy } from '@/models';
 import { LoadModelsResponse } from '@/models/types';
 import { getEffectiveEnvironmentVariable } from '@/utils';
 import { getDefaultModelInfo, getDefaultUsageReport } from '@/models/providers/default';
+import { getAnthropicAdaptiveThinkingOptions, resolveProviderCredential } from '@/models/providers/shared';
 
 export const loadAnthropicModels = async (profile: ProviderProfile, settings: SettingsData): Promise<LoadModelsResponse> => {
   if (!isAnthropicProvider(profile.provider)) {
@@ -82,19 +82,14 @@ export const getAnthropicAiderMapping = (provider: ProviderProfile, modelId: str
 // === LLM Creation Functions ===
 export const createAnthropicLlm = (profile: ProviderProfile, model: Model, settings: SettingsData, projectDir: string): LanguageModel => {
   const provider = profile.provider as AnthropicProvider;
-  let apiKey = provider.apiKey;
-
-  if (!apiKey) {
-    const effectiveVar = getEffectiveEnvironmentVariable('ANTHROPIC_API_KEY', settings, projectDir);
-    if (effectiveVar) {
-      apiKey = effectiveVar.value;
-      logger.debug(`Loaded ANTHROPIC_API_KEY from ${effectiveVar.source}`);
-    }
-  }
-
-  if (!apiKey) {
-    throw new Error('Anthropic API key is required in Providers settings or Aider environment variables (ANTHROPIC_API_KEY)');
-  }
+  const apiKey = resolveProviderCredential({
+    provider,
+    field: 'apiKey',
+    settings,
+    projectDir,
+    envKey: 'ANTHROPIC_API_KEY',
+    required: 'Anthropic API key is required in Providers settings or Aider environment variables (ANTHROPIC_API_KEY)',
+  });
 
   const anthropicProvider = createAnthropic({
     apiKey,
@@ -120,14 +115,7 @@ export const getAnthropicProviderOptions = (llmProvider: LlmProvider, _model: Mo
     return undefined;
   }
 
-  // Explicitly request adaptive thinking with summarized display so reasoning/thinking
-  // text is returned via thinking_delta events. Without this, newer Claude models (opus-4-7+)
-  // default to 'omitted' display and return empty thinking blocks.
-  return {
-    anthropic: {
-      thinking: { type: 'adaptive', display: 'summarized' },
-    },
-  } satisfies SharedV4ProviderOptions;
+  return getAnthropicAdaptiveThinkingOptions();
 };
 
 // === Complete Strategy Implementation ===

--- a/src/main/models/providers/azure.ts
+++ b/src/main/models/providers/azure.ts
@@ -1,7 +1,6 @@
 import { createAzure } from '@ai-sdk/azure';
 import { Model, ProviderProfile, ReasoningEffort, SettingsData, Reasoning } from '@common/types';
 import { AzureProvider, isAzureProvider, LlmProvider } from '@common/agent';
-import { type OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
 
 import type { LanguageModel } from 'ai';
 import type { SharedV4ProviderOptions } from '@ai-sdk/provider';
@@ -10,6 +9,7 @@ import logger from '@/logger';
 import { AiderModelMapping, LlmProviderStrategy } from '@/models';
 import { getEffectiveEnvironmentVariable } from '@/utils';
 import { getDefaultModelInfo, getDefaultUsageReport } from '@/models/providers/default';
+import { getOpenAiFamilyProviderOptions, mergeModelProps } from '@/models/providers/shared';
 
 const extractResourceNameFromEndpoint = (endpoint: string): string => {
   try {
@@ -92,42 +92,10 @@ export const createAzureLlm = (profile: ProviderProfile, model: Model, settings:
 
 export const getAzureProviderOptions = (llmProvider: LlmProvider, model: Model, reasoning?: Reasoning): SharedV4ProviderOptions | undefined => {
   if (isAzureProvider(llmProvider)) {
-    // When the top-level reasoning parameter is set (not undefined or 'provider-default'),
-    // omit reasoningEffort from providerOptions so the AI SDK's portable reasoning takes effect.
-    // Keep reasoningSummary so reasoning output is still returned.
-    if (reasoning && reasoning !== 'provider-default') {
-      return {
-        openai: {
-          reasoningSummary: 'auto',
-        } satisfies OpenAIResponsesProviderOptions,
-      };
-    }
-
     // Extract reasoningEffort from model overrides or provider config
-    const providerOverrides = model.providerOverrides as Partial<AzureProvider> | undefined;
-    const reasoningEffort = providerOverrides?.reasoningEffort ?? llmProvider.reasoningEffort;
+    const { reasoningEffort } = mergeModelProps(model, llmProvider, ['reasoningEffort']);
 
-    // Map ReasoningEffort enum to AI SDK format
-    const mappedReasoningEffort =
-      reasoningEffort === undefined || reasoningEffort === ReasoningEffort.None
-        ? undefined
-        : (reasoningEffort.toLowerCase() as 'minimal' | 'low' | 'medium' | 'high' | 'xhigh');
-
-    const options: OpenAIResponsesProviderOptions = {};
-
-    if (mappedReasoningEffort) {
-      logger.debug('Using reasoning effort:', { mappedReasoningEffort });
-      options.reasoningEffort = mappedReasoningEffort;
-      options.reasoningSummary = 'auto';
-    }
-
-    if (Object.keys(options).length === 0) {
-      return undefined;
-    }
-
-    return {
-      openai: options,
-    };
+    return getOpenAiFamilyProviderOptions('openai', reasoningEffort, reasoning);
   }
 
   return undefined;

--- a/src/main/models/providers/cerebras.ts
+++ b/src/main/models/providers/cerebras.ts
@@ -1,120 +1,25 @@
-import { Model, ProviderProfile, SettingsData } from '@common/types';
-import { CerebrasProvider, isCerebrasProvider } from '@common/agent';
+import { isCerebrasProvider } from '@common/agent';
 import { createCerebras } from '@ai-sdk/cerebras';
 
-import type { LanguageModel } from 'ai';
+import { LlmProviderStrategy } from '@/models';
+import { createStrategyFromDescriptor } from '@/models/providers/strategy-factory';
 
-import { AiderModelMapping, LlmProviderStrategy } from '@/models';
-import logger from '@/logger';
-import { getEffectiveEnvironmentVariable } from '@/utils/environment';
-import { LoadModelsResponse } from '@/models/types';
-import { getDefaultModelInfo, getDefaultUsageReport } from '@/models/providers/default';
+export const cerebrasProviderStrategy: LlmProviderStrategy = createStrategyFromDescriptor({
+  name: 'cerebras',
+  label: 'Cerebras',
+  sdkFactory: createCerebras,
+  apiKeyEnv: 'CEREBRAS_API_KEY',
+  isProvider: isCerebrasProvider,
+  modelsLoader: {
+    type: 'openai-compatible',
+    url: 'https://api.cerebras.ai/v1/models',
+    noKeyDebug: 'Cerebras API key is required. Please set it in Providers settings or via CEREBRAS_API_KEY environment variable.',
+    mapper: (id, item) => ({
+      id,
+      maxInputTokens: (item as { max_context_length?: number }).max_context_length,
+    }),
+  },
+  aider: { prefix: 'cerebras', apiKeyEnv: 'CEREBRAS_API_KEY' },
+});
 
-interface CerebrasModel {
-  id: string;
-  max_context_length?: number;
-  description?: string;
-}
-
-export const loadCerebrasModels = async (profile: ProviderProfile, settings: SettingsData): Promise<LoadModelsResponse> => {
-  if (!isCerebrasProvider(profile.provider)) {
-    return { models: [], success: false };
-  }
-
-  const provider = profile.provider;
-  const apiKey = provider.apiKey || '';
-  const apiKeyEnv = getEffectiveEnvironmentVariable('CEREBRAS_API_KEY', settings);
-  const effectiveApiKey = apiKey || apiKeyEnv?.value || '';
-
-  if (!effectiveApiKey) {
-    logger.debug('Cerebras API key is required. Please set it in Providers settings or via CEREBRAS_API_KEY environment variable.');
-    return { models: [], success: false };
-  }
-
-  try {
-    const response = await fetch('https://api.cerebras.ai/v1/models', {
-      headers: { Authorization: `Bearer ${effectiveApiKey}` },
-    });
-
-    if (!response.ok) {
-      const errorMsg = `Cerebras models API response failed: ${response.status} ${response.statusText} ${await response.text()}`;
-      logger.error(errorMsg, {
-        status: response.status,
-        statusText: response.statusText,
-      });
-      return { models: [], success: false, error: errorMsg };
-    }
-
-    const data = await response.json();
-    const models =
-      data.data?.map((model: CerebrasModel) => {
-        return {
-          id: model.id,
-          providerId: profile.id,
-          maxInputTokens: model.max_context_length,
-        } satisfies Model;
-      }) || [];
-
-    logger.info(`Loaded ${models.length} Cerebras models for profile ${profile.id}`);
-    return { models, success: true };
-  } catch (error) {
-    const errorMsg = typeof error === 'string' ? error : error instanceof Error ? error.message : 'Unknown error loading Cerebras models';
-    logger.error('Error loading Cerebras models:', error);
-    return { models: [], success: false, error: errorMsg };
-  }
-};
-
-export const hasCerebrasEnvVars = (settings: SettingsData): boolean => {
-  return !!getEffectiveEnvironmentVariable('CEREBRAS_API_KEY', settings, undefined)?.value;
-};
-
-export const getCerebrasAiderMapping = (provider: ProviderProfile, modelId: string): AiderModelMapping => {
-  const cerebrasProvider = provider.provider as CerebrasProvider;
-  const envVars: Record<string, string> = {};
-
-  if (cerebrasProvider.apiKey) {
-    envVars.CEREBRAS_API_KEY = cerebrasProvider.apiKey;
-  }
-
-  return {
-    modelName: `cerebras/${modelId}`,
-    environmentVariables: envVars,
-  };
-};
-
-// === LLM Creation Functions ===
-export const createCerebrasLlm = (profile: ProviderProfile, model: Model, settings: SettingsData, projectDir: string): LanguageModel => {
-  const provider = profile.provider as CerebrasProvider;
-  let apiKey = provider.apiKey;
-
-  if (!apiKey) {
-    const effectiveVar = getEffectiveEnvironmentVariable('CEREBRAS_API_KEY', settings, projectDir);
-    if (effectiveVar) {
-      apiKey = effectiveVar.value;
-      logger.debug(`Loaded CEREBRAS_API_KEY from ${effectiveVar.source}`);
-    }
-  }
-
-  if (!apiKey) {
-    throw new Error('Cerebras API key is required in Providers settings or Aider environment variables (CEREBRAS_API_KEY)');
-  }
-
-  const cerebrasProvider = createCerebras({
-    apiKey,
-    headers: profile.headers,
-  });
-  return cerebrasProvider(model.id);
-};
-
-// === Complete Strategy Implementation ===
-export const cerebrasProviderStrategy: LlmProviderStrategy = {
-  // Core LLM functions
-  createLlm: createCerebrasLlm,
-  getUsageReport: getDefaultUsageReport,
-
-  // Model discovery functions
-  loadModels: loadCerebrasModels,
-  hasEnvVars: hasCerebrasEnvVars,
-  getAiderMapping: getCerebrasAiderMapping,
-  getModelInfo: getDefaultModelInfo,
-};
+export const loadCerebrasModels = cerebrasProviderStrategy.loadModels;

--- a/src/main/models/providers/clinepass.ts
+++ b/src/main/models/providers/clinepass.ts
@@ -1,13 +1,13 @@
-import { Model, ProviderProfile, SettingsData } from '@common/types';
 import { ClinePassProvider, isClinePassProvider } from '@common/agent';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
-
-import type { LanguageModel } from 'ai';
+import { Model, ProviderProfile, SettingsData } from '@common/types';
 
 import { AiderModelMapping, LlmProviderStrategy, LoadModelsResponse } from '@/models';
 import logger from '@/logger';
 import { getEffectiveEnvironmentVariable } from '@/utils';
-import { getDefaultModelInfo, getDefaultUsageReport } from '@/models/providers/default';
+import { createStrategyFromDescriptor } from '@/models/providers/strategy-factory';
+import { normalizeError } from '@/models/providers/shared';
+import { MINIMAX_M3_MODEL_PRICING } from '@/models/providers/minimax';
 
 const CLINEPASS_BASE_URL = 'https://api.cline.bot/api/v1';
 
@@ -72,10 +72,7 @@ const CLINEPASS_MODELS: ClinePassModelMetadata[] = [
   },
   {
     id: 'minimax-m3',
-    maxInputTokens: 1000000,
-    inputCostPerToken: 0.0000003, // $0.30 per 1M
-    outputCostPerToken: 0.0000012, // $1.20 per 1M
-    cacheReadInputTokenCost: 0.00000006, // $0.06 per 1M
+    ...MINIMAX_M3_MODEL_PRICING,
   },
   {
     id: 'qwen3.7-max',
@@ -115,6 +112,9 @@ interface ClinePassApiResponse {
   data: ClinePassApiModel[];
 }
 
+const clinePassStaticModels = (profile: ProviderProfile): Model[] => CLINEPASS_MODELS.map((m) => toClinePassModel(m, profile.id));
+
+// ClinePass consults CLINE_API_KEY even when provider.apiKey is set
 const resolveApiKey = (provider: ClinePassProvider, settings: SettingsData, projectDir?: string): string => {
   const envKey = getEffectiveEnvironmentVariable('CLINE_API_KEY', settings, projectDir);
   return provider.apiKey || envKey?.value || '';
@@ -130,7 +130,7 @@ export const loadClinePassModels = async (profile: ProviderProfile, settings: Se
 
   if (!apiKey) {
     logger.debug('ClinePass API key not available, using static model list');
-    const models = CLINEPASS_MODELS.map((m) => toClinePassModel(m, profile.id));
+    const models = clinePassStaticModels(profile);
     return { models, success: true };
   }
 
@@ -142,8 +142,7 @@ export const loadClinePassModels = async (profile: ProviderProfile, settings: Se
     if (!response.ok) {
       const errorMsg = `ClinePass models API response failed: ${response.status} ${response.statusText} ${await response.text()}`;
       logger.debug(errorMsg);
-      const models = CLINEPASS_MODELS.map((m) => toClinePassModel(m, profile.id));
-      return { models, success: true };
+      return { models: clinePassStaticModels(profile), success: true };
     }
 
     const data: ClinePassApiResponse = await response.json();
@@ -161,25 +160,19 @@ export const loadClinePassModels = async (profile: ProviderProfile, settings: Se
 
     if (models.length === 0) {
       logger.debug('No models returned from ClinePass API, using static model list');
-      const staticModels = CLINEPASS_MODELS.map((m) => toClinePassModel(m, profile.id));
-      return { models: staticModels, success: true };
+      return { models: clinePassStaticModels(profile), success: true };
     }
 
     logger.info(`Loaded ${models.length} ClinePass models for profile ${profile.id}`);
     return { models, success: true };
   } catch (error) {
-    const errorMsg = typeof error === 'string' ? error : error instanceof Error ? error.message : 'Unknown error loading ClinePass models';
+    const errorMsg = normalizeError(error, 'Unknown error loading ClinePass models');
     logger.warn('Failed to fetch ClinePass models via API:', error);
-    const models = CLINEPASS_MODELS.map((m) => toClinePassModel(m, profile.id));
-    return { models, success: true, error: errorMsg };
+    return { models: clinePassStaticModels(profile), success: true, error: errorMsg };
   }
 };
 
-export const hasClinePassEnvVars = (settings: SettingsData): boolean => {
-  return !!getEffectiveEnvironmentVariable('CLINE_API_KEY', settings, undefined)?.value;
-};
-
-export const getClinePassAiderMapping = (provider: ProviderProfile, modelId: string, settings: SettingsData, projectDir: string): AiderModelMapping => {
+const getClinePassAiderMapping = (provider: ProviderProfile, modelId: string, settings: SettingsData, projectDir: string): AiderModelMapping => {
   const clinePassProvider = provider.provider as ClinePassProvider;
   const envVars: Record<string, string> = {
     OPENAI_API_BASE: CLINEPASS_BASE_URL,
@@ -196,28 +189,19 @@ export const getClinePassAiderMapping = (provider: ProviderProfile, modelId: str
   };
 };
 
-export const createClinePassLlm = (profile: ProviderProfile, model: Model, settings: SettingsData, projectDir: string): LanguageModel => {
-  const provider = profile.provider as ClinePassProvider;
-  const apiKey = resolveApiKey(provider, settings, projectDir);
-
-  if (!apiKey) {
-    throw new Error('ClinePass API key is required in Providers settings or Aider environment variables (CLINE_API_KEY)');
-  }
-
-  const compatibleProvider = createOpenAICompatible({
-    name: 'clinepass',
-    apiKey,
-    baseURL: CLINEPASS_BASE_URL,
-    headers: profile.headers,
-  });
-  return compatibleProvider(`cline-pass/${model.id}`);
-};
-
-export const clinePassProviderStrategy: LlmProviderStrategy = {
-  createLlm: createClinePassLlm,
-  getUsageReport: getDefaultUsageReport,
-  loadModels: loadClinePassModels,
-  hasEnvVars: hasClinePassEnvVars,
-  getAiderMapping: getClinePassAiderMapping,
-  getModelInfo: getDefaultModelInfo,
-};
+export const clinePassProviderStrategy: LlmProviderStrategy = createStrategyFromDescriptor({
+  name: 'clinepass',
+  label: 'ClinePass',
+  sdkFactory: createOpenAICompatible,
+  apiKeyEnv: 'CLINE_API_KEY',
+  apiKeyRequired: () => 'ClinePass API key is required in Providers settings or Aider environment variables (CLINE_API_KEY)',
+  credResolver: ({ provider, settings, projectDir }) => resolveApiKey(provider as unknown as ClinePassProvider, settings, projectDir),
+  fixedBaseURL: CLINEPASS_BASE_URL,
+  extraFactoryOptions: () => ({ name: 'clinepass' }),
+  createModelId: (model) => `cline-pass/${model.id}`,
+  isProvider: isClinePassProvider,
+  overrides: {
+    loadModels: loadClinePassModels,
+    getAiderMapping: getClinePassAiderMapping,
+  },
+});

--- a/src/main/models/providers/deepseek.ts
+++ b/src/main/models/providers/deepseek.ts
@@ -1,99 +1,14 @@
-import { Model, ProviderProfile, Reasoning, SettingsData } from '@common/types';
-import { DeepseekProvider, isDeepseekProvider, LlmProvider } from '@common/agent';
+import { isDeepseekProvider, LlmProvider } from '@common/agent';
 import { createDeepSeek } from '@ai-sdk/deepseek';
+import { Model, Reasoning } from '@common/types';
 
 import type { SharedV4ProviderOptions } from '@ai-sdk/provider';
-import type { LanguageModel } from 'ai';
 
-import { AiderModelMapping, LlmProviderStrategy, LoadModelsResponse } from '@/models';
-import logger from '@/logger';
-import { getEffectiveEnvironmentVariable } from '@/utils';
-import { getDefaultModelInfo, getDefaultUsageReport } from '@/models/providers/default';
+import { LlmProviderStrategy } from '@/models';
+import { createStrategyFromDescriptor } from '@/models/providers/strategy-factory';
+import { mergeModelProps } from '@/models/providers/shared';
 
-export const loadDeepseekModels = async (profile: ProviderProfile, settings: SettingsData): Promise<LoadModelsResponse> => {
-  if (!isDeepseekProvider(profile.provider)) {
-    return { models: [], success: false };
-  }
-
-  const provider = profile.provider as DeepseekProvider;
-  const apiKey = provider.apiKey || '';
-  const apiKeyEnv = getEffectiveEnvironmentVariable('DEEPSEEK_API_KEY', settings);
-
-  if (!apiKey && !apiKeyEnv?.value) {
-    return { models: [], success: false };
-  }
-
-  try {
-    const response = await fetch('https://api.deepseek.com/v1/models', {
-      headers: { Authorization: `Bearer ${apiKey || apiKeyEnv?.value || ''}` },
-    });
-    if (!response.ok) {
-      const errorMsg = `DeepSeek models API response failed: ${response.status} ${response.statusText} ${await response.text()}`;
-      logger.error(errorMsg, response.status, response.statusText);
-      return { models: [], success: false, error: errorMsg };
-    }
-
-    const data = await response.json();
-    const models =
-      data.data?.map((m: { id: string }) => {
-        return {
-          id: m.id,
-          providerId: profile.id,
-        } satisfies Model;
-      }) || [];
-
-    logger.info(`Loaded ${models.length} DeepSeek models for profile ${profile.id}`);
-    return { models, success: true };
-  } catch (error) {
-    const errorMsg = typeof error === 'string' ? error : error instanceof Error ? error.message : 'Unknown error loading DeepSeek models';
-    logger.error('Error loading DeepSeek models:', error);
-    return { models: [], success: false, error: errorMsg };
-  }
-};
-
-export const hasDeepseekEnvVars = (settings: SettingsData): boolean => {
-  return !!getEffectiveEnvironmentVariable('DEEPSEEK_API_KEY', settings, undefined)?.value;
-};
-
-export const getDeepseekAiderMapping = (provider: ProviderProfile, modelId: string): AiderModelMapping => {
-  const deepseekProvider = provider.provider as DeepseekProvider;
-  const envVars: Record<string, string> = {};
-
-  if (deepseekProvider.apiKey) {
-    envVars.DEEPSEEK_API_KEY = deepseekProvider.apiKey;
-  }
-
-  return {
-    modelName: `deepseek/${modelId}`,
-    environmentVariables: envVars,
-  };
-};
-
-// === LLM Creation Functions ===
-export const createDeepseekLlm = (profile: ProviderProfile, model: Model, settings: SettingsData, projectDir: string): LanguageModel => {
-  const provider = profile.provider as DeepseekProvider;
-  let apiKey = provider.apiKey;
-
-  if (!apiKey) {
-    const effectiveVar = getEffectiveEnvironmentVariable('DEEPSEEK_API_KEY', settings, projectDir);
-    if (effectiveVar) {
-      apiKey = effectiveVar.value;
-      logger.debug(`Loaded DEEPSEEK_API_KEY from ${effectiveVar.source}`);
-    }
-  }
-
-  if (!apiKey) {
-    throw new Error('Deepseek API key is required in Providers settings or Aider environment variables (DEEPSEEK_API_KEY)');
-  }
-
-  const deepseekProvider = createDeepSeek({
-    apiKey,
-    headers: profile.headers,
-  });
-  return deepseekProvider(model.id);
-};
-
-const getDeepseekProviderOptions = (llmProvider: LlmProvider, model: Model, reasoning?: Reasoning): SharedV4ProviderOptions | undefined => {
+export const getDeepseekProviderOptions = (llmProvider: LlmProvider, model: Model, reasoning?: Reasoning): SharedV4ProviderOptions | undefined => {
   if (!isDeepseekProvider(llmProvider)) {
     return undefined;
   }
@@ -111,9 +26,9 @@ const getDeepseekProviderOptions = (llmProvider: LlmProvider, model: Model, reas
     return undefined;
   }
 
-  const providerOverrides = model.providerOverrides as Partial<DeepseekProvider> | undefined;
-  const thinkingEnabled = providerOverrides?.thinkingEnabled ?? llmProvider.thinkingEnabled ?? true;
-  const reasoningEffort = providerOverrides?.reasoningEffort ?? llmProvider.reasoningEffort ?? 'high';
+  const overrides = mergeModelProps(model, llmProvider, ['thinkingEnabled', 'reasoningEffort']);
+  const thinkingEnabled = overrides.thinkingEnabled ?? true;
+  const reasoningEffort = overrides.reasoningEffort ?? 'high';
 
   return {
     deepseek: {
@@ -128,8 +43,8 @@ const getDeepseekProviderParameters = (llmProvider: LlmProvider, model: Model, r
     return {};
   }
 
-  const providerOverrides = model.providerOverrides as Partial<DeepseekProvider> | undefined;
-  const configuredThinkingEnabled = providerOverrides?.thinkingEnabled ?? llmProvider.thinkingEnabled ?? true;
+  const overrides = mergeModelProps(model, llmProvider, ['thinkingEnabled']);
+  const configuredThinkingEnabled = overrides.thinkingEnabled ?? true;
   const thinkingEnabled = reasoning && reasoning !== 'provider-default' ? reasoning !== 'none' : configuredThinkingEnabled;
 
   if (thinkingEnabled) {
@@ -142,18 +57,23 @@ const getDeepseekProviderParameters = (llmProvider: LlmProvider, model: Model, r
   return {};
 };
 
-// === Complete Strategy Implementation ===
-export const deepseekProviderStrategy: LlmProviderStrategy = {
-  // Core LLM functions
-  createLlm: createDeepseekLlm,
-  getUsageReport: getDefaultUsageReport,
+export const deepseekProviderStrategy: LlmProviderStrategy = createStrategyFromDescriptor({
+  name: 'deepseek',
+  // error message spells the name without the internal 'DeepSeek' casing
+  label: 'DeepSeek',
+  sdkFactory: createDeepSeek,
+  apiKeyEnv: 'DEEPSEEK_API_KEY',
+  apiKeyRequired: 'Deepseek API key is required in Providers settings or Aider environment variables (DEEPSEEK_API_KEY)',
+  isProvider: isDeepseekProvider,
+  modelsLoader: {
+    type: 'openai-compatible',
+    url: 'https://api.deepseek.com/v1/models',
+  },
+  aider: { prefix: 'deepseek', apiKeyEnv: 'DEEPSEEK_API_KEY' },
+  overrides: {
+    getProviderOptions: getDeepseekProviderOptions,
+    getProviderParameters: getDeepseekProviderParameters,
+  },
+});
 
-  // Model discovery functions
-  loadModels: loadDeepseekModels,
-  hasEnvVars: hasDeepseekEnvVars,
-  getAiderMapping: getDeepseekAiderMapping,
-  getModelInfo: getDefaultModelInfo,
-
-  getProviderOptions: getDeepseekProviderOptions,
-  getProviderParameters: getDeepseekProviderParameters,
-};
+export const loadDeepseekModels = deepseekProviderStrategy.loadModels;

--- a/src/main/models/providers/default.ts
+++ b/src/main/models/providers/default.ts
@@ -6,13 +6,16 @@ import { Task } from '@/task';
 import logger from '@/logger';
 
 export const getDefaultModelInfo = (provider: ProviderProfile, modelId: string, allModelInfos: Record<string, ModelInfo>): ModelInfo | undefined => {
-  // Try provider.name prefix first
-  let fullModelId = `${provider.name}/${modelId}`;
+  // Canonical profile identity first: modelsInfo is keyed by catalog provider
+  // ids (openai, google, ...), and profile.name is an arbitrary user-facing
+  // label that must not shadow or substitute for it (a profile merely named
+  // after another catalog provider would otherwise inherit its metadata).
+  let fullModelId = `${provider.id}/${modelId}`;
   let modelInfo = allModelInfos[fullModelId];
 
-  // If not found, try provider.id prefix
-  if (!modelInfo) {
-    fullModelId = `${provider.id}/${modelId}`;
+  // Fall back to the profile name only when the canonical id has no entry
+  if (!modelInfo && provider.name) {
+    fullModelId = `${provider.name}/${modelId}`;
     modelInfo = allModelInfos[fullModelId];
   }
 

--- a/src/main/models/providers/gemini.ts
+++ b/src/main/models/providers/gemini.ts
@@ -1,8 +1,7 @@
-import { ContextUserMessage, Model, ModelInfo, ProviderProfile, SettingsData, UsageReportData, VoiceSession, Reasoning } from '@common/types';
+import { Model, ProviderProfile, SettingsData, UsageReportData, VoiceSession, Reasoning } from '@common/types';
 import { DEFAULT_VOICE_SYSTEM_INSTRUCTIONS, GeminiProvider, GeminiVoiceModel, isGeminiProvider, LlmProvider } from '@common/agent';
-import { createGoogle, google, type GoogleLanguageModelOptions } from '@ai-sdk/google';
+import { createGoogle, google } from '@ai-sdk/google';
 import { Modality } from '@google/genai';
-import { v4 as uuidv4 } from 'uuid';
 
 import type { LanguageModel, LanguageModelUsage, ModelMessage, ToolSet } from 'ai';
 import type { SharedV4ProviderOptions } from '@ai-sdk/provider';
@@ -11,7 +10,8 @@ import { AiderModelMapping, LlmProviderStrategy, LoadModelsResponse } from '@/mo
 import logger from '@/logger';
 import { getEffectiveEnvironmentVariable } from '@/utils';
 import { Task } from '@/task/task';
-import { calculateCost } from '@/models/providers/default';
+import { appendContinueUserMessage, getModelInfoByPrefix, normalizeError } from '@/models/providers/shared';
+import { getGoogleFamilyProviderOptions, getGoogleFamilyUsageReport } from '@/models/providers/google-family';
 
 const loadGeminiModels = async (profile: ProviderProfile, settings: SettingsData): Promise<LoadModelsResponse> => {
   if (!isGeminiProvider(profile.provider)) {
@@ -59,7 +59,7 @@ const loadGeminiModels = async (profile: ProviderProfile, settings: SettingsData
     logger.info(`Loaded ${models.length} Gemini models for profile ${profile.id}`);
     return { models, success: true };
   } catch (error) {
-    const errorMsg = typeof error === 'string' ? error : error instanceof Error ? error.message : 'Unknown error loading Gemini models';
+    const errorMsg = normalizeError(error, 'Unknown error loading Gemini models');
     logger.error('Error loading Gemini models:', error);
     return { models: [], success: false, error: errorMsg };
   }
@@ -121,72 +121,21 @@ const createGeminiLlm = (profile: ProviderProfile, model: Model, settings: Setti
   return googleProvider(model.id);
 };
 
-type GoogleMetadata = {
-  google: {
-    cachedContentTokenCount?: number;
-  };
-};
-
-const getGeminiUsageReport = (task: Task, provider: ProviderProfile, model: Model, usage: LanguageModelUsage, providerMetadata?: unknown): UsageReportData => {
-  const totalSentTokens = usage.inputTokens || 0;
-  const receivedTokens = usage.outputTokens || 0;
-
-  // Extract cache read tokens from provider metadata or usage
-  const { google } = (providerMetadata as GoogleMetadata) || {};
-  const cacheReadTokens = google?.cachedContentTokenCount ?? usage.inputTokenDetails?.cacheReadTokens ?? 0;
-
-  // Calculate sentTokens after deducting cached tokens
-  const sentTokens = totalSentTokens - cacheReadTokens;
-
-  // Calculate cost internally with already deducted sentTokens
-  const messageCost = calculateCost(model, sentTokens, receivedTokens, cacheReadTokens);
-
-  return {
-    model: `${provider.id}/${model.id}`,
-    sentTokens,
-    receivedTokens,
-    cacheReadTokens,
-    messageCost,
-    agentTotalCost: task.task.agentTotalCost + messageCost,
-  };
-};
+const getGeminiUsageReport = (task: Task, provider: ProviderProfile, model: Model, usage: LanguageModelUsage, providerMetadata?: unknown): UsageReportData =>
+  getGoogleFamilyUsageReport('google', task, provider, model, usage, providerMetadata);
 
 const getGeminiProviderOptions = (llmProvider: LlmProvider, model: Model, reasoning?: Reasoning): SharedV4ProviderOptions | undefined => {
-  if (isGeminiProvider(llmProvider)) {
-    const providerOverrides = model.providerOverrides as Partial<GeminiProvider> | undefined;
-
-    // Use model-specific overrides, falling back to provider defaults
-    const includeThoughts = providerOverrides?.includeThoughts ?? llmProvider.includeThoughts;
-    const thinkingBudget = providerOverrides?.thinkingBudget ?? llmProvider.thinkingBudget;
-
-    // When the top-level reasoning parameter is set (not undefined or 'provider-default'),
-    // omit thinkingBudget from thinkingConfig so the AI SDK's portable reasoning takes effect.
-    // Keep includeThoughts if set so reasoning output is still returned.
-    if (reasoning && reasoning !== 'provider-default') {
-      return {
-        google: {
-          ...(includeThoughts && {
-            thinkingConfig: {
-              includeThoughts: true,
-            },
-          }),
-        } satisfies GoogleLanguageModelOptions,
-      };
-    }
-
-    return {
-      google: {
-        ...((includeThoughts || thinkingBudget) && {
-          thinkingConfig: {
-            includeThoughts: includeThoughts && (thinkingBudget ?? 0) > 0,
-            thinkingBudget,
-          },
-        }),
-      } satisfies GoogleLanguageModelOptions,
-    };
+  if (!isGeminiProvider(llmProvider)) {
+    return undefined;
   }
 
-  return undefined;
+  const providerOverrides = model.providerOverrides as Partial<GeminiProvider> | undefined;
+
+  // Use model-specific overrides, falling back to provider defaults
+  const includeThoughts = providerOverrides?.includeThoughts ?? llmProvider.includeThoughts;
+  const thinkingBudget = providerOverrides?.thinkingBudget ?? llmProvider.thinkingBudget;
+
+  return getGoogleFamilyProviderOptions('google', includeThoughts, thinkingBudget, reasoning);
 };
 
 // === Provider Tools Functions ===
@@ -208,31 +157,8 @@ const getGeminiProviderTools = (provider: LlmProvider, model: Model): ToolSet =>
   } as ToolSet;
 };
 
-const getGeminiModelInfo = (_provider: ProviderProfile, modelId: string, allModelInfos: Record<string, ModelInfo>): ModelInfo | undefined => {
-  const fullModelId = `google/${modelId}`;
-  return allModelInfos[fullModelId];
-};
-
-const normalizeGeminiMessages = (_provider: LlmProvider, _model: Model, messages: ModelMessage[]): ModelMessage[] => {
-  if (messages.length === 0) {
-    return messages;
-  }
-
-  const lastMessage = messages[messages.length - 1];
-
-  if (lastMessage.role !== 'user') {
-    const continueMessage: ContextUserMessage = {
-      id: uuidv4(),
-      role: 'user',
-      content: 'Continue',
-    };
-
-    logger.debug('Added "Continue" user message for Gemini provider (last message was not a user message)');
-    return [...messages, continueMessage];
-  }
-
-  return messages;
-};
+const normalizeGeminiMessages = (_provider: LlmProvider, _model: Model, messages: ModelMessage[]): ModelMessage[] =>
+  appendContinueUserMessage(messages, 'Gemini provider');
 
 const createGeminiVoiceSession = async (profile: ProviderProfile, settings: SettingsData): Promise<VoiceSession> => {
   if (!isGeminiProvider(profile.provider)) {
@@ -337,7 +263,7 @@ export const geminiProviderStrategy: LlmProviderStrategy = {
 
   getProviderOptions: getGeminiProviderOptions,
   getProviderTools: getGeminiProviderTools,
-  getModelInfo: getGeminiModelInfo,
+  getModelInfo: getModelInfoByPrefix('google'),
   createVoiceSession: createGeminiVoiceSession,
 
   // Message normalization

--- a/src/main/models/providers/google-family.ts
+++ b/src/main/models/providers/google-family.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared behavior for the Gemini / Vertex AI strategies: the two usage reports and
+ * thinkingConfig builders are near-verbatim twins that differ only in the provider
+ * metadata / options registry key (`google` vs `vertex`), which callers pass in.
+ */
+import { Model, ProviderProfile, Reasoning, UsageReportData } from '@common/types';
+
+import type { GoogleLanguageModelOptions } from '@ai-sdk/google';
+import type { SharedV4ProviderOptions } from '@ai-sdk/provider';
+import type { LanguageModelUsage } from 'ai';
+import type { Task } from '@/task/task';
+
+import { calculateCost } from '@/models/providers/default';
+
+type GoogleFamilyMetadata = {
+  google?: {
+    cachedContentTokenCount?: number;
+  };
+  vertex?: {
+    cachedContentTokenCount?: number;
+  };
+};
+
+/**
+ * Deducts cached tokens from the sent-token count and prices the request with the
+ * shared calculateCost defaults, reading cachedContentTokenCount from the Google
+ * family metadata bucket named `metadataKey` before falling back to usage details.
+ */
+export const getGoogleFamilyUsageReport = (
+  metadataKey: 'google' | 'vertex',
+  task: Task,
+  provider: ProviderProfile,
+  model: Model,
+  usage: LanguageModelUsage,
+  providerMetadata?: unknown,
+): UsageReportData => {
+  const totalSentTokens = usage.inputTokens || 0;
+  const receivedTokens = usage.outputTokens || 0;
+
+  // Extract cache read tokens from provider metadata or usage
+  const familyMetadata = (providerMetadata as GoogleFamilyMetadata | undefined)?.[metadataKey];
+  const cacheReadTokens = familyMetadata?.cachedContentTokenCount ?? usage.inputTokenDetails?.cacheReadTokens ?? 0;
+
+  // Calculate sentTokens after deducting cached tokens
+  const sentTokens = totalSentTokens - cacheReadTokens;
+
+  // Calculate cost internally with already deducted sentTokens
+  const messageCost = calculateCost(model, sentTokens, receivedTokens, cacheReadTokens);
+
+  return {
+    model: `${provider.id}/${model.id}`,
+    sentTokens,
+    receivedTokens,
+    cacheReadTokens,
+    messageCost,
+    agentTotalCost: task.task.agentTotalCost + messageCost,
+  };
+};
+
+/**
+ * Builds the thinkingConfig provider options for Gemini / Vertex AI, keyed by
+ * `metadataKey`. `includeThoughts`/`thinkingBudget` must already be resolved by
+ * the caller (model-specific overrides falling back to provider defaults).
+ */
+export const getGoogleFamilyProviderOptions = (
+  metadataKey: 'google' | 'vertex',
+  includeThoughts: boolean,
+  thinkingBudget: number | undefined,
+  reasoning?: Reasoning,
+): SharedV4ProviderOptions | undefined => {
+  // When the top-level reasoning parameter is set (not undefined or 'provider-default'),
+  // omit thinkingBudget from thinkingConfig so the AI SDK's portable reasoning takes effect.
+  // Keep includeThoughts if set so reasoning output is still returned.
+  if (reasoning && reasoning !== 'provider-default') {
+    return {
+      [metadataKey]: {
+        ...(includeThoughts && {
+          thinkingConfig: {
+            includeThoughts: true,
+          },
+        }),
+      } satisfies GoogleLanguageModelOptions,
+    };
+  }
+
+  return {
+    [metadataKey]: {
+      ...((includeThoughts || thinkingBudget) && {
+        thinkingConfig: {
+          includeThoughts: includeThoughts && (thinkingBudget ?? 0) > 0,
+          thinkingBudget,
+        },
+      }),
+    } satisfies GoogleLanguageModelOptions,
+  };
+};

--- a/src/main/models/providers/gpustack.ts
+++ b/src/main/models/providers/gpustack.ts
@@ -1,13 +1,12 @@
-import { Model, ProviderProfile, SettingsData } from '@common/types';
 import { GpustackProvider, isGpustackProvider } from '@common/agent';
+import { Model, ProviderProfile, SettingsData } from '@common/types';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
-
-import type { LanguageModel } from 'ai';
 
 import { AiderModelMapping, LlmProviderStrategy, LoadModelsResponse } from '@/models';
 import logger from '@/logger';
 import { getEffectiveEnvironmentVariable } from '@/utils';
-import { getDefaultUsageReport } from '@/models/providers/default';
+import { createStrategyFromDescriptor } from '@/models/providers/strategy-factory';
+import { normalizeError } from '@/models/providers/shared';
 
 interface GpustackModelResponse {
   items: Array<{
@@ -18,7 +17,7 @@ interface GpustackModelResponse {
   }>;
 }
 
-const loadGpustackModels = async (profile: ProviderProfile, settings: SettingsData): Promise<LoadModelsResponse> => {
+export const loadGpustackModels = async (profile: ProviderProfile, settings: SettingsData): Promise<LoadModelsResponse> => {
   if (!isGpustackProvider(profile.provider)) {
     return { models: [], success: false };
   }
@@ -26,7 +25,6 @@ const loadGpustackModels = async (profile: ProviderProfile, settings: SettingsDa
   const provider = profile.provider as GpustackProvider;
   const apiKey = provider.apiKey || '';
   const baseUrl = provider.baseUrl;
-
   const apiKeyEnv = getEffectiveEnvironmentVariable('GPUSTACK_API_KEY', settings);
   const baseUrlEnv = getEffectiveEnvironmentVariable('GPUSTACK_API_BASE', settings);
 
@@ -61,18 +59,13 @@ const loadGpustackModels = async (profile: ProviderProfile, settings: SettingsDa
     logger.info(`Loaded ${models.length} GPUStack models for profile ${profile.id}`);
     return { models, success: true };
   } catch (error) {
-    const errorMsg = typeof error === 'string' ? error : error instanceof Error ? error.message : 'Unknown error loading GPUStack models';
+    const errorMsg = normalizeError(error, 'Unknown error loading GPUStack models');
     logger.warn('Failed to fetch GPUStack models via API:', error);
     return { models: [], success: false, error: errorMsg };
   }
 };
 
-const hasGpustackEnvVars = (settings: SettingsData): boolean => {
-  const hasApiKey = !!getEffectiveEnvironmentVariable('GPUSTACK_API_KEY', settings, undefined)?.value;
-  const hasBaseUrl = !!getEffectiveEnvironmentVariable('GPUSTACK_API_BASE', settings, undefined)?.value;
-  return hasApiKey || hasBaseUrl;
-};
-
+// GPUStack is a second credential (baseUrl), so its Aider mapping is bespoke
 const getGpustackAiderMapping = (provider: ProviderProfile, modelId: string, settings: SettingsData, projectDir: string): AiderModelMapping => {
   const gpustackProvider = provider.provider as GpustackProvider;
   const envVars: Record<string, string> = {};
@@ -96,55 +89,21 @@ const getGpustackAiderMapping = (provider: ProviderProfile, modelId: string, set
   };
 };
 
-// === LLM Creation Functions ===
-const createGpustackLlm = (profile: ProviderProfile, model: Model, settings: SettingsData, projectDir: string): LanguageModel => {
-  const provider = profile.provider as GpustackProvider;
-  let apiKey = provider.apiKey;
-  let baseUrl = provider.baseUrl;
-
-  if (!apiKey) {
-    const effectiveVar = getEffectiveEnvironmentVariable('GPUSTACK_API_KEY', settings, projectDir);
-    if (effectiveVar) {
-      apiKey = effectiveVar.value;
-      logger.debug(`Loaded GPUSTACK_API_KEY from ${effectiveVar.source}`);
-    }
-  }
-
-  if (!apiKey) {
-    throw new Error(`API key is required for ${provider.name}. Check Providers settings or Aider environment variables (GPUSTACK_API_KEY).`);
-  }
-
-  if (!baseUrl) {
-    const effectiveVar = getEffectiveEnvironmentVariable('GPUSTACK_API_BASE', settings, projectDir);
-    if (effectiveVar) {
-      baseUrl = effectiveVar.value;
-      logger.debug(`Loaded GPUSTACK_API_BASE from ${effectiveVar.source}`);
-    }
-  }
-
-  if (!baseUrl) {
-    throw new Error(`Base URL is required for ${provider.name} provider. Set it in Providers settings or via the GPUSTACK_API_BASE environment variable.`);
-  }
-
-  // Use createOpenAICompatible to get a provider instance, then get the model
-  // GPUStack uses /v1-openai prefix for OpenAI compatibility
-  const compatibleProvider = createOpenAICompatible({
-    name: provider.name,
-    apiKey,
-    baseURL: `${baseUrl}/v1-openai`,
-    headers: profile.headers,
-  });
-  return compatibleProvider(model.id);
-};
-
-// === Complete Strategy Implementation ===
-export const gpustackProviderStrategy: LlmProviderStrategy = {
-  // Core LLM functions
-  createLlm: createGpustackLlm,
-  getUsageReport: getDefaultUsageReport,
-
-  // Model discovery functions
-  loadModels: loadGpustackModels,
-  hasEnvVars: hasGpustackEnvVars,
-  getAiderMapping: getGpustackAiderMapping,
-};
+export const gpustackProviderStrategy: LlmProviderStrategy = createStrategyFromDescriptor({
+  name: 'gpustack',
+  label: 'GPUStack',
+  sdkFactory: createOpenAICompatible,
+  apiKeyEnv: 'GPUSTACK_API_KEY',
+  apiKeyRequired: (provider) => `API key is required for ${provider.name}. Check Providers settings or Aider environment variables (GPUSTACK_API_KEY).`,
+  baseUrl: {
+    envKey: 'GPUSTACK_API_BASE',
+    required: (provider) =>
+      `Base URL is required for ${provider.name} provider. Set it in Providers settings or via the GPUSTACK_API_BASE environment variable.`,
+    // GPUStack uses /v1-openai prefix for OpenAI compatibility
+    transform: (url) => `${url}/v1-openai`,
+  },
+  extraFactoryOptions: ({ provider }) => ({ name: provider.name }),
+  isProvider: isGpustackProvider,
+  hasEnvKeys: ['GPUSTACK_API_KEY', 'GPUSTACK_API_BASE'],
+  overrides: { loadModels: loadGpustackModels, getAiderMapping: getGpustackAiderMapping },
+});

--- a/src/main/models/providers/groq.ts
+++ b/src/main/models/providers/groq.ts
@@ -1,121 +1,21 @@
-import { Model, ProviderProfile, SettingsData } from '@common/types';
-import { GroqProvider, isGroqProvider } from '@common/agent';
+import { isGroqProvider } from '@common/agent';
 import { createGroq } from '@ai-sdk/groq';
 
-import type { LanguageModel } from 'ai';
+import { LlmProviderStrategy } from '@/models';
+import { createStrategyFromDescriptor } from '@/models/providers/strategy-factory';
 
-import { AiderModelMapping, LlmProviderStrategy, LoadModelsResponse } from '@/models';
-import logger from '@/logger';
-import { getEffectiveEnvironmentVariable } from '@/utils';
-import { getDefaultModelInfo, getDefaultUsageReport } from '@/models/providers/default';
+export const groqProviderStrategy: LlmProviderStrategy = createStrategyFromDescriptor({
+  name: 'groq',
+  label: 'Groq',
+  sdkFactory: createGroq,
+  apiKeyEnv: 'GROQ_API_KEY',
+  isProvider: isGroqProvider,
+  modelsLoader: {
+    type: 'openai-compatible',
+    url: 'https://api.groq.com/openai/v1/models',
+    noKeyDebug: 'Groq API key is required. Please set it in Providers settings or via GROQ_API_KEY environment variable.',
+  },
+  aider: { prefix: 'groq', apiKeyEnv: 'GROQ_API_KEY' },
+});
 
-interface GroqModel {
-  id: string;
-}
-
-interface GroqApiResponse {
-  data: GroqModel[];
-}
-
-export const loadGroqModels = async (profile: ProviderProfile, settings: SettingsData): Promise<LoadModelsResponse> => {
-  if (!isGroqProvider(profile.provider)) {
-    return { models: [], success: false };
-  }
-
-  const provider = profile.provider;
-  const apiKey = provider.apiKey || '';
-  const apiKeyEnv = getEffectiveEnvironmentVariable('GROQ_API_KEY', settings);
-  const effectiveApiKey = apiKey || apiKeyEnv?.value || '';
-
-  if (!effectiveApiKey) {
-    const errorMsg = 'Groq API key is required. Please set it in Providers settings or via GROQ_API_KEY environment variable.';
-    logger.debug(errorMsg);
-    return { models: [], success: false };
-  }
-
-  try {
-    const response = await fetch('https://api.groq.com/openai/v1/models', {
-      headers: { Authorization: `Bearer ${effectiveApiKey}` },
-    });
-
-    if (!response.ok) {
-      const errorMsg = `Groq models API response failed: ${response.status} ${response.statusText} ${await response.text()}`;
-      logger.error(errorMsg, {
-        status: response.status,
-        statusText: response.statusText,
-      });
-      return { models: [], success: false, error: errorMsg };
-    }
-
-    const data: GroqApiResponse = await response.json();
-    const models =
-      data.data?.map((model: GroqModel) => {
-        return {
-          id: model.id,
-          providerId: profile.id,
-        } satisfies Model;
-      }) || [];
-
-    logger.info(`Loaded ${models.length} Groq models for profile ${profile.id}`);
-    return { models, success: true };
-  } catch (error) {
-    const errorMsg = typeof error === 'string' ? error : error instanceof Error ? error.message : 'Unknown error loading Groq models';
-    logger.error('Error loading Groq models:', error);
-    return { models: [], success: false, error: errorMsg };
-  }
-};
-
-export const hasGroqEnvVars = (settings: SettingsData): boolean => {
-  return !!getEffectiveEnvironmentVariable('GROQ_API_KEY', settings, undefined)?.value;
-};
-
-export const getGroqAiderMapping = (provider: ProviderProfile, modelId: string): AiderModelMapping => {
-  const groqProvider = provider.provider as GroqProvider;
-  const envVars: Record<string, string> = {};
-
-  if (groqProvider.apiKey) {
-    envVars.GROQ_API_KEY = groqProvider.apiKey;
-  }
-
-  return {
-    modelName: `groq/${modelId}`,
-    environmentVariables: envVars,
-  };
-};
-
-// === LLM Creation Functions ===
-export const createGroqLlm = (profile: ProviderProfile, model: Model, settings: SettingsData, projectDir: string): LanguageModel => {
-  const provider = profile.provider as GroqProvider;
-  let apiKey = provider.apiKey;
-
-  if (!apiKey) {
-    const effectiveVar = getEffectiveEnvironmentVariable('GROQ_API_KEY', settings, projectDir);
-    if (effectiveVar) {
-      apiKey = effectiveVar.value;
-      logger.debug(`Loaded GROQ_API_KEY from ${effectiveVar.source}`);
-    }
-  }
-
-  if (!apiKey) {
-    throw new Error('Groq API key is required in Providers settings or Aider environment variables (GROQ_API_KEY)');
-  }
-
-  const groqProvider = createGroq({
-    apiKey,
-    headers: profile.headers,
-  });
-  return groqProvider(model.id);
-};
-
-// === Complete Strategy Implementation ===
-export const groqProviderStrategy: LlmProviderStrategy = {
-  // Core LLM functions
-  createLlm: createGroqLlm,
-  getUsageReport: getDefaultUsageReport,
-
-  // Model discovery functions
-  loadModels: loadGroqModels,
-  hasEnvVars: hasGroqEnvVars,
-  getAiderMapping: getGroqAiderMapping,
-  getModelInfo: getDefaultModelInfo,
-};
+export const loadGroqModels = groqProviderStrategy.loadModels;

--- a/src/main/models/providers/kimi-plan.ts
+++ b/src/main/models/providers/kimi-plan.ts
@@ -1,124 +1,53 @@
-import { Model, ProviderProfile, SettingsData } from '@common/types';
-import { isKimiPlanProvider, KimiPlanProvider } from '@common/agent';
+import { isKimiPlanProvider } from '@common/agent';
 import { createAnthropic } from '@ai-sdk/anthropic';
+import { Model, ProviderProfile } from '@common/types';
 
-import type { LanguageModel } from 'ai';
-
-import { AiderModelMapping, LlmProviderStrategy, LoadModelsResponse } from '@/models';
-import logger from '@/logger';
-import { getEffectiveEnvironmentVariable } from '@/utils';
+import { LlmProviderStrategy } from '@/models';
 import { getAnthropicCacheControl } from '@/models/providers/anthropic';
-import { getDefaultUsageReport } from '@/models/providers/default';
+import { createStrategyFromDescriptor } from '@/models/providers/strategy-factory';
+import { stripV1Suffix } from '@/models/providers/shared';
 
 const KIMI_PLAN_BASE_URL = 'https://api.kimi.com/coding/v1';
 
-const loadKimiPlanModels = async (profile: ProviderProfile, settings: SettingsData): Promise<LoadModelsResponse> => {
-  if (!isKimiPlanProvider(profile.provider)) {
-    return { models: [], success: false };
-  }
+// Kimi plan exposes a fixed model catalog (no API listing)
+const kimiPlanStaticModels = (profile: ProviderProfile): Model[] => [
+  {
+    id: 'kimi-k2-thinking',
+    providerId: profile.id,
+    maxInputTokens: 262144,
+    maxOutputTokensLimit: 32768,
+  },
+  {
+    id: 'k2p5',
+    providerId: profile.id,
+    maxInputTokens: 262144,
+    maxOutputTokensLimit: 32768,
+  },
+  {
+    id: 'k2p6',
+    providerId: profile.id,
+    maxInputTokens: 262144,
+    maxOutputTokensLimit: 32768,
+  },
+];
 
-  const provider = profile.provider as KimiPlanProvider;
-  const apiKey = provider.apiKey || '';
-  const apiKeyEnv = getEffectiveEnvironmentVariable('KIMI_PLAN_API_KEY', settings);
-  const effectiveApiKey = apiKey || apiKeyEnv?.value;
-
-  if (!effectiveApiKey) {
-    return { models: [], success: false };
-  }
-
-  // Return hardcoded models instead of fetching from API
-  const models: Model[] = [
-    {
-      id: 'kimi-k2-thinking',
-      providerId: profile.id,
-      maxInputTokens: 262144,
-      maxOutputTokensLimit: 32768,
-    },
-    {
-      id: 'k2p5',
-      providerId: profile.id,
-      maxInputTokens: 262144,
-      maxOutputTokensLimit: 32768,
-    },
-    {
-      id: 'k2p6',
-      providerId: profile.id,
-      maxInputTokens: 262144,
-      maxOutputTokensLimit: 32768,
-    },
-  ];
-
-  logger.info(`Loaded ${models.length} Kimi plan models for profile ${profile.id}`);
-  return { models, success: true };
-};
-
-const hasKimiPlanEnvVars = (settings: SettingsData): boolean => {
-  return !!getEffectiveEnvironmentVariable('KIMI_PLAN_API_KEY', settings, undefined)?.value;
-};
-
-const getKimiPlanAiderMapping = (provider: ProviderProfile, modelId: string, settings: SettingsData, projectDir: string): AiderModelMapping => {
-  const kimiPlanProvider = provider.provider as KimiPlanProvider;
-  const envVars: Record<string, string> = {};
-
-  let apiKey = kimiPlanProvider.apiKey;
-
-  if (!apiKey) {
-    const effectiveVar = getEffectiveEnvironmentVariable('KIMI_PLAN_API_KEY', settings, projectDir);
-    if (effectiveVar) {
-      apiKey = effectiveVar.value;
-    }
-  }
-
-  if (apiKey) {
-    envVars.ANTHROPIC_API_KEY = apiKey;
-  }
-  // remove /v1 from the end of the base url for LiteLLM compatibility
-  envVars.ANTHROPIC_BASE_URL = KIMI_PLAN_BASE_URL.slice(0, -3);
-
-  // Use anthropic prefix for Kimi since it uses Anthropic-compatible API
-  return {
-    modelName: `anthropic/${modelId}`,
-    environmentVariables: envVars,
-  };
-};
-
-// === LLM Creation Functions ===
-const createKimiPlanLlm = (profile: ProviderProfile, model: Model, settings: SettingsData, projectDir: string): LanguageModel => {
-  const provider = profile.provider as KimiPlanProvider;
-  let apiKey = provider.apiKey;
-
-  if (!apiKey) {
-    const effectiveVar = getEffectiveEnvironmentVariable('KIMI_PLAN_API_KEY', settings, projectDir);
-    if (effectiveVar) {
-      apiKey = effectiveVar.value;
-      logger.debug(`Loaded KIMI_PLAN_API_KEY from ${effectiveVar.source}`);
-    }
-  }
-
-  if (!apiKey) {
-    throw new Error(`API key is required for ${provider.name}. Check Providers settings or Aider environment variables (KIMI_PLAN_API_KEY).`);
-  }
-
-  // Use createAnthropic with Kimi's base URL
-  const kimiPlanProvider = createAnthropic({
-    apiKey,
-    baseURL: KIMI_PLAN_BASE_URL,
-    headers: profile.headers,
-  });
-  return kimiPlanProvider(model.id);
-};
-
-// === Complete Strategy Implementation ===
-export const kimiPlanProviderStrategy: LlmProviderStrategy = {
-  // Core LLM functions
-  createLlm: createKimiPlanLlm,
-  getUsageReport: getDefaultUsageReport,
-
-  // Model discovery functions
-  loadModels: loadKimiPlanModels,
-  hasEnvVars: hasKimiPlanEnvVars,
-  getAiderMapping: getKimiPlanAiderMapping,
-
-  // Cache control
-  getCacheControl: getAnthropicCacheControl,
-};
+export const kimiPlanProviderStrategy: LlmProviderStrategy = createStrategyFromDescriptor({
+  name: 'kimi-plan',
+  label: 'Kimi Plan',
+  // Kimi plan speaks the Anthropic wire protocol
+  sdkFactory: createAnthropic,
+  apiKeyEnv: 'KIMI_PLAN_API_KEY',
+  apiKeyRequired: (provider) => `API key is required for ${provider.name}. Check Providers settings or Aider environment variables (KIMI_PLAN_API_KEY).`,
+  fixedBaseURL: KIMI_PLAN_BASE_URL,
+  isProvider: isKimiPlanProvider,
+  modelsLoader: { type: 'static', apiKeyEnv: 'KIMI_PLAN_API_KEY', items: kimiPlanStaticModels },
+  aider: {
+    prefix: 'anthropic',
+    apiKeyEnv: 'ANTHROPIC_API_KEY',
+    sourceEnvKey: 'KIMI_PLAN_API_KEY',
+    readEnvFallback: true,
+    // remove /v1 from the end of the base url for LiteLLM compatibility
+    extraEnv: { ANTHROPIC_BASE_URL: stripV1Suffix(KIMI_PLAN_BASE_URL) },
+  },
+  overrides: { getCacheControl: getAnthropicCacheControl },
+});

--- a/src/main/models/providers/litellm.ts
+++ b/src/main/models/providers/litellm.ts
@@ -1,13 +1,12 @@
-import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { isLitellmProvider, LitellmProvider } from '@common/agent';
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { Model, ProviderProfile, SettingsData } from '@common/types';
 
-import type { LanguageModel } from 'ai';
-
-import logger from '@/logger';
 import { AiderModelMapping, LlmProviderStrategy, LoadModelsResponse } from '@/models';
+import logger from '@/logger';
 import { getEffectiveEnvironmentVariable } from '@/utils';
-import { getDefaultUsageReport } from '@/models/providers/default';
+import { createStrategyFromDescriptor } from '@/models/providers/strategy-factory';
+import { normalizeError } from '@/models/providers/shared';
 
 interface LiteLLMModelInfo {
   model_name: string;
@@ -35,6 +34,13 @@ interface LiteLLMModelInfo {
     output_cost_per_token?: number;
   };
 }
+
+const getValue = (
+  info: LiteLLMModelInfo,
+  key: 'context_window' | 'max_input_tokens' | 'max_output_tokens' | 'max_tokens' | 'input_cost_per_token' | 'output_cost_per_token',
+) => {
+  return info[key] ?? info.model_info?.[key] ?? info.litellm_params?.[key];
+};
 
 export const loadLitellmModels = async (profile: ProviderProfile, settings: SettingsData): Promise<LoadModelsResponse> => {
   if (!isLitellmProvider(profile.provider)) {
@@ -101,14 +107,6 @@ export const loadLitellmModels = async (profile: ProviderProfile, settings: Sett
     });
 
     const models: Model[] = Object.entries(modelsByName).map(([name, infos]) => {
-      // Helper to find value in multiple places for a single info object
-      const getValue = (
-        info: LiteLLMModelInfo,
-        key: 'context_window' | 'max_input_tokens' | 'max_output_tokens' | 'max_tokens' | 'input_cost_per_token' | 'output_cost_per_token',
-      ) => {
-        return info[key] ?? info.model_info?.[key] ?? info.litellm_params?.[key];
-      };
-
       // Aggregate values across all backends for this model name
       // For limits (context window, max output), use MIN to be safe
       // For costs, use MAX to be safe/conservative
@@ -136,17 +134,13 @@ export const loadLitellmModels = async (profile: ProviderProfile, settings: Sett
     logger.info(`Loaded ${models.length} LiteLLM models from /model/info for profile ${profile.id}`);
     return { models, success: true };
   } catch (error) {
-    const errorMsg = typeof error === 'string' ? error : error instanceof Error ? error.message : 'Unknown error loading LiteLLM models';
+    const errorMsg = normalizeError(error, 'Unknown error loading LiteLLM models');
     logger.error('Error loading LiteLLM models:', error);
     return { models: [], success: false, error: errorMsg };
   }
 };
 
-export const hasLitellmEnvVars = (settings: SettingsData): boolean => {
-  return !!getEffectiveEnvironmentVariable('LITELLM_API_BASE', settings, undefined)?.value;
-};
-
-export const getLitellmAiderMapping = (provider: ProviderProfile, modelId: string): AiderModelMapping => {
+const getLitellmAiderMapping = (provider: ProviderProfile, modelId: string): AiderModelMapping => {
   const litellmProvider = provider.provider as LitellmProvider;
   const envVars: Record<string, string> = {};
 
@@ -164,53 +158,22 @@ export const getLitellmAiderMapping = (provider: ProviderProfile, modelId: strin
   };
 };
 
-// === LLM Creation Functions ===
-export const createLitellmLlm = (profile: ProviderProfile, model: Model, settings: SettingsData, projectDir: string): LanguageModel => {
-  const provider = profile.provider as LitellmProvider;
-  let apiKey = provider.apiKey;
-  let baseUrl = provider.baseUrl;
-
-  if (!apiKey) {
-    const effectiveVar = getEffectiveEnvironmentVariable('LITELLM_API_KEY', settings, projectDir);
-    if (effectiveVar) {
-      apiKey = effectiveVar.value;
-    }
-  }
-
-  if (!apiKey) {
-    apiKey = 'sk-dummy'; // Dummy key for OpenAI-compatible client which expects a key.
-  }
-
-  if (!baseUrl) {
-    const effectiveVar = getEffectiveEnvironmentVariable('LITELLM_API_BASE', settings, projectDir);
-    if (effectiveVar) {
-      baseUrl = effectiveVar.value;
-    }
-  }
-
-  if (!baseUrl) {
-    throw new Error('Base URL is required for LiteLLM provider');
-  }
-
-  const compatibleProvider = createOpenAICompatible({
-    name: 'litellm',
-    apiKey,
-    baseURL: baseUrl,
-    headers: profile.headers,
-    includeUsage: true,
-  });
-
-  return compatibleProvider(model.id);
-};
-
-// === Complete Strategy Implementation ===
-export const litellmProviderStrategy: LlmProviderStrategy = {
-  // Core LLM functions
-  createLlm: createLitellmLlm,
-  getUsageReport: getDefaultUsageReport,
-
-  // Model discovery functions
-  loadModels: loadLitellmModels,
-  hasEnvVars: hasLitellmEnvVars,
-  getAiderMapping: getLitellmAiderMapping,
-};
+export const litellmProviderStrategy: LlmProviderStrategy = createStrategyFromDescriptor({
+  name: 'litellm',
+  label: 'LiteLLM',
+  sdkFactory: createOpenAICompatible,
+  // dummy key for the OpenAI-compatible client, which expects a key
+  extraFactoryOptions: ({ apiKey }) => ({ name: 'litellm', includeUsage: true, ...(apiKey ? {} : { apiKey: 'sk-dummy' }) }),
+  apiKeyEnv: 'LITELLM_API_KEY',
+  // the API key is optional here; the shared client gets a dummy key when unset
+  apiKeyRequired: null,
+  baseUrl: {
+    envKey: 'LITELLM_API_BASE',
+    required: 'Base URL is required for LiteLLM provider',
+  },
+  hasEnvKeys: ['LITELLM_API_BASE'],
+  overrides: {
+    loadModels: loadLitellmModels,
+    getAiderMapping: getLitellmAiderMapping,
+  },
+});

--- a/src/main/models/providers/lm-studio.ts
+++ b/src/main/models/providers/lm-studio.ts
@@ -1,13 +1,12 @@
-import { Model, ProviderProfile, SettingsData } from '@common/types';
 import { isLmStudioProvider, LmStudioProvider } from '@common/agent';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
-
-import type { LanguageModel } from 'ai';
+import { Model, ProviderProfile, SettingsData } from '@common/types';
 
 import { AiderModelMapping, LlmProviderStrategy, LoadModelsResponse } from '@/models';
 import logger from '@/logger';
 import { getEffectiveEnvironmentVariable } from '@/utils';
-import { getDefaultUsageReport } from '@/models/providers/default';
+import { createStrategyFromDescriptor } from '@/models/providers/strategy-factory';
+import { normalizeError } from '@/models/providers/shared';
 
 export const loadLmStudioModels = async (profile: ProviderProfile, settings: SettingsData): Promise<LoadModelsResponse> => {
   if (!isLmStudioProvider(profile.provider)) {
@@ -19,7 +18,9 @@ export const loadLmStudioModels = async (profile: ProviderProfile, settings: Set
 
   const provider = profile.provider as LmStudioProvider;
   const baseUrl = provider.baseUrl || '';
-  const environmentVariable = getEffectiveEnvironmentVariable('LM_STUDIO_API_BASE', settings);
+  // LMSTUDIO_API_BASE (no underscore between LM and STUDIO) is the spelling already used by
+  // createLlm, hasEnvVars and the renderer's LmStudioParameters component.
+  const environmentVariable = getEffectiveEnvironmentVariable('LMSTUDIO_API_BASE', settings);
   const effectiveBaseUrl = baseUrl || environmentVariable?.value || '';
 
   if (!effectiveBaseUrl) {
@@ -47,18 +48,13 @@ export const loadLmStudioModels = async (profile: ProviderProfile, settings: Set
     logger.info(`Loaded ${models.length} LM Studio models from ${effectiveBaseUrl} for profile ${profile.id}`);
     return { models, success: true };
   } catch (error) {
-    const errorMsg = typeof error === 'string' ? error : error instanceof Error ? error.message : 'Unknown error loading LM Studio models';
+    const errorMsg = normalizeError(error, 'Unknown error loading LM Studio models');
     logger.error('Error loading LM Studio models:', error);
     return { models: [], success: false, error: errorMsg };
   }
 };
 
-export const hasLmStudioEnvVars = (settings: SettingsData): boolean => {
-  const base = getEffectiveEnvironmentVariable('LMSTUDIO_API_BASE', settings, undefined)?.value;
-  return !!base;
-};
-
-export const getLmStudioAiderMapping = (provider: ProviderProfile, modelId: string): AiderModelMapping => {
+const getLmStudioAiderMapping = (provider: ProviderProfile, modelId: string): AiderModelMapping => {
   const lmstudioProvider = provider.provider as LmStudioProvider;
   const envVars: Record<string, string> = {};
 
@@ -73,40 +69,17 @@ export const getLmStudioAiderMapping = (provider: ProviderProfile, modelId: stri
   };
 };
 
-// === LLM Creation Functions ===
-export const createLmStudioLlm = (profile: ProviderProfile, model: Model, settings: SettingsData, projectDir: string): LanguageModel => {
-  const provider = profile.provider as LmStudioProvider;
-  let baseUrl = provider.baseUrl;
-
-  if (!baseUrl) {
-    const effectiveVar = getEffectiveEnvironmentVariable('LMSTUDIO_API_BASE', settings, projectDir);
-    if (effectiveVar) {
-      baseUrl = effectiveVar.value;
-      logger.debug(`Loaded LMSTUDIO_API_BASE from ${effectiveVar.source}`);
-    }
-  }
-
-  if (!baseUrl) {
-    throw new Error('Base URL is required for LMStudio provider. Set it in Providers settings or via the LMSTUDIO_API_BASE environment variable.');
-  }
-
-  const lmStudioProvider = createOpenAICompatible({
-    name: 'lmstudio',
-    baseURL: baseUrl,
-    headers: profile.headers,
-    includeUsage: true,
-  });
-  return lmStudioProvider(model.id);
-};
-
-// === Complete Strategy Implementation ===
-export const lmStudioProviderStrategy: LlmProviderStrategy = {
-  // Core LLM functions
-  createLlm: createLmStudioLlm,
-  getUsageReport: getDefaultUsageReport,
-
-  // Model discovery functions
-  loadModels: loadLmStudioModels,
-  hasEnvVars: hasLmStudioEnvVars,
-  getAiderMapping: getLmStudioAiderMapping,
-};
+// LM Studio is local-only (base URL, no credential), so loadModels/mapping stay bespoke
+export const lmStudioProviderStrategy: LlmProviderStrategy = createStrategyFromDescriptor({
+  name: 'lmstudio',
+  label: 'LM Studio',
+  sdkFactory: createOpenAICompatible,
+  extraFactoryOptions: () => ({ name: 'lmstudio', includeUsage: true }),
+  baseUrl: {
+    envKey: 'LMSTUDIO_API_BASE',
+    required: 'Base URL is required for LMStudio provider. Set it in Providers settings or via the LMSTUDIO_API_BASE environment variable.',
+  },
+  isProvider: isLmStudioProvider,
+  hasEnvKeys: ['LMSTUDIO_API_BASE'],
+  overrides: { loadModels: loadLmStudioModels, getAiderMapping: getLmStudioAiderMapping },
+});

--- a/src/main/models/providers/minimax.ts
+++ b/src/main/models/providers/minimax.ts
@@ -1,198 +1,131 @@
 import { createAnthropic } from '@ai-sdk/anthropic';
-import { isMinimaxProvider, MinimaxProvider, LlmProvider } from '@common/agent';
-import { Model, ProviderProfile, Reasoning, SettingsData } from '@common/types';
+import { isMinimaxProvider, LlmProvider } from '@common/agent';
+import { Model, ProviderProfile, Reasoning } from '@common/types';
 
-import type { LanguageModel } from 'ai';
 import type { SharedV4ProviderOptions } from '@ai-sdk/provider';
 
-import logger from '@/logger';
-import { AiderModelMapping, CacheControl, LlmProviderStrategy } from '@/models';
-import { LoadModelsResponse } from '@/models/types';
-import { getEffectiveEnvironmentVariable } from '@/utils';
-import { getDefaultUsageReport } from '@/models/providers/default';
+import { CacheControl, LlmProviderStrategy } from '@/models';
+import { createStrategyFromDescriptor } from '@/models/providers/strategy-factory';
+import { getAnthropicAdaptiveThinkingOptions } from '@/models/providers/shared';
 
-export const loadMinimaxModels = async (profile: ProviderProfile): Promise<LoadModelsResponse> => {
-  if (!isMinimaxProvider(profile.provider)) {
-    return {
-      models: [],
-      success: false,
-    };
-  }
-  // Hardcoded MiniMax models - no API call needed
-  const hardcodedModels: Model[] = [
-    {
-      id: 'MiniMax-M3',
-      providerId: profile.id,
-      maxInputTokens: 1000000,
-      maxOutputTokensLimit: 131072,
-      inputCostPerToken: 0.0000003, // 0.3 per 1M tokens
-      outputCostPerToken: 0.0000012, // 1.2 per 1M tokens
-      cacheReadInputTokenCost: 0.00000006, // 0.06 per 1M tokens
-      cacheWriteInputTokenCost: 0.000000375, // 0.375 per 1M tokens
-    },
-    {
-      id: 'MiniMax-M2.7',
-      providerId: profile.id,
-      maxInputTokens: 204800,
-      maxOutputTokensLimit: 131072,
-      inputCostPerToken: 0.0000003, // 0.3 per 1M tokens
-      outputCostPerToken: 0.0000012, // 1.2 per 1M tokens
-      cacheReadInputTokenCost: 0.00000006, // 0.06 per 1M tokens
-      cacheWriteInputTokenCost: 0.000000375, // 0.375 per 1M tokens
-    },
-    {
-      id: 'MiniMax-M2.7-highspeed',
-      providerId: profile.id,
-      maxInputTokens: 204800,
-      maxOutputTokensLimit: 131072,
-      inputCostPerToken: 0.0000006, // 0.6 per 1M tokens
-      outputCostPerToken: 0.0000024, // 2.4 per 1M tokens
-      cacheReadInputTokenCost: 0.00000006, // 0.06 per 1M tokens
-      cacheWriteInputTokenCost: 0.000000375, // 0.375 per 1M tokens
-    },
-    {
-      id: 'MiniMax-M2.5',
-      providerId: profile.id,
-      maxInputTokens: 204800,
-      maxOutputTokensLimit: 131072,
-      inputCostPerToken: 0.0000003, // 0.3 per 1M tokens
-      outputCostPerToken: 0.0000012, // 1.2 per 1M tokens
-      cacheReadInputTokenCost: 0.00000003, // 0.03 per 1M tokens
-      cacheWriteInputTokenCost: 0.000000375, // 0.375 per 1M tokens
-    },
-    {
-      id: 'MiniMax-M2.5-highspeed',
-      providerId: profile.id,
-      maxInputTokens: 204800,
-      maxOutputTokensLimit: 131072,
-      inputCostPerToken: 0.0000006, // 0.6 per 1M tokens
-      outputCostPerToken: 0.0000024, // 2.4 per 1M tokens
-      cacheReadInputTokenCost: 0.00000003, // 0.03 per 1M tokens
-      cacheWriteInputTokenCost: 0.000000375, // 0.375 per 1M tokens
-    },
-    {
-      id: 'MiniMax-M2.1',
-      providerId: profile.id,
-      maxInputTokens: 204800,
-      maxOutputTokensLimit: 131072,
-      inputCostPerToken: 0.0000003, // 0.3 per 1M tokens
-      outputCostPerToken: 0.0000012, // 1.2 per 1M tokens
-      cacheReadInputTokenCost: 0.00000003, // 0.03 per 1M tokens
-      cacheWriteInputTokenCost: 0.000000375, // 0.375 per 1M tokens
-    },
-    {
-      id: 'MiniMax-M2.1-highspeed',
-      providerId: profile.id,
-      maxInputTokens: 204800,
-      maxOutputTokensLimit: 131072,
-      inputCostPerToken: 0.0000006, // 0.6 per 1M tokens
-      outputCostPerToken: 0.0000024, // 2.4 per 1M tokens
-      cacheReadInputTokenCost: 0.00000003, // 0.03 per 1M tokens
-      cacheWriteInputTokenCost: 0.000000375, // 0.375 per 1M tokens
-    },
-    {
-      id: 'MiniMax-M2',
-      providerId: profile.id,
-      maxInputTokens: 204800,
-      maxOutputTokensLimit: 131072,
-      inputCostPerToken: 0.0000003, // 0.3 per 1M tokens
-      outputCostPerToken: 0.0000012, // 1.2 per 1M tokens
-      cacheReadInputTokenCost: 0.00000003, // 0.03 per 1M tokens
-      cacheWriteInputTokenCost: 0.000000375, // 0.375 per 1M tokens
-    },
-  ];
+// Canonical MiniMax-M3 catalog pricing, shared with vendors of MiniMax models
+// (ClinePass) so pricing cannot drift between the providers. Model ids and
+// catalog metadata (e.g. maxOutputTokensLimit) stay provider-specific.
+export const MINIMAX_M3_MODEL_PRICING = {
+  maxInputTokens: 1000000,
+  inputCostPerToken: 0.0000003, // 0.3 per 1M tokens
+  outputCostPerToken: 0.0000012, // 1.2 per 1M tokens
+  cacheReadInputTokenCost: 0.00000006, // 0.06 per 1M tokens
+  cacheWriteInputTokenCost: 0.000000375, // 0.375 per 1M tokens
+} as const;
 
-  return { models: hardcodedModels, success: true };
-};
+const MINIMAX_STATIC_MODELS = [
+  {
+    id: 'MiniMax-M3',
+    maxOutputTokensLimit: 131072,
+    ...MINIMAX_M3_MODEL_PRICING,
+  },
+  {
+    id: 'MiniMax-M2.7',
+    maxInputTokens: 204800,
+    maxOutputTokensLimit: 131072,
+    inputCostPerToken: 0.0000003, // 0.3 per 1M tokens
+    outputCostPerToken: 0.0000012, // 1.2 per 1M tokens
+    cacheReadInputTokenCost: 0.00000006, // 0.06 per 1M tokens
+    cacheWriteInputTokenCost: 0.000000375, // 0.375 per 1M tokens
+  },
+  {
+    id: 'MiniMax-M2.7-highspeed',
+    maxInputTokens: 204800,
+    maxOutputTokensLimit: 131072,
+    inputCostPerToken: 0.0000006, // 0.6 per 1M tokens
+    outputCostPerToken: 0.0000024, // 2.4 per 1M tokens
+    cacheReadInputTokenCost: 0.00000006, // 0.06 per 1M tokens
+    cacheWriteInputTokenCost: 0.000000375, // 0.375 per 1M tokens
+  },
+  {
+    id: 'MiniMax-M2.5',
+    maxInputTokens: 204800,
+    maxOutputTokensLimit: 131072,
+    inputCostPerToken: 0.0000003, // 0.3 per 1M tokens
+    outputCostPerToken: 0.0000012, // 1.2 per 1M tokens
+    cacheReadInputTokenCost: 0.00000003, // 0.03 per 1M tokens
+    cacheWriteInputTokenCost: 0.000000375, // 0.375 per 1M tokens
+  },
+  {
+    id: 'MiniMax-M2.5-highspeed',
+    maxInputTokens: 204800,
+    maxOutputTokensLimit: 131072,
+    inputCostPerToken: 0.0000006, // 0.6 per 1M tokens
+    outputCostPerToken: 0.0000024, // 2.4 per 1M tokens
+    cacheReadInputTokenCost: 0.00000003, // 0.03 per 1M tokens
+    cacheWriteInputTokenCost: 0.000000375, // 0.375 per 1M tokens
+  },
+  {
+    id: 'MiniMax-M2.1',
+    maxInputTokens: 204800,
+    maxOutputTokensLimit: 131072,
+    inputCostPerToken: 0.0000003, // 0.3 per 1M tokens
+    outputCostPerToken: 0.0000012, // 1.2 per 1M tokens
+    cacheReadInputTokenCost: 0.00000003, // 0.03 per 1M tokens
+    cacheWriteInputTokenCost: 0.000000375, // 0.375 per 1M tokens
+  },
+  {
+    id: 'MiniMax-M2.1-highspeed',
+    maxInputTokens: 204800,
+    maxOutputTokensLimit: 131072,
+    inputCostPerToken: 0.0000006, // 0.6 per 1M tokens
+    outputCostPerToken: 0.0000024, // 2.4 per 1M tokens
+    cacheReadInputTokenCost: 0.00000003, // 0.03 per 1M tokens
+    cacheWriteInputTokenCost: 0.000000375, // 0.375 per 1M tokens
+  },
+  {
+    id: 'MiniMax-M2',
+    maxInputTokens: 204800,
+    maxOutputTokensLimit: 131072,
+    inputCostPerToken: 0.0000003, // 0.3 per 1M tokens
+    outputCostPerToken: 0.0000012, // 1.2 per 1M tokens
+    cacheReadInputTokenCost: 0.00000003, // 0.03 per 1M tokens
+    cacheWriteInputTokenCost: 0.000000375, // 0.375 per 1M tokens
+  },
+];
 
-export const hasMinimaxEnvVars = (settings: SettingsData): boolean => {
-  return !!getEffectiveEnvironmentVariable('MINIMAX_API_KEY', settings, undefined)?.value;
-};
-
-export const getMinimaxAiderMapping = (provider: ProviderProfile, modelId: string, settings: SettingsData, projectDir: string): AiderModelMapping => {
-  const minimaxProvider = provider.provider as MinimaxProvider;
-  const envVars: Record<string, string> = {};
-
-  envVars.OPENAI_API_BASE = 'https://api.minimax.io/v1';
-  if (minimaxProvider.apiKey) {
-    envVars.OPENAI_API_KEY = minimaxProvider.apiKey;
-  } else {
-    const effectiveVar = getEffectiveEnvironmentVariable('MINIMAX_API_KEY', settings, projectDir);
-    if (effectiveVar) {
-      envVars.OPENAI_API_KEY = effectiveVar.value;
-    }
-  }
-
-  return {
-    modelName: `openai/${modelId}`,
-    environmentVariables: envVars,
-  };
-};
-
-// === LLM Creation Functions ===
-export const createMinimaxLlm = (profile: ProviderProfile, model: Model, settings: SettingsData, projectDir: string): LanguageModel => {
-  const provider = profile.provider as MinimaxProvider;
-  let apiKey = provider.apiKey;
-
-  if (!apiKey) {
-    const effectiveVar = getEffectiveEnvironmentVariable('MINIMAX_API_KEY', settings, projectDir);
-    if (effectiveVar) {
-      apiKey = effectiveVar.value;
-      logger.debug(`Loaded MINIMAX_API_KEY from ${effectiveVar.source}`);
-    }
-  }
-
-  if (!apiKey) {
-    throw new Error('Minimax API key is required in Providers settings or Aider environment variables (MINIMAX_API_KEY)');
-  }
-
-  const anthropicProvider = createAnthropic({
-    apiKey,
-    baseURL: 'https://api.minimax.io/anthropic/v1',
-    headers: profile.headers,
-  });
-  return anthropicProvider(model.id);
-};
-
-// === Configuration Helper Functions ===
-export const getMinimaxCacheControl = (): CacheControl | undefined => {
-  return {
-    providerOptions: {
-      anthropic: {
-        cacheControl: { type: 'ephemeral' },
-      },
-    },
-    placement: 'message',
-  };
-};
+// Hardcoded MiniMax catalog - no API call needed
+const minimaxStaticModels = (profile: ProviderProfile): Model[] => MINIMAX_STATIC_MODELS.map((model) => ({ ...model, providerId: profile.id }));
 
 export const getMinimaxProviderOptions = (llmProvider: LlmProvider, _model: Model, reasoning?: Reasoning): SharedV4ProviderOptions | undefined => {
   if (!isMinimaxProvider(llmProvider) || (reasoning && reasoning !== 'provider-default')) {
     return undefined;
   }
 
-  // Explicitly request adaptive thinking with summarized display so reasoning/thinking
-  // text is returned via thinking_delta events. Without this, newer Claude models (opus-4-7+)
-  // default to 'omitted' display and return empty thinking blocks.
-  return {
-    anthropic: {
-      thinking: { type: 'adaptive', display: 'summarized' },
-    },
-  } satisfies SharedV4ProviderOptions;
+  return getAnthropicAdaptiveThinkingOptions();
 };
 
-// === Complete Strategy Implementation ===
-export const minimaxProviderStrategy: LlmProviderStrategy = {
-  // Core LLM functions
-  createLlm: createMinimaxLlm,
-  getUsageReport: getDefaultUsageReport,
-
-  // Model discovery functions
-  loadModels: loadMinimaxModels,
-  hasEnvVars: hasMinimaxEnvVars,
-  getAiderMapping: getMinimaxAiderMapping,
-
-  // Configuration helpers
-  getCacheControl: getMinimaxCacheControl,
-  getProviderOptions: getMinimaxProviderOptions,
-};
+export const minimaxProviderStrategy: LlmProviderStrategy = createStrategyFromDescriptor({
+  name: 'minimax',
+  label: 'Minimax',
+  // MiniMax speaks the Anthropic wire protocol
+  sdkFactory: createAnthropic,
+  apiKeyEnv: 'MINIMAX_API_KEY',
+  fixedBaseURL: 'https://api.minimax.io/anthropic/v1',
+  isProvider: isMinimaxProvider,
+  modelsLoader: { type: 'static', items: minimaxStaticModels },
+  aider: {
+    prefix: 'openai',
+    apiKeyEnv: 'OPENAI_API_KEY',
+    sourceEnvKey: 'MINIMAX_API_KEY',
+    readEnvFallback: true,
+    upstreamBaseUrl: 'https://api.minimax.io/v1',
+  },
+  overrides: {
+    getCacheControl: (): CacheControl | undefined => ({
+      providerOptions: {
+        anthropic: {
+          cacheControl: { type: 'ephemeral' },
+        },
+      },
+      placement: 'message',
+    }),
+    getProviderOptions: getMinimaxProviderOptions,
+  },
+});

--- a/src/main/models/providers/mistral.ts
+++ b/src/main/models/providers/mistral.ts
@@ -1,124 +1,24 @@
-import { Model, ProviderProfile, SettingsData } from '@common/types';
-import { MistralProvider, isMistralProvider } from '@common/agent';
+import { isMistralProvider } from '@common/agent';
 import { createMistral } from '@ai-sdk/mistral';
 
-import type { LanguageModel } from 'ai';
+import { LlmProviderStrategy } from '@/models';
+import { createStrategyFromDescriptor } from '@/models/providers/strategy-factory';
 
-import { AiderModelMapping, LlmProviderStrategy, LoadModelsResponse } from '@/models';
-import logger from '@/logger';
-import { getEffectiveEnvironmentVariable } from '@/utils';
-import { getDefaultModelInfo, getDefaultUsageReport } from '@/models/providers/default';
+export const mistralProviderStrategy: LlmProviderStrategy = createStrategyFromDescriptor({
+  name: 'mistral',
+  label: 'Mistral',
+  sdkFactory: createMistral,
+  apiKeyEnv: 'MISTRAL_API_KEY',
+  isProvider: isMistralProvider,
+  modelsLoader: {
+    type: 'openai-compatible',
+    url: 'https://api.mistral.ai/v1/models',
+    // the Mistral API returns duplicated entries
+    dedupeById: true,
+    noKeyDebug: 'Mistral API key is required. Please set it in Providers settings or via MISTRAL_API_KEY environment variable.',
+    mapper: (id) => ({ id, temperature: 0.7 }),
+  },
+  aider: { prefix: 'mistral', apiKeyEnv: 'MISTRAL_API_KEY' },
+});
 
-interface MistralModel {
-  id: string;
-}
-
-interface MistralApiResponse {
-  data: MistralModel[];
-}
-
-export const loadMistralModels = async (profile: ProviderProfile, settings: SettingsData): Promise<LoadModelsResponse> => {
-  if (!isMistralProvider(profile.provider)) {
-    return { models: [], success: false };
-  }
-
-  const provider = profile.provider;
-  const apiKey = provider.apiKey || '';
-  const apiKeyEnv = getEffectiveEnvironmentVariable('MISTRAL_API_KEY', settings);
-  const effectiveApiKey = apiKey || apiKeyEnv?.value || '';
-
-  if (!effectiveApiKey) {
-    const errorMsg = 'Mistral API key is required. Please set it in Providers settings or via MISTRAL_API_KEY environment variable.';
-    logger.debug(errorMsg);
-    return { models: [], success: false };
-  }
-
-  try {
-    const response = await fetch('https://api.mistral.ai/v1/models', {
-      headers: { Authorization: `Bearer ${effectiveApiKey}` },
-    });
-
-    if (!response.ok) {
-      const errorMsg = `Mistral models API response failed: ${response.status} ${response.statusText} ${await response.text()}`;
-      logger.error(errorMsg, {
-        status: response.status,
-        statusText: response.statusText,
-      });
-      return { models: [], success: false, error: errorMsg };
-    }
-
-    const data: MistralApiResponse = await response.json();
-    const models =
-      data.data
-        ?.map((model: MistralModel) => {
-          return {
-            id: model.id,
-            providerId: profile.id,
-            temperature: 0.7,
-          } satisfies Model;
-        })
-        ?.filter((model, index, arr) => arr.findIndex((m) => m.id === model.id) === index) || [];
-
-    logger.info(`Loaded ${models.length} Mistral models for profile ${profile.id}`);
-    return { models, success: true };
-  } catch (error) {
-    const errorMsg = typeof error === 'string' ? error : error instanceof Error ? error.message : 'Unknown error loading Mistral models';
-    logger.error('Error loading Mistral models:', error);
-    return { models: [], success: false, error: errorMsg };
-  }
-};
-
-export const hasMistralEnvVars = (settings: SettingsData): boolean => {
-  return !!getEffectiveEnvironmentVariable('MISTRAL_API_KEY', settings, undefined)?.value;
-};
-
-export const getMistralAiderMapping = (provider: ProviderProfile, modelId: string): AiderModelMapping => {
-  const mistralProvider = provider.provider as MistralProvider;
-  const envVars: Record<string, string> = {};
-
-  if (mistralProvider.apiKey) {
-    envVars.MISTRAL_API_KEY = mistralProvider.apiKey;
-  }
-
-  return {
-    modelName: `mistral/${modelId}`,
-    environmentVariables: envVars,
-  };
-};
-
-// === LLM Creation Functions ===
-export const createMistralLlm = (profile: ProviderProfile, model: Model, settings: SettingsData, projectDir: string): LanguageModel => {
-  const provider = profile.provider as MistralProvider;
-  let apiKey = provider.apiKey;
-
-  if (!apiKey) {
-    const effectiveVar = getEffectiveEnvironmentVariable('MISTRAL_API_KEY', settings, projectDir);
-    if (effectiveVar) {
-      apiKey = effectiveVar.value;
-      logger.debug(`Loaded MISTRAL_API_KEY from ${effectiveVar.source}`);
-    }
-  }
-
-  if (!apiKey) {
-    throw new Error('Mistral API key is required in Providers settings or Aider environment variables (MISTRAL_API_KEY)');
-  }
-
-  const mistralProvider = createMistral({
-    apiKey,
-    headers: profile.headers,
-  });
-  return mistralProvider(model.id);
-};
-
-// === Complete Strategy Implementation ===
-export const mistralProviderStrategy: LlmProviderStrategy = {
-  // Core LLM functions
-  createLlm: createMistralLlm,
-  getUsageReport: getDefaultUsageReport,
-
-  // Model discovery functions
-  loadModels: loadMistralModels,
-  hasEnvVars: hasMistralEnvVars,
-  getAiderMapping: getMistralAiderMapping,
-  getModelInfo: getDefaultModelInfo,
-};
+export const loadMistralModels = mistralProviderStrategy.loadModels;

--- a/src/main/models/providers/neuralwatt.ts
+++ b/src/main/models/providers/neuralwatt.ts
@@ -1,14 +1,12 @@
-import { Model, ProviderProfile, Reasoning, SettingsData } from '@common/types';
-import { isNeuralwattProvider, LlmProvider, NeuralwattProvider } from '@common/agent';
+import { isNeuralwattProvider, LlmProvider } from '@common/agent';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { Model, Reasoning } from '@common/types';
 
-import type { LanguageModel } from 'ai';
 import type { SharedV4ProviderOptions } from '@ai-sdk/provider';
 
-import { AiderModelMapping, LlmProviderStrategy, LoadModelsResponse } from '@/models';
-import logger from '@/logger';
-import { getEffectiveEnvironmentVariable } from '@/utils';
-import { getDefaultModelInfo, getDefaultUsageReport } from '@/models/providers/default';
+import { LlmProviderStrategy } from '@/models';
+import { createStrategyFromDescriptor } from '@/models/providers/strategy-factory';
+import { mergeModelProps } from '@/models/providers/shared';
 
 const NEURALWATT_BASE_URL = 'https://api.neuralwatt.com/v1';
 
@@ -58,105 +56,22 @@ interface NeuralwattModelEntry {
   metadata?: NeuralwattModelMetadata;
 }
 
-const loadNeuralwattModels = async (profile: ProviderProfile, settings: SettingsData): Promise<LoadModelsResponse> => {
-  if (!isNeuralwattProvider(profile.provider)) {
-    return { models: [], success: false };
-  }
-
-  const provider = profile.provider as NeuralwattProvider;
-  const apiKey = provider.apiKey || '';
-  const apiKeyEnv = getEffectiveEnvironmentVariable('NEURALWATT_API_KEY', settings);
-  const effectiveApiKey = apiKey || apiKeyEnv?.value || '';
-
-  if (!effectiveApiKey) {
-    logger.debug('Neuralwatt API key is required. Please set it in Providers settings or via NEURALWATT_API_KEY environment variable.');
-    return { models: [], success: false };
-  }
-
-  try {
-    const response = await fetch(`${NEURALWATT_BASE_URL}/models`, {
-      headers: { Authorization: `Bearer ${effectiveApiKey}` },
-    });
-
-    if (!response.ok) {
-      const errorMsg = `Neuralwatt models API response failed: ${response.status} ${response.statusText} ${await response.text()}`;
-      logger.error(errorMsg, { status: response.status, statusText: response.statusText });
-      return { models: [], success: false, error: errorMsg };
-    }
-
-    const data = await response.json();
-    logger.debug(`Received response from Neuralwatt models API for profile ${profile.id}`, { data });
-    const models =
-      data.data?.map((model: NeuralwattModelEntry) => {
-        const metadata = model.metadata;
-        const pricing = metadata?.pricing;
-        const limits = metadata?.limits;
-        const capabilities = metadata?.capabilities;
-
-        return {
-          id: model.id,
-          providerId: profile.id,
-          maxInputTokens: limits?.max_context_length ?? model.max_model_len,
-          maxOutputTokensLimit: limits?.max_output_tokens ?? undefined,
-          inputCostPerToken: pricing ? pricing.input_per_million / 1_000_000 : undefined,
-          outputCostPerToken: pricing ? pricing.output_per_million / 1_000_000 : undefined,
-          cacheReadInputTokenCost: pricing?.cached_input_per_million != null ? pricing.cached_input_per_million / 1_000_000 : undefined,
-          supportsTools: capabilities?.tools,
-        } satisfies Model;
-      }) || [];
-
-    logger.info(`Loaded ${models.length} Neuralwatt models for profile ${profile.id}`);
-    return { models, success: true };
-  } catch (error) {
-    const errorMsg = typeof error === 'string' ? error : error instanceof Error ? error.message : 'Unknown error loading Neuralwatt models';
-    logger.error('Error loading Neuralwatt models:', error);
-    return { models: [], success: false, error: errorMsg };
-  }
-};
-
-const hasNeuralwattEnvVars = (settings: SettingsData): boolean => {
-  return !!getEffectiveEnvironmentVariable('NEURALWATT_API_KEY', settings, undefined)?.value;
-};
-
-const getNeuralwattAiderMapping = (provider: ProviderProfile, modelId: string): AiderModelMapping => {
-  const neuralwattProvider = provider.provider as NeuralwattProvider;
-  const envVars: Record<string, string> = {};
-
-  if (neuralwattProvider.apiKey) {
-    envVars.OPENAI_API_KEY = neuralwattProvider.apiKey;
-  }
-
-  envVars.OPENAI_API_BASE = NEURALWATT_BASE_URL;
+const neuralwattModelsMapper = (id: string, item: unknown): Partial<Model> => {
+  const model = item as NeuralwattModelEntry;
+  const metadata = model.metadata;
+  const pricing = metadata?.pricing;
+  const limits = metadata?.limits;
+  const capabilities = metadata?.capabilities;
 
   return {
-    modelName: `openai/${modelId}`,
-    environmentVariables: envVars,
+    id,
+    maxInputTokens: limits?.max_context_length ?? model.max_model_len,
+    maxOutputTokensLimit: limits?.max_output_tokens ?? undefined,
+    inputCostPerToken: pricing ? pricing.input_per_million / 1_000_000 : undefined,
+    outputCostPerToken: pricing ? pricing.output_per_million / 1_000_000 : undefined,
+    cacheReadInputTokenCost: pricing?.cached_input_per_million != null ? pricing.cached_input_per_million / 1_000_000 : undefined,
+    supportsTools: capabilities?.tools,
   };
-};
-
-const createNeuralwattLlm = (profile: ProviderProfile, model: Model, settings: SettingsData, projectDir: string): LanguageModel => {
-  const provider = profile.provider as NeuralwattProvider;
-  let apiKey = provider.apiKey;
-
-  if (!apiKey) {
-    const effectiveVar = getEffectiveEnvironmentVariable('NEURALWATT_API_KEY', settings, projectDir);
-    if (effectiveVar) {
-      apiKey = effectiveVar.value;
-      logger.debug(`Loaded NEURALWATT_API_KEY from ${effectiveVar.source}`);
-    }
-  }
-
-  if (!apiKey) {
-    throw new Error('Neuralwatt API key is required in Providers settings or Aider environment variables (NEURALWATT_API_KEY)');
-  }
-
-  const compatibleProvider = createOpenAICompatible({
-    name: 'neuralwatt',
-    apiKey,
-    baseURL: NEURALWATT_BASE_URL,
-    headers: profile.headers,
-  });
-  return compatibleProvider(model.id);
 };
 
 const getNeuralwattProviderOptions = (llmProvider: LlmProvider, model: Model, reasoning?: Reasoning): SharedV4ProviderOptions | undefined => {
@@ -170,15 +85,13 @@ const getNeuralwattProviderOptions = (llmProvider: LlmProvider, model: Model, re
     return undefined;
   }
 
-  const neuralwattProvider = llmProvider as NeuralwattProvider;
-
-  // Extract reasoningEffort from model overrides or provider config
-  const providerOverrides = model.providerOverrides as Partial<NeuralwattProvider> | undefined;
-  const reasoningEffort = providerOverrides?.reasoningEffort ?? neuralwattProvider.reasoningEffort;
+  const overrides = mergeModelProps(model, llmProvider, ['reasoningEffort']);
 
   // Map ReasoningEffort enum to AI SDK format
   const mappedReasoningEffort =
-    reasoningEffort === undefined ? undefined : (reasoningEffort.toLowerCase() as 'max' | 'xhigh' | 'high' | 'medium' | 'low' | 'minimal' | 'none');
+    overrides.reasoningEffort === undefined
+      ? undefined
+      : (overrides.reasoningEffort.toLowerCase() as 'max' | 'xhigh' | 'high' | 'medium' | 'low' | 'minimal' | 'none');
 
   if (mappedReasoningEffort) {
     return {
@@ -191,12 +104,20 @@ const getNeuralwattProviderOptions = (llmProvider: LlmProvider, model: Model, re
   return undefined;
 };
 
-export const neuralwattProviderStrategy: LlmProviderStrategy = {
-  createLlm: createNeuralwattLlm,
-  getUsageReport: getDefaultUsageReport,
-  loadModels: loadNeuralwattModels,
-  hasEnvVars: hasNeuralwattEnvVars,
-  getAiderMapping: getNeuralwattAiderMapping,
-  getModelInfo: getDefaultModelInfo,
-  getProviderOptions: getNeuralwattProviderOptions,
-};
+export const neuralwattProviderStrategy: LlmProviderStrategy = createStrategyFromDescriptor({
+  name: 'neuralwatt',
+  label: 'Neuralwatt',
+  sdkFactory: createOpenAICompatible,
+  extraFactoryOptions: () => ({ name: 'neuralwatt' }),
+  apiKeyEnv: 'NEURALWATT_API_KEY',
+  fixedBaseURL: NEURALWATT_BASE_URL,
+  isProvider: isNeuralwattProvider,
+  modelsLoader: {
+    type: 'openai-compatible',
+    url: `${NEURALWATT_BASE_URL}/models`,
+    noKeyDebug: 'Neuralwatt API key is required. Please set it in Providers settings or via NEURALWATT_API_KEY environment variable.',
+    mapper: neuralwattModelsMapper,
+  },
+  aider: { prefix: 'openai', apiKeyEnv: 'OPENAI_API_KEY', upstreamBaseUrl: NEURALWATT_BASE_URL },
+  overrides: { getProviderOptions: getNeuralwattProviderOptions },
+});

--- a/src/main/models/providers/ollama.ts
+++ b/src/main/models/providers/ollama.ts
@@ -1,14 +1,22 @@
-import { Model, ProviderProfile, SettingsData } from '@common/types';
 import { isOllamaProvider, OllamaProvider } from '@common/agent';
 import { createOllama } from 'ollama-ai-provider-v2';
 import { simulateStreamingMiddleware, wrapLanguageModel } from 'ai';
-
-import type { LanguageModel } from 'ai';
+import { Model, ProviderProfile, SettingsData } from '@common/types';
 
 import { AiderModelMapping, LlmProviderStrategy, LoadModelsResponse } from '@/models';
 import logger from '@/logger';
 import { getEffectiveEnvironmentVariable } from '@/utils';
-import { getDefaultUsageReport } from '@/models/providers/default';
+import { createStrategyFromDescriptor } from '@/models/providers/strategy-factory';
+import { normalizeError } from '@/models/providers/shared';
+
+/** strips trailing slashes, then appends the Ollama REST prefix if missing */
+const normalizeOllamaBaseUrl = (baseUrl: string): string => {
+  let normalized = baseUrl.replace(/\/+$/, '');
+  if (!normalized.endsWith('/api')) {
+    normalized = `${normalized}/api`;
+  }
+  return normalized;
+};
 
 export const loadOllamaModels = async (profile: ProviderProfile, settings: SettingsData): Promise<LoadModelsResponse> => {
   if (!isOllamaProvider(profile.provider)) {
@@ -25,11 +33,7 @@ export const loadOllamaModels = async (profile: ProviderProfile, settings: Setti
   }
 
   try {
-    let normalized = effectiveBaseUrl.replace(/\/+$/, ''); // Remove all trailing slashes
-    if (!normalized.endsWith('/api')) {
-      normalized = `${normalized}/api`;
-    }
-    const response = await fetch(`${normalized}/tags`);
+    const response = await fetch(`${normalizeOllamaBaseUrl(effectiveBaseUrl)}/tags`);
     if (!response.ok) {
       const errorMsg = `Ollama models API response failed: ${response.status} ${response.statusText} ${await response.text()}`;
       logger.warn(errorMsg);
@@ -50,17 +54,13 @@ export const loadOllamaModels = async (profile: ProviderProfile, settings: Setti
     logger.info(`Loaded ${models.length} Ollama models from ${effectiveBaseUrl} for profile ${profile.id}`);
     return { models, success: true };
   } catch (error) {
-    const errorMsg = typeof error === 'string' ? error : error instanceof Error ? error.message : 'Unknown error loading Ollama models';
+    const errorMsg = normalizeError(error, 'Unknown error loading Ollama models');
     logger.error('Error loading Ollama models:', error);
     return { models: [], success: false, error: errorMsg };
   }
 };
 
-export const hasOllamaEnvVars = (settings: SettingsData): boolean => {
-  return !!getEffectiveEnvironmentVariable('OLLAMA_API_BASE', settings, undefined)?.value;
-};
-
-export const getOllamaAiderMapping = (provider: ProviderProfile, modelId: string): AiderModelMapping => {
+const getOllamaAiderMapping = (provider: ProviderProfile, modelId: string): AiderModelMapping => {
   const ollamaProvider = provider.provider as OllamaProvider;
   const envVars: Record<string, string> = {};
 
@@ -75,46 +75,18 @@ export const getOllamaAiderMapping = (provider: ProviderProfile, modelId: string
   };
 };
 
-// === LLM Creation Functions ===
-export const createOllamaLlm = (profile: ProviderProfile, model: Model, settings: SettingsData, projectDir: string): LanguageModel => {
-  const provider = profile.provider as OllamaProvider;
-  let baseUrl = provider.baseUrl;
-
-  if (!baseUrl) {
-    const effectiveVar = getEffectiveEnvironmentVariable('OLLAMA_API_BASE', settings, projectDir);
-    if (effectiveVar) {
-      baseUrl = effectiveVar.value;
-      logger.debug(`Loaded OLLAMA_API_BASE from ${effectiveVar.source}`);
-    }
-  }
-
-  if (!baseUrl) {
-    throw new Error('Base URL is required for Ollama provider. Set it in Providers settings or via the OLLAMA_API_BASE environment variable.');
-  }
-
-  let normalized = baseUrl.replace(/\/+$/, ''); // Remove all trailing slashes
-  if (!normalized.endsWith('/api')) {
-    normalized = `${normalized}/api`;
-  }
-
-  const ollamaInstance = createOllama({
-    baseURL: normalized,
-    headers: profile.headers,
-  });
-  return wrapLanguageModel({
-    model: ollamaInstance(model.id),
-    middleware: simulateStreamingMiddleware(),
-  });
-};
-
-// === Complete Strategy Implementation ===
-export const ollamaProviderStrategy: LlmProviderStrategy = {
-  // Core LLM functions
-  createLlm: createOllamaLlm,
-  getUsageReport: getDefaultUsageReport,
-
-  // Model discovery functions
-  loadModels: loadOllamaModels,
-  hasEnvVars: hasOllamaEnvVars,
-  getAiderMapping: getOllamaAiderMapping,
-};
+// Ollama is local-only (no credential, base URL only), so loadModels/mapping stay bespoke
+export const ollamaProviderStrategy: LlmProviderStrategy = createStrategyFromDescriptor({
+  name: 'ollama',
+  label: 'Ollama',
+  sdkFactory: createOllama,
+  baseUrl: {
+    envKey: 'OLLAMA_API_BASE',
+    required: 'Base URL is required for Ollama provider. Set it in Providers settings or via the OLLAMA_API_BASE environment variable.',
+    transform: normalizeOllamaBaseUrl,
+  },
+  wrapModel: (model) => wrapLanguageModel({ model, middleware: simulateStreamingMiddleware() }),
+  isProvider: isOllamaProvider,
+  hasEnvKeys: ['OLLAMA_API_BASE'],
+  overrides: { loadModels: loadOllamaModels, getAiderMapping: getOllamaAiderMapping },
+});

--- a/src/main/models/providers/openai-compatible.ts
+++ b/src/main/models/providers/openai-compatible.ts
@@ -1,15 +1,15 @@
-import { Model, ProviderProfile, ReasoningEffort, SettingsData, Reasoning, TlsPolicyRegistrar } from '@common/types';
 import { isOpenAiCompatibleProvider, LlmProvider, OpenAiCompatibleProvider } from '@common/agent';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { Model, ProviderProfile, Reasoning, ReasoningEffort, SettingsData, TlsPolicyRegistrar } from '@common/types';
 
 import type { JSONValue, SharedV4ProviderOptions } from '@ai-sdk/provider';
-import type { LanguageModel, ToolSet } from 'ai';
 
-import { AiderModelMapping, LlmProviderStrategy, LoadModelsResponse } from '@/models';
+import { LlmProviderStrategy, LoadModelsResponse } from '@/models';
 import logger from '@/logger';
 import { getEffectiveEnvironmentVariable } from '@/utils';
-import { getDefaultUsageReport } from '@/models/providers/default';
 import { syncProviderTlsRule } from '@/models/utils';
+import { createStrategyFromDescriptor } from '@/models/providers/strategy-factory';
+import { loadOpenAiCompatibleModels, mergeModelProps } from '@/models/providers/shared';
 
 const loadOpenaiCompatibleModels = async (profile: ProviderProfile, settings: SettingsData, tlsRegistrar?: TlsPolicyRegistrar): Promise<LoadModelsResponse> => {
   if (!isOpenAiCompatibleProvider(profile.provider)) {
@@ -32,130 +32,34 @@ const loadOpenaiCompatibleModels = async (profile: ProviderProfile, settings: Se
 
   syncProviderTlsRule(tlsRegistrar, effectiveBaseUrl, provider.sslVerify, provider.caCertPath);
 
-  try {
-    const response = await fetch(
-      `${effectiveBaseUrl}/models`,
-      effectiveApiKey
-        ? {
-            headers: { Authorization: `Bearer ${effectiveApiKey}` },
-          }
-        : {},
-    );
-    if (!response.ok) {
-      const errorMsg = `OpenAI-compatible models API response failed: ${response.status} ${response.statusText} ${await response.text()}`;
-      logger.debug(errorMsg);
-      return { models: [], success: false, error: errorMsg };
-    }
+  return loadOpenAiCompatibleModels({
+    url: `${effectiveBaseUrl}/models`,
+    headers: effectiveApiKey ? { Authorization: `Bearer ${effectiveApiKey}` } : {},
+    profile,
+    label: 'OpenAI-compatible',
+    notOkLog: 'debug',
+    catchLog: 'warn',
+    mapper: (id, item) => {
+      const model = item as {
+        max_model_len?: number;
+        context_length?: number;
+        num_ctx?: number;
+        context_window?: number;
+        max_completion_tokens?: number;
+        max_tokens?: number;
+      };
+      const maxInputTokens = model.max_model_len ?? model.context_length ?? model.num_ctx ?? model.context_window;
+      const maxOutputTokensLimit = model.max_completion_tokens ?? model.max_tokens;
 
-    const data = await response.json();
-    const models =
-      data.data?.map(
-        (model: {
-          id: string;
-          max_model_len?: number;
-          context_length?: number;
-          num_ctx?: number;
-          context_window?: number;
-          max_completion_tokens?: number;
-          max_tokens?: number;
-        }) => {
-          const maxInputTokens = model.max_model_len ?? model.context_length ?? model.num_ctx ?? model.context_window;
-          const maxOutputTokensLimit = model.max_completion_tokens ?? model.max_tokens;
-
-          return {
-            id: model.id,
-            providerId: profile.id,
-            ...(maxInputTokens != null && { maxInputTokens }),
-            ...(maxOutputTokensLimit != null && { maxOutputTokensLimit }),
-          } satisfies Model;
-        },
-      ) || [];
-
-    logger.info(`Loaded ${models.length} OpenAI-compatible models for profile ${profile.id}`);
-    return { models, success: true };
-  } catch (error) {
-    const errorMsg = typeof error === 'string' ? error : error instanceof Error ? error.message : 'Unknown error loading OpenAI-compatible models';
-    logger.warn('Failed to fetch OpenAI-compatible models via API:', error);
-    return { models: [], success: false, error: errorMsg };
-  }
-};
-
-const hasOpenAiCompatibleEnvVars = (settings: SettingsData): boolean => {
-  const hasApiKey = !!getEffectiveEnvironmentVariable('OPENAI_API_KEY', settings, undefined)?.value;
-  const hasBaseUrl = !!getEffectiveEnvironmentVariable('OPENAI_API_BASE', settings, undefined)?.value;
-  return hasApiKey || hasBaseUrl;
-};
-
-const getOpenAiCompatibleAiderMapping = (provider: ProviderProfile, modelId: string): AiderModelMapping => {
-  const compatibleProvider = provider.provider as OpenAiCompatibleProvider;
-  const envVars: Record<string, string> = {};
-
-  if (compatibleProvider.apiKey) {
-    envVars.OPENAI_API_KEY = compatibleProvider.apiKey;
-  }
-  if (compatibleProvider.baseUrl) {
-    envVars.OPENAI_API_BASE = compatibleProvider.baseUrl;
-  }
-
-  // Use openai prefix for OpenAI-compatible providers
-  return {
-    modelName: `openai/${modelId}`,
-    environmentVariables: envVars,
-  };
-};
-
-// === LLM Creation Functions ===
-const createOpenAiCompatibleLlm = (
-  profile: ProviderProfile,
-  model: Model,
-  settings: SettingsData,
-  projectDir: string,
-  _toolSet?: ToolSet,
-  _systemPrompt?: string,
-  _providerMetadata?: unknown,
-  tlsRegistrar?: TlsPolicyRegistrar,
-): LanguageModel => {
-  const provider = profile.provider as OpenAiCompatibleProvider;
-  let apiKey = provider.apiKey;
-  let baseUrl = provider.baseUrl;
-
-  if (!apiKey) {
-    const effectiveVar = getEffectiveEnvironmentVariable('OPENAI_API_KEY', settings, projectDir);
-    if (effectiveVar) {
-      apiKey = effectiveVar.value;
-      logger.debug(`Loaded OPENAI_API_KEY from ${effectiveVar.source}`);
-    }
-  }
-
-  if (!baseUrl) {
-    const effectiveVar = getEffectiveEnvironmentVariable('OPENAI_API_BASE', settings, projectDir);
-    if (effectiveVar) {
-      baseUrl = effectiveVar.value;
-      logger.debug(`Loaded OPENAI_API_BASE from ${effectiveVar.source}`);
-    }
-  }
-
-  if (!baseUrl) {
-    throw new Error(`Base URL is required for ${provider.name} provider. Set it in Providers settings or via the OPENAI_API_BASE environment variable.`);
-  }
-
-  syncProviderTlsRule(tlsRegistrar, baseUrl, provider.sslVerify, provider.caCertPath);
-
-  const providerOverrides = model.providerOverrides as Partial<OpenAiCompatibleProvider> | undefined;
-  const trackTokenUsage = providerOverrides?.trackTokenUsage ?? provider.trackTokenUsage;
-
-  // Use createOpenAICompatible to get a provider instance, then get the model
-  const compatibleProvider = createOpenAICompatible({
-    name: provider.name,
-    apiKey,
-    baseURL: baseUrl,
-    headers: profile.headers,
-    includeUsage: trackTokenUsage !== false,
+      return {
+        id,
+        ...(maxInputTokens != null && { maxInputTokens }),
+        ...(maxOutputTokensLimit != null && { maxOutputTokensLimit }),
+      } satisfies Partial<Model>;
+    },
   });
-  return compatibleProvider(model.id);
 };
 
-// === Configuration Helper Functions ===
 const getOpenAiCompatibleProviderOptions = (provider: LlmProvider, model: Model, reasoning?: Reasoning): SharedV4ProviderOptions | undefined => {
   if (!isOpenAiCompatibleProvider(provider)) {
     return undefined;
@@ -164,9 +68,9 @@ const getOpenAiCompatibleProviderOptions = (provider: LlmProvider, model: Model,
   const openAiCompatibleProvider = provider as OpenAiCompatibleProvider;
 
   // Extract reasoningEffort from model overrides or provider config
-  const providerOverrides = model.providerOverrides as Partial<OpenAiCompatibleProvider> | undefined;
-  const reasoningEffort = providerOverrides?.reasoningEffort ?? openAiCompatibleProvider.reasoningEffort;
-  const extraBody = providerOverrides?.extraBody ?? openAiCompatibleProvider.extraBody;
+  const overrides = mergeModelProps(model, openAiCompatibleProvider, ['reasoningEffort', 'extraBody']);
+  const reasoningEffort = overrides.reasoningEffort;
+  const extraBody = overrides.extraBody;
 
   const providerOptions: Record<string, JSONValue> = {};
 
@@ -201,17 +105,31 @@ const getOpenAiCompatibleProviderOptions = (provider: LlmProvider, model: Model,
   return undefined;
 };
 
-// === Complete Strategy Implementation ===
-export const openaiCompatibleProviderStrategy: LlmProviderStrategy = {
-  // Core LLM functions
-  createLlm: createOpenAiCompatibleLlm,
-  getUsageReport: getDefaultUsageReport,
-
-  // Model discovery functions
-  loadModels: loadOpenaiCompatibleModels,
-  hasEnvVars: hasOpenAiCompatibleEnvVars,
-  getAiderMapping: getOpenAiCompatibleAiderMapping,
-
-  // Configuration helper functions
-  getProviderOptions: getOpenAiCompatibleProviderOptions,
-};
+// loadModels keeps its bespoke flow: base URL required, key optional, TLS sync
+export const openaiCompatibleProviderStrategy: LlmProviderStrategy = createStrategyFromDescriptor({
+  name: 'openai-compatible',
+  label: 'OpenAI-compatible',
+  sdkFactory: createOpenAICompatible,
+  apiKeyEnv: 'OPENAI_API_KEY',
+  // the API key is optional here; only the base URL is required
+  apiKeyRequired: null,
+  baseUrl: {
+    envKey: 'OPENAI_API_BASE',
+    required: (provider) => `Base URL is required for ${provider.name} provider. Set it in Providers settings or via the OPENAI_API_BASE environment variable.`,
+  },
+  extraFactoryOptions: ({ provider, model }) => {
+    const openAiCompatibleProvider = provider as unknown as OpenAiCompatibleProvider;
+    return {
+      name: openAiCompatibleProvider.name,
+      includeUsage: mergeModelProps(model, openAiCompatibleProvider, ['trackTokenUsage']).trackTokenUsage !== false,
+    };
+  },
+  tlsSync: true,
+  isProvider: isOpenAiCompatibleProvider,
+  hasEnvKeys: ['OPENAI_API_KEY', 'OPENAI_API_BASE'],
+  aider: { prefix: 'openai', apiKeyEnv: 'OPENAI_API_KEY', baseUrlField: 'baseUrl' },
+  overrides: {
+    loadModels: loadOpenaiCompatibleModels,
+    getProviderOptions: getOpenAiCompatibleProviderOptions,
+  },
+});

--- a/src/main/models/providers/openai.ts
+++ b/src/main/models/providers/openai.ts
@@ -1,6 +1,6 @@
 import { createOpenAI } from '@ai-sdk/openai';
 import { DEFAULT_VOICE_SYSTEM_INSTRUCTIONS, isOpenAiProvider, LlmProvider, OpenAiProvider, OpenAiVoiceModel } from '@common/agent';
-import { Reasoning, Model, ProviderProfile, ReasoningEffort, SettingsData, VoiceSession } from '@common/types';
+import { Reasoning, Model, ProviderProfile, SettingsData, VoiceSession } from '@common/types';
 
 import type { LanguageModel, ToolSet } from 'ai';
 import type { SharedV4ProviderOptions } from '@ai-sdk/provider';
@@ -9,6 +9,7 @@ import logger from '@/logger';
 import { AiderModelMapping, LlmProviderStrategy, LoadModelsResponse } from '@/models';
 import { getEffectiveEnvironmentVariable } from '@/utils';
 import { getDefaultModelInfo, getDefaultUsageReport } from '@/models/providers/default';
+import { getOpenAiFamilyProviderOptions, mergeModelProps, normalizeError } from '@/models/providers/shared';
 
 export const loadOpenAiModels = async (profile: ProviderProfile, settings: SettingsData): Promise<LoadModelsResponse> => {
   if (!isOpenAiProvider(profile.provider)) {
@@ -70,7 +71,7 @@ export const loadOpenAiModels = async (profile: ProviderProfile, settings: Setti
     logger.info(`Loaded ${models.length} OpenAI models for profile ${profile.id}`);
     return { models, success: true };
   } catch (error) {
-    const errorMsg = typeof error === 'string' ? error : error instanceof Error ? error.message : 'Unknown error loading OpenAI models';
+    const errorMsg = normalizeError(error, 'Unknown error loading OpenAI models');
     logger.error('Error loading OpenAI models:', error);
     return { models: [], success: false, error: errorMsg };
   }
@@ -129,38 +130,10 @@ export const getOpenAiProviderOptions = (provider: LlmProvider, model: Model, re
 
   const openAiProvider = provider as OpenAiProvider;
 
-  // When the top-level reasoning parameter is set (not undefined or 'provider-default'),
-  // omit reasoningEffort from providerOptions so the AI SDK's portable reasoning takes effect.
-  // Keep reasoningSummary so reasoning output is still returned.
-  if (reasoning && reasoning !== 'provider-default') {
-    return {
-      openai: {
-        reasoningSummary: 'auto',
-      },
-    };
-  }
-
   // Extract reasoningEffort from model overrides or provider config
-  const providerOverrides = model.providerOverrides as Partial<OpenAiProvider> | undefined;
-  const reasoningEffort = providerOverrides?.reasoningEffort ?? openAiProvider.reasoningEffort;
+  const { reasoningEffort } = mergeModelProps(model, openAiProvider, ['reasoningEffort']);
 
-  // Map ReasoningEffort enum to AI SDK format
-  const mappedReasoningEffort =
-    reasoningEffort === undefined || reasoningEffort === ReasoningEffort.None
-      ? undefined
-      : (reasoningEffort.toLowerCase() as 'minimal' | 'low' | 'medium' | 'high' | 'xhigh');
-
-  if (mappedReasoningEffort) {
-    logger.debug('Using reasoning effort:', { mappedReasoningEffort });
-    return {
-      openai: {
-        reasoningSummary: 'auto',
-        reasoningEffort: mappedReasoningEffort,
-      },
-    };
-  }
-
-  return undefined;
+  return getOpenAiFamilyProviderOptions('openai', reasoningEffort, reasoning);
 };
 
 // === Provider Tools Functions ===

--- a/src/main/models/providers/opencode-go.ts
+++ b/src/main/models/providers/opencode-go.ts
@@ -11,20 +11,9 @@ import type { LanguageModel, ModelMessage, ToolSet } from 'ai';
 
 import { AiderModelMapping, LlmProviderStrategy, LoadModelsResponse } from '@/models';
 import { getEffectiveEnvironmentVariable } from '@/utils';
+import { loadOpenAiCompatibleModels, resolveProviderCredential, stripV1Suffix } from '@/models/providers/shared';
 
 const ENDPOINT_BASE_URL = 'https://opencode.ai/zen/go/v1';
-
-interface OpenCodeGoModel {
-  id: string;
-  object: string;
-  created: number;
-  owned_by: string;
-}
-
-interface OpenCodeGoModelsResponse {
-  object: string;
-  data: OpenCodeGoModel[];
-}
 
 type ModelEndpointType = 'openai-responses' | 'anthropic' | 'openai-compatible';
 
@@ -71,31 +60,16 @@ const loadOpencodeGoModels = async (profile: ProviderProfile, settings: Settings
     return { models: [], success: false };
   }
 
-  try {
-    const response = await fetch(`${ENDPOINT_BASE_URL}/models`, {
-      headers: {
-        Authorization: `Bearer ${effectiveApiKey}`,
-      },
-    });
-    if (!response.ok) {
-      const errorMsg = `OpenCode Go models API response failed: ${response.status} ${response.statusText} ${await response.text()}`;
-      return { models: [], success: false, error: errorMsg };
-    }
-
-    const data = (await response.json()) as OpenCodeGoModelsResponse;
-    const models =
-      data.data?.map((model: OpenCodeGoModel) => {
-        return {
-          id: model.id,
-          providerId: profile.id,
-        } satisfies Model;
-      }) || [];
-
-    return { models, success: true };
-  } catch (error) {
-    const errorMsg = typeof error === 'string' ? error : error instanceof Error ? error.message : 'Unknown error loading OpenCode Go models';
-    return { models: [], success: false, error: errorMsg };
-  }
+  // OpenCode Go loadModels is intentionally silent: it never logs on failure.
+  return loadOpenAiCompatibleModels({
+    url: `${ENDPOINT_BASE_URL}/models`,
+    headers: { Authorization: `Bearer ${effectiveApiKey}` },
+    profile,
+    label: 'OpenCode Go',
+    notOkLog: 'none',
+    catchLog: 'none',
+    mapper: (id) => ({ id }),
+  });
 };
 
 export const hasOpencodeGoEnvVars = (settings: SettingsData): boolean => {
@@ -113,7 +87,7 @@ export const getOpencodeGoAiderMapping = (provider: ProviderProfile, modelId: st
     if (apiKey) {
       envVars.ANTHROPIC_API_KEY = apiKey;
     }
-    envVars.ANTHROPIC_BASE_URL = ENDPOINT_BASE_URL.slice(0, -3);
+    envVars.ANTHROPIC_BASE_URL = stripV1Suffix(ENDPOINT_BASE_URL);
 
     return {
       modelName: `anthropic/${modelId}`,
@@ -145,18 +119,14 @@ export const createOpencodeGoLlm = (
   sessionId?: string,
 ): LanguageModel => {
   const provider = profile.provider as OpenCodeGoProvider;
-  let apiKey = provider.apiKey;
-
-  if (!apiKey) {
-    const effectiveVar = getEffectiveEnvironmentVariable('OPENCODE_GO_API_KEY', settings, projectDir);
-    if (effectiveVar) {
-      apiKey = effectiveVar.value;
-    }
-  }
-
-  if (!apiKey) {
-    throw new Error('OpenCode Go API key is required in Providers settings or Aider environment variables (OPENCODE_GO_API_KEY)');
-  }
+  const apiKey = resolveProviderCredential({
+    provider,
+    field: 'apiKey',
+    settings,
+    projectDir,
+    envKey: 'OPENCODE_GO_API_KEY',
+    required: 'OpenCode Go API key is required in Providers settings or Aider environment variables (OPENCODE_GO_API_KEY)',
+  });
 
   const headers: Record<string, string> = {
     ...profile.headers,

--- a/src/main/models/providers/opencode.ts
+++ b/src/main/models/providers/opencode.ts
@@ -10,6 +10,7 @@ import { getDefaultModelInfo, getDefaultUsageReport } from './default';
 import type { LanguageModel } from 'ai';
 
 import { AiderModelMapping, LlmProviderStrategy, LoadModelsResponse } from '@/models';
+import { getDefaultModelTemperature as getBaseDefaultModelTemperature, normalizeError } from '@/models/providers/shared';
 import { getEffectiveEnvironmentVariable } from '@/utils';
 
 const ENDPOINT_BASE_URL = 'https://opencode.ai/zen/v1';
@@ -41,24 +42,11 @@ const getModelEndpointType = (modelId: string): ModelEndpointType => {
   return 'openai-compatible';
 };
 
-const getDefaultModelTemperature = (modelId: string) => {
-  if (modelId.includes('claude')) {
-    return undefined;
-  }
-  if (modelId.includes('gemini')) {
-    return 0.7;
-  }
-  if (modelId.includes('gpt-5') || modelId.startsWith('gpt5')) {
-    return undefined;
-  }
-  if (modelId.includes('qwen')) {
-    return 0.55;
-  }
-  if (modelId.includes('glm-')) {
-    return 0.7;
-  }
-  return undefined;
-};
+const getDefaultModelTemperature = (modelId: string) =>
+  getBaseDefaultModelTemperature(modelId, [
+    { match: (id) => id.includes('glm-'), temperature: 0.7 },
+    { match: (id) => id.startsWith('gpt5'), temperature: undefined },
+  ]);
 
 const loadOpencodeModels = async (profile: ProviderProfile, settings: SettingsData): Promise<LoadModelsResponse> => {
   if (!isOpenCodeProvider(profile.provider)) {
@@ -97,7 +85,7 @@ const loadOpencodeModels = async (profile: ProviderProfile, settings: SettingsDa
 
     return { models, success: true };
   } catch (error) {
-    const errorMsg = typeof error === 'string' ? error : error instanceof Error ? error.message : 'Unknown error loading OpenCode models';
+    const errorMsg = normalizeError(error, 'Unknown error loading OpenCode models');
     return { models: [], success: false, error: errorMsg };
   }
 };

--- a/src/main/models/providers/openrouter.ts
+++ b/src/main/models/providers/openrouter.ts
@@ -10,6 +10,7 @@ import logger from '@/logger';
 import { getEffectiveEnvironmentVariable } from '@/utils';
 import { Task } from '@/task/task';
 import { calculateCost } from '@/models/providers/default';
+import { getDefaultModelTemperature, mergeModelProps, normalizeError } from '@/models/providers/shared';
 
 interface OpenRouterTopProvider {
   is_moderated: boolean;
@@ -37,22 +38,6 @@ interface OpenRouterModel {
 interface OpenRouterModelsResponse {
   data: OpenRouterModel[];
 }
-
-const getDefaultModelTemperature = (modelId: string) => {
-  if (modelId.includes('claude')) {
-    return undefined;
-  }
-  if (modelId.includes('gemini')) {
-    return 0.7;
-  }
-  if (modelId.includes('gpt-5')) {
-    return undefined;
-  }
-  if (modelId.includes('qwen')) {
-    return 0.55;
-  }
-  return undefined;
-};
 
 const loadOpenrouterModels = async (profile: ProviderProfile, settings: SettingsData): Promise<LoadModelsResponse> => {
   if (!isOpenRouterProvider(profile.provider)) {
@@ -99,7 +84,7 @@ const loadOpenrouterModels = async (profile: ProviderProfile, settings: Settings
     logger.info(`Loaded ${models.length} OpenRouter models for profile ${profile.id}`);
     return { models, success: true };
   } catch (error) {
-    const errorMsg = typeof error === 'string' ? error : error instanceof Error ? error.message : 'Unknown error loading OpenRouter models';
+    const errorMsg = normalizeError(error, 'Unknown error loading OpenRouter models');
     logger.error('Error loading OpenRouter models:', error);
     return { models: [], success: false, error: errorMsg };
   }
@@ -140,15 +125,24 @@ export const createOpenRouterLlm = (profile: ProviderProfile, model: Model, sett
     throw new Error('OpenRouter API key is required in Providers settings or Aider environment variables (OPENROUTER_API_KEY)');
   }
 
-  const providerOverrides = model.providerOverrides as Partial<OpenRouterProvider> | undefined;
-  const requireParameters = providerOverrides?.requireParameters ?? provider.requireParameters;
-  const order = providerOverrides?.order ?? provider.order;
-  const only = providerOverrides?.only ?? provider.only;
-  const ignore = providerOverrides?.ignore ?? provider.ignore;
-  const allowFallbacks = providerOverrides?.allowFallbacks ?? provider.allowFallbacks;
-  const dataCollection = providerOverrides?.dataCollection ?? provider.dataCollection;
-  const quantizations = providerOverrides?.quantizations ?? provider.quantizations;
-  const sort = providerOverrides?.sort ?? provider.sort;
+  const overrides = mergeModelProps(model, provider, [
+    'requireParameters',
+    'order',
+    'only',
+    'ignore',
+    'allowFallbacks',
+    'dataCollection',
+    'quantizations',
+    'sort',
+  ]);
+  const requireParameters = overrides.requireParameters;
+  const order = overrides.order;
+  const only = overrides.only;
+  const ignore = overrides.ignore;
+  const allowFallbacks = overrides.allowFallbacks;
+  const dataCollection = overrides.dataCollection;
+  const quantizations = overrides.quantizations;
+  const sort = overrides.sort;
 
   const openRouter = createOpenRouter({
     apiKey,

--- a/src/main/models/providers/requesty.ts
+++ b/src/main/models/providers/requesty.ts
@@ -1,12 +1,12 @@
-import { ContextUserMessage, Model, ProviderProfile, ReasoningEffort, SettingsData, UsageReportData } from '@common/types';
+import { Model, ProviderProfile, ReasoningEffort, SettingsData, UsageReportData } from '@common/types';
 import { isRequestyProvider, LlmProvider, RequestyProvider } from '@common/agent';
 import { createRequesty, type RequestyProviderMetadata } from '@requesty/ai-sdk';
-import { v4 as uuidv4 } from 'uuid';
 
 import type { LanguageModel, LanguageModelUsage, ModelMessage } from 'ai';
 
 import { AIDER_DESK_TITLE, AIDER_DESK_WEBSITE } from '@/constants';
 import { AiderModelMapping, CacheControl, LlmProviderStrategy, LoadModelsResponse } from '@/models';
+import { appendContinueUserMessage, getDefaultModelTemperature, mergeModelProps, normalizeError } from '@/models/providers/shared';
 import logger from '@/logger';
 import { getEffectiveEnvironmentVariable } from '@/utils';
 import { Task } from '@/task/task';
@@ -31,22 +31,6 @@ interface RequestyModel {
 interface RequestyModelsResponse {
   data: RequestyModel[];
 }
-
-const getDefaultModelTemperature = (modelId: string) => {
-  if (modelId.includes('claude')) {
-    return undefined;
-  }
-  if (modelId.includes('gemini')) {
-    return 0.7;
-  }
-  if (modelId.includes('gpt-5')) {
-    return undefined;
-  }
-  if (modelId.includes('qwen')) {
-    return 0.55;
-  }
-  return undefined;
-};
 
 const loadRequestyModels = async (profile: ProviderProfile, settings: SettingsData): Promise<LoadModelsResponse> => {
   if (!isRequestyProvider(profile.provider)) {
@@ -92,7 +76,7 @@ const loadRequestyModels = async (profile: ProviderProfile, settings: SettingsDa
     logger.info(`Loaded ${models.length} Requesty models for profile ${profile.id}`);
     return { models, success: true };
   } catch (error) {
-    const errorMsg = typeof error === 'string' ? error : error instanceof Error ? error.message : 'Unknown error loading Requesty models';
+    const errorMsg = normalizeError(error, 'Unknown error loading Requesty models');
     logger.warn('Failed to fetch Requesty models via API:', error);
     return { models: [], success: false, error: errorMsg };
   }
@@ -141,9 +125,9 @@ export const createRequestyLlm = (profile: ProviderProfile, model: Model, settin
     throw new Error('Requesty API key is required in Providers settings or Aider environment variables (REQUESTY_API_KEY)');
   }
 
-  const providerOverrides = model.providerOverrides as Partial<RequestyProvider> | undefined;
-  const useAutoCache = providerOverrides?.useAutoCache ?? provider.useAutoCache;
-  const reasoningEffort = providerOverrides?.reasoningEffort ?? provider.reasoningEffort;
+  const overrides = mergeModelProps(model, provider, ['useAutoCache', 'reasoningEffort']);
+  const useAutoCache = overrides.useAutoCache;
+  const reasoningEffort = overrides.reasoningEffort;
 
   const requestyProvider = createRequesty({
     apiKey,
@@ -226,22 +210,7 @@ export const getRequestyUsageReport = (
 export const normalizeRequestyMessages = (_provider: LlmProvider, model: Model, messages: ModelMessage[]): ModelMessage[] => {
   // Apply Gemini normalization for Google/Gemini models
   if (model.id.includes('gemini')) {
-    if (messages.length === 0) {
-      return messages;
-    }
-
-    const lastMessage = messages[messages.length - 1];
-
-    if (lastMessage.role !== 'user') {
-      const continueMessage: ContextUserMessage = {
-        id: uuidv4(),
-        role: 'user',
-        content: 'Continue',
-      };
-
-      logger.debug('Added "Continue" user message for Requesty provider with Gemini model (last message was not a user message)');
-      return [...messages, continueMessage];
-    }
+    return appendContinueUserMessage(messages, 'Requesty provider with Gemini model');
   }
 
   return messages;

--- a/src/main/models/providers/shared.ts
+++ b/src/main/models/providers/shared.ts
@@ -1,0 +1,349 @@
+/**
+ * Shared kernel helpers for provider strategies. Extracted from the per-provider
+ * files so each strategy only keeps the parts that are genuinely provider-specific.
+ */
+import { v4 as uuidv4 } from 'uuid';
+import { ContextUserMessage, Model, ModelInfo, ProviderProfile, Reasoning, ReasoningEffort, SettingsData } from '@common/types';
+
+import type { ModelMessage } from 'ai';
+import type { SharedV4ProviderOptions } from '@ai-sdk/provider';
+
+import { AiderModelMapping, LoadModelsResponse } from '@/models/types';
+import logger from '@/logger';
+import { getEffectiveEnvironmentVariable } from '@/utils/environment';
+
+/**
+ * Resolves a credential using the canonical chain: `provider[field]`, then each
+ * entry in `envKey` via getEffectiveEnvironmentVariable (with a debug log of the
+ * source). When the credential is still missing and `required` is non-null, throws
+ * an Error whose message is the exact `required` text the caller locks to.
+ */
+export interface ResolveProviderCredentialOptions {
+  provider: unknown;
+  field: string;
+  settings: SettingsData;
+  projectDir?: string;
+  envKey?: string | string[];
+  required: string | null;
+}
+
+// Overloads so TS knows a non-null `required` guarantees a string result.
+export function resolveProviderCredential(opts: ResolveProviderCredentialOptions & { required: string }): string;
+export function resolveProviderCredential(opts: ResolveProviderCredentialOptions & { required: null }): string | undefined;
+export function resolveProviderCredential(opts: ResolveProviderCredentialOptions): string | undefined {
+  const directValue = (opts.provider as Record<string, unknown> | undefined)?.[opts.field];
+  if (typeof directValue === 'string' && directValue) {
+    return directValue;
+  }
+
+  const envKeys = opts.envKey ? (Array.isArray(opts.envKey) ? opts.envKey : [opts.envKey]) : [];
+  for (const envKey of envKeys) {
+    const effectiveVar = getEffectiveEnvironmentVariable(envKey, opts.settings, opts.projectDir);
+    if (effectiveVar) {
+      logger.debug(`Loaded ${envKey} from ${effectiveVar.source}`);
+      return effectiveVar.value;
+    }
+  }
+
+  if (opts.required !== null) {
+    throw new Error(opts.required);
+  }
+
+  return undefined;
+}
+
+/**
+ * Normalizes an unknown thrown value into the error-message string the provider
+ * strategies put on LoadModelsResponse. Callers pass the per-provider fallback
+ * used when the value is neither a string nor an Error.
+ */
+export const normalizeError = (error: unknown, fallback?: string): string => {
+  if (typeof error === 'string') {
+    return error;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return fallback ?? JSON.stringify(error);
+};
+
+/** Appends a trailing `/v1` when the base URL does not already end with it. */
+export const ensureV1Suffix = (baseUrl: string): string => (baseUrl.endsWith('/v1') ? baseUrl : `${baseUrl}/v1`);
+
+/** Removes a trailing `/v1` when present; URLs without the suffix pass through unchanged. */
+export const stripV1Suffix = (baseUrl: string): string => (baseUrl.endsWith('/v1') ? baseUrl.slice(0, -3) : baseUrl);
+
+/**
+ * Applies the shared `model.providerOverrides?.k ?? provider.k` precedence for the
+ * given keys, returning just the resolved subset.
+ */
+export const mergeModelProps = <T extends object, K extends keyof T>(model: Model, provider: T, keys: readonly K[]): Pick<T, K> => {
+  const overrides = model.providerOverrides as Partial<T> | undefined;
+  return Object.fromEntries(keys.map((key) => [key, overrides?.[key] ?? provider[key]])) as Pick<T, K>;
+};
+
+/**
+ * Returns the static (hardcoded-catalog) loadModels response shape.
+ */
+export const staticModels = (models: Model[], label: string, profileId: string): LoadModelsResponse => {
+  logger.info(`Loaded ${models.length} ${label} models for profile ${profileId}`);
+  return { models, success: true };
+};
+
+interface LoadOpenAiCompatibleModelsOptions {
+  url: string;
+  headers: Record<string, string>;
+  profile: ProviderProfile;
+  /** display name used in all log/error texts, e.g. 'Groq' or 'OpenAI-compatible' */
+  label: string;
+  /**
+   * Maps one item of the response collection to a Model (or its partial without
+   * id/providerId, which the helper stamps). Returning null skips the item.
+   */
+  mapper: (id: string, item: unknown, provider: unknown) => Partial<Model> | null;
+  /** log call for non-OK responses; 'none' = stay silent */
+  notOkLog?: 'error' | 'warn' | 'debug' | 'none';
+  /** log call for thrown errors; 'none' = stay silent */
+  catchLog?: 'error' | 'warn' | 'none';
+  /** drop duplicate ids (mistral returns duplicated entries) */
+  dedupeById?: boolean;
+}
+
+/**
+ * Shared guard -> fetch -> error-normalize -> map -> log frame for the
+ * `<label> models API` loadModels implementations.
+ */
+export const loadOpenAiCompatibleModels = async (opts: LoadOpenAiCompatibleModelsOptions): Promise<LoadModelsResponse> => {
+  const { url, headers, profile, label, mapper, notOkLog = 'error', catchLog = 'error', dedupeById = false } = opts;
+
+  try {
+    const response = await fetch(url, Object.keys(headers).length > 0 ? { headers } : undefined);
+    if (!response.ok) {
+      const errorMsg = `${label} models API response failed: ${response.status} ${response.statusText} ${await response.text()}`;
+      if (notOkLog === 'error') {
+        logger.error(errorMsg, { status: response.status, statusText: response.statusText });
+      } else if (notOkLog === 'warn') {
+        logger.warn(errorMsg);
+      } else if (notOkLog === 'debug') {
+        logger.debug(errorMsg);
+      }
+      return { models: [], success: false, error: errorMsg };
+    }
+
+    const data = (await response.json()) as Record<string, unknown>;
+    const items = data.data as Array<{ id?: string }> | undefined;
+    const models =
+      items
+        ?.map((item) => {
+          // keep a possibly-undefined id so malformed entries behave like the originals did
+          const id = item.id as string;
+          const mapped = mapper(id, item, profile.provider);
+          // stamp id/providerId exactly like every per-provider implementation did
+          return mapped ? { ...mapped, id, providerId: profile.id } : null;
+        })
+        .filter((model): model is Model => model !== null) || [];
+
+    const resultModels = dedupeById ? models.filter((model, index, arr) => arr.findIndex((m) => m.id === model.id) === index) : models;
+
+    logger.info(`Loaded ${resultModels.length} ${label} models for profile ${profile.id}`);
+    return { models: resultModels, success: true };
+  } catch (error) {
+    const errorMsg = normalizeError(error, `Unknown error loading ${label} models`);
+    if (catchLog === 'error') {
+      logger.error(`Error loading ${label} models:`, error);
+    } else if (catchLog === 'warn') {
+      logger.warn(`Failed to fetch ${label} models via API:`, error);
+    }
+    return { models: [], success: false, error: errorMsg };
+  }
+};
+
+export interface SimpleAiderMappingOptions {
+  prefix: string;
+  /** env var written into the mapping when a key is resolved */
+  apiKeyEnv: string;
+  /** env var consulted as fallback when provider.apiKey is missing (defaults to apiKeyEnv) */
+  sourceEnvKey?: string;
+  /** write the resolved key into apiKeyEnv even when the provider value is missing */
+  readEnvFallback?: boolean;
+  /** fixed upstream base URL written to OPENAI_API_BASE */
+  upstreamBaseUrl?: string;
+  /** provider field holding a dynamic base URL, written to OPENAI_API_BASE when set */
+  baseUrlField?: string;
+  /** extra environment variables (undefined values are skipped) */
+  extraEnv?: Record<string, string | undefined>;
+}
+
+/**
+ * Builds the standard getAiderMapping for simple providers:
+ * `envVars.<apiKeyEnv> = resolved key` (+ optional fixed OPENAI_API_BASE, optional
+ * extra vars) under a `<prefix>/<modelId>` model name.
+ */
+export const buildSimpleAiderMapping = (opts: SimpleAiderMappingOptions) => {
+  return (provider: ProviderProfile, modelId: string, settings: SettingsData, projectDir: string): AiderModelMapping => {
+    const envVars: Record<string, string> = {};
+
+    let apiKey = (provider.provider as Record<string, unknown> | undefined)?.apiKey as string | undefined;
+    const sourceEnvKey = opts.sourceEnvKey ?? opts.apiKeyEnv;
+    // env fallback only applies when the explicit provider.apiKey is missing
+    if (opts.readEnvFallback && !apiKey) {
+      const effectiveVar = getEffectiveEnvironmentVariable(sourceEnvKey, settings, projectDir);
+      if (effectiveVar) {
+        logger.debug(`Loaded ${sourceEnvKey} from ${effectiveVar.source}`);
+        apiKey = effectiveVar.value;
+      }
+    }
+    if (apiKey) {
+      envVars[opts.apiKeyEnv] = apiKey;
+    }
+
+    if (opts.upstreamBaseUrl) {
+      envVars.OPENAI_API_BASE = opts.upstreamBaseUrl;
+    }
+
+    if (opts.baseUrlField) {
+      const baseUrl = (provider.provider as Record<string, unknown> | undefined)?.[opts.baseUrlField] as string | undefined;
+      if (baseUrl) {
+        envVars.OPENAI_API_BASE = baseUrl;
+      }
+    }
+
+    if (opts.extraEnv) {
+      for (const [key, value] of Object.entries(opts.extraEnv)) {
+        if (value !== undefined) {
+          envVars[key] = value;
+        }
+      }
+    }
+
+    return {
+      modelName: `${opts.prefix}/${modelId}`,
+      environmentVariables: envVars,
+    };
+  };
+};
+
+/**
+ * Appends a synthetic "Continue" user message when the last message is not a user
+ * message (required by Gemini-family APIs). `logLabel` closes the debug sentence
+ * `Added "Continue" user message for <logLabel>`, so callers keep their exact log text.
+ */
+export const appendContinueUserMessage = (messages: ModelMessage[], logLabel: string): ModelMessage[] => {
+  if (messages.length === 0) {
+    return messages;
+  }
+
+  const lastMessage = messages[messages.length - 1];
+
+  if (lastMessage.role !== 'user') {
+    const continueMessage: ContextUserMessage = {
+      id: uuidv4(),
+      role: 'user',
+      content: 'Continue',
+    };
+
+    logger.debug(`Added "Continue" user message for ${logLabel} (last message was not a user message)`);
+    return [...messages, continueMessage];
+  }
+
+  return messages;
+};
+
+/**
+ * Builds the OpenAI Responses provider options shared by the `openai` and `azure`
+ * strategies (both write to the `openai` options registry key). `reasoningEffort`
+ * must already be resolved by the caller (model overrides falling back to provider
+ * config).
+ */
+export const getOpenAiFamilyProviderOptions = (
+  metadataKey: string,
+  reasoningEffort: ReasoningEffort | undefined,
+  reasoning?: Reasoning,
+): SharedV4ProviderOptions | undefined => {
+  // When the top-level reasoning parameter is set (not undefined or 'provider-default'),
+  // omit reasoningEffort from providerOptions so the AI SDK's portable reasoning takes effect.
+  // Keep reasoningSummary so reasoning output is still returned.
+  if (reasoning && reasoning !== 'provider-default') {
+    return {
+      [metadataKey]: {
+        reasoningSummary: 'auto',
+      },
+    };
+  }
+
+  // Map ReasoningEffort enum to AI SDK format
+  const mappedReasoningEffort =
+    reasoningEffort === undefined || reasoningEffort === ReasoningEffort.None
+      ? undefined
+      : (reasoningEffort.toLowerCase() as 'minimal' | 'low' | 'medium' | 'high' | 'xhigh');
+
+  if (mappedReasoningEffort) {
+    logger.debug('Using reasoning effort:', { mappedReasoningEffort });
+    return {
+      [metadataKey]: {
+        reasoningSummary: 'auto',
+        reasoningEffort: mappedReasoningEffort,
+      },
+    };
+  }
+
+  return undefined;
+};
+
+/**
+ * Builds the Anthropic adaptive-thinking provider options shared by the
+ * `anthropic`, `anthropic-compatible` and `minimax` strategies (all speak the
+ * Anthropic wire protocol). Callers keep their own type-guard/reasoning gating
+ * and only delegate the payload construction.
+ */
+export const getAnthropicAdaptiveThinkingOptions = (): SharedV4ProviderOptions =>
+  // Explicitly request adaptive thinking with summarized display so reasoning/thinking
+  // text is returned via thinking_delta events. Without this, newer Claude models (opus-4-7+)
+  // default to 'omitted' display and return empty thinking blocks.
+  ({
+    anthropic: {
+      thinking: { type: 'adaptive', display: 'summarized' },
+    },
+  });
+
+export interface ModelTemperatureRule {
+  match: (modelId: string) => boolean;
+  temperature: number | undefined;
+}
+
+/**
+ * Default temperature heuristic used by aggregator-style providers (OpenRouter,
+ * Requesty, OpenCode): well-known families get curated temperatures, everything
+ * else stays undefined so the provider default applies. `extraRules` run after the
+ * built-in rules for provider-specific families.
+ */
+export const getDefaultModelTemperature = (modelId: string, extraRules?: ModelTemperatureRule[]): number | undefined => {
+  if (modelId.includes('claude')) {
+    return undefined;
+  }
+  if (modelId.includes('gemini')) {
+    return 0.7;
+  }
+  if (modelId.includes('gpt-5')) {
+    return undefined;
+  }
+  if (modelId.includes('qwen')) {
+    return 0.55;
+  }
+  for (const rule of extraRules ?? []) {
+    if (rule.match(modelId)) {
+      return rule.temperature;
+    }
+  }
+  return undefined;
+};
+
+/**
+ * Builds the fixed-prefix getModelInfo implementations used by providers whose
+ * model-info keys never vary with the profile (e.g. `google/${modelId}` for the
+ * Gemini strategies).
+ */
+export const getModelInfoByPrefix =
+  (prefix: string) =>
+  (_provider: ProviderProfile, modelId: string, allModelInfos: Record<string, ModelInfo>): ModelInfo | undefined =>
+    allModelInfos[`${prefix}/${modelId}`];

--- a/src/main/models/providers/strategy-factory.ts
+++ b/src/main/models/providers/strategy-factory.ts
@@ -1,0 +1,293 @@
+/**
+ * Descriptor-driven factory for the two dominant provider shapes:
+ *
+ * 1. "simple API-key SDK provider" — one credential, a fixed or resolved base URL,
+ *    a single vendored SDK factory, optional models listing, the standard Aider mapping.
+ * 2. "fixed-URL OpenAI-compatible provider" — same as (1) with a hardcoded base URL.
+ *
+ * Anything genuinely bespoke stays in the provider file and is spread on top via
+ * `overrides`, keeping the generated strategy behavior-identical to the originals.
+ */
+import { LlmProvider } from '@common/agent';
+import { Model, ProviderProfile, SettingsData, TlsPolicyRegistrar } from '@common/types';
+
+import type { LanguageModel, ToolSet } from 'ai';
+import type { LanguageModelV2, LanguageModelV3, LanguageModelV4 } from '@ai-sdk/provider';
+
+import { AiderModelMapping, LlmProviderStrategy } from '@/models';
+import logger from '@/logger';
+import { syncProviderTlsRule } from '@/models/utils';
+import {
+  buildSimpleAiderMapping,
+  loadOpenAiCompatibleModels,
+  resolveProviderCredential,
+  staticModels,
+  type SimpleAiderMappingOptions,
+} from '@/models/providers/shared';
+import { getEffectiveEnvironmentVariable } from '@/utils/environment';
+import { getDefaultModelInfo, getDefaultUsageReport } from '@/models/providers/default';
+
+type ProviderRecord = Record<string, unknown>;
+
+/**
+ * SDK factories declare their own options types. Typing the parameter as `never`
+ * (contravariance) lets any concrete factory (createGroq, createAnthropic,
+ * createOpenAICompatible, ...) be assigned as-is; the invocation below performs the
+ * single internal cast.
+ */
+/** concrete model instance returned by an SDK factory (never a model-id string) */
+type SdkModel = LanguageModelV2 | LanguageModelV3 | LanguageModelV4;
+
+type SdkModelFactory = (opts: never) => (modelId: string) => SdkModel;
+
+export interface CredentialResolutionContext {
+  provider: ProviderRecord;
+  settings: SettingsData;
+  projectDir?: string;
+}
+
+export interface SdkFactoryContext {
+  provider: ProviderRecord;
+  profile: ProviderProfile;
+  model: Model;
+  apiKey: string | undefined;
+  baseUrl: string | undefined;
+}
+
+interface OpenAiCompatibleLoader {
+  type: 'openai-compatible';
+  /** endpoint of the models collection */
+  url: string;
+  /** debug message logged when no credential resolves; unset = stay silent */
+  noKeyDebug?: string;
+  notOkLog?: 'error' | 'warn' | 'debug';
+  catchLog?: 'error' | 'warn';
+  dedupeById?: boolean;
+  /** defaults to `(id) => ({ id })`; id/providerId are stamped by the shared loader */
+  mapper?: (id: string, item: unknown, provider: LlmProvider) => Partial<Model> | null;
+}
+
+interface StaticLoader {
+  type: 'static';
+  /** env var gated on before returning the list; unset = no credential gate */
+  apiKeyEnv?: string;
+  noKeyDebug?: string;
+  items: (profile: ProviderProfile) => Model[];
+}
+
+export interface ProviderDescriptor {
+  /** identifier used in descriptor-validation and error messages; the model-manager
+   * provider registry keys are derived independently from the provider list */
+  name: string;
+  /** human label used in log/error texts */
+  label: string;
+  sdkFactory: SdkModelFactory;
+
+  /** env var(s) consulted when the provider API-key field is missing */
+  apiKeyEnv?: string | string[];
+  /** provider field holding the API key (default 'apiKey') */
+  apiKeyField?: string;
+  /**
+   * message thrown when no credential resolves (function form receives the provider).
+   * Default: `<label> API key is required in Providers settings or Aider environment
+   * variables (<first apiKeyEnv>)`; null = credential is optional.
+   */
+  apiKeyRequired?: string | ((provider: ProviderRecord) => string) | null;
+  /** replaces the default provider-field → env resolution chain (see clinepass) */
+  credResolver?: (ctx: CredentialResolutionContext) => string | undefined;
+
+  /** dynamic base URL, resolved like a credential from a provider field + env fallback */
+  baseUrl?: {
+    field?: string;
+    envKey?: string | string[];
+    required: string | ((provider: ProviderRecord) => string);
+    transform?: (url: string) => string;
+  };
+  /** fixed base URL passed to the SDK factory (ignored when `baseUrl` is set) */
+  fixedBaseURL?: string;
+  /** call syncProviderTlsRule(tlsRegistrar, resolvedUrl, sslVerify, caCertPath) during createLlm */
+  tlsSync?: boolean;
+
+  /** merged over the default `{ apiKey, headers, baseURL }` factory options */
+  extraFactoryOptions?: (ctx: SdkFactoryContext) => Record<string, unknown>;
+  /** final decoration of the constructed language model (e.g. ollama streaming middleware) */
+  wrapModel?: (model: SdkModel) => LanguageModel;
+  /** model id passed to the SDK instance (default model.id) */
+  createModelId?: (model: Model) => string;
+
+  /** loadModels gate: return { models: [], success: false } unless this holds */
+  isProvider?: (provider: LlmProvider) => boolean;
+  modelsLoader?: OpenAiCompatibleLoader | StaticLoader;
+  /** keys OR-checked by the default hasEnvVars (default: [apiKeyEnv]) */
+  hasEnvKeys?: string[];
+  /** replaces the default hasEnvVars; false = never any env var present */
+  hasEnvVars?: ((settings: SettingsData) => boolean) | false;
+
+  /** standard buildSimpleAiderMapping implementation; required unless overrides
+   * supplies getAiderMapping (e.g. lm-studio / ollama keep bespoke mappings) */
+  aider?: SimpleAiderMappingOptions;
+  /** bespoke strategy members spread on top of the generated ones */
+  overrides?: Partial<LlmProviderStrategy>;
+}
+
+const arrayify = (value: string | string[] | undefined): string[] => (value === undefined ? [] : Array.isArray(value) ? value : [value]);
+
+export const createStrategyFromDescriptor = (d: ProviderDescriptor): LlmProviderStrategy => {
+  if (!d.modelsLoader && !d.overrides?.loadModels) {
+    throw new Error(`Provider '${d.name}' descriptor needs modelsLoader or overrides.loadModels`);
+  }
+  if (!d.aider && !d.overrides?.getAiderMapping) {
+    throw new Error(`Provider '${d.name}' descriptor needs aider config or overrides.getAiderMapping`);
+  }
+  // The generated mapping is always shadowed by overrides (spread last), so the
+  // combination above would silently make the aider config dead code.
+  if (d.aider && d.overrides?.getAiderMapping) {
+    throw new Error(`Provider '${d.name}' descriptor must not set both aider and overrides.getAiderMapping`);
+  }
+
+  const apiKeyRequiredMessage: string | ((provider: ProviderRecord) => string) | null = (() => {
+    if (d.apiKeyRequired !== undefined) {
+      return d.apiKeyRequired;
+    }
+    const env = arrayify(d.apiKeyEnv)[0];
+    return env ? `${d.label} API key is required in Providers settings or Aider environment variables (${env})` : null;
+  })();
+
+  const createLlm: LlmProviderStrategy['createLlm'] = (
+    profile,
+    model,
+    settings,
+    projectDir,
+    _toolSet?: ToolSet,
+    _systemPrompt?: string,
+    _providerMetadata?: unknown,
+    tlsRegistrar?: TlsPolicyRegistrar,
+  ): LanguageModel => {
+    const provider = profile.provider as unknown as ProviderRecord;
+
+    const apiKey = d.credResolver
+      ? d.credResolver({ provider, settings, projectDir })
+      : resolveProviderCredential({
+          provider,
+          field: d.apiKeyField ?? 'apiKey',
+          settings,
+          projectDir,
+          envKey: d.apiKeyEnv,
+          required: null,
+        });
+
+    if (!apiKey && apiKeyRequiredMessage !== null) {
+      throw new Error(typeof apiKeyRequiredMessage === 'function' ? apiKeyRequiredMessage(provider) : apiKeyRequiredMessage);
+    }
+
+    let baseUrl: string | undefined;
+    if (d.baseUrl) {
+      const raw = resolveProviderCredential({
+        provider,
+        field: d.baseUrl.field ?? 'baseUrl',
+        settings,
+        projectDir,
+        envKey: d.baseUrl.envKey,
+        required: null,
+      });
+      // Pre-refactor providers validated with `!baseUrl`, so an explicitly configured
+      // empty value (e.g. OPENAI_API_BASE='') must be rejected, not just an absent one.
+      // Whitespace stays accepted, matching the original truthy-string behavior.
+      if (raw === undefined || raw === '') {
+        throw new Error(typeof d.baseUrl.required === 'function' ? d.baseUrl.required(provider) : d.baseUrl.required);
+      }
+      baseUrl = d.baseUrl.transform ? d.baseUrl.transform(raw) : raw;
+    } else if (d.fixedBaseURL !== undefined) {
+      baseUrl = d.fixedBaseURL;
+    }
+
+    if (d.tlsSync) {
+      syncProviderTlsRule(tlsRegistrar, baseUrl, provider.sslVerify as boolean | undefined, provider.caCertPath as string | undefined);
+    }
+
+    const factoryOptions: Record<string, unknown> = { [d.apiKeyField ?? 'apiKey']: apiKey, headers: profile.headers };
+    if (baseUrl !== undefined) {
+      factoryOptions.baseURL = baseUrl;
+    }
+    Object.assign(factoryOptions, d.extraFactoryOptions?.({ provider, profile, model, apiKey, baseUrl }) ?? {});
+
+    // `never` cast: see SdkModelFactory above.
+    const languageModel = d.sdkFactory(factoryOptions as never)(d.createModelId ? d.createModelId(model) : model.id);
+    return d.wrapModel ? d.wrapModel(languageModel) : languageModel;
+  };
+
+  const loadModels: LlmProviderStrategy['loadModels'] = async (profile, settings) => {
+    if (d.isProvider && !d.isProvider(profile.provider as LlmProvider)) {
+      return { models: [], success: false };
+    }
+
+    const loader = d.modelsLoader!;
+    const provider = profile.provider as unknown as ProviderRecord;
+    const apiKeyField = d.apiKeyField ?? 'apiKey';
+
+    if (loader.type === 'static') {
+      if (loader.apiKeyEnv) {
+        const apiKey = resolveProviderCredential({ provider, field: apiKeyField, settings, envKey: loader.apiKeyEnv, required: null });
+        if (!apiKey) {
+          if (loader.noKeyDebug) {
+            logger.debug(loader.noKeyDebug);
+          }
+          return { models: [], success: false };
+        }
+      }
+      return staticModels(loader.items(profile), d.label, profile.id);
+    }
+
+    const apiKey = resolveProviderCredential({ provider, field: apiKeyField, settings, envKey: d.apiKeyEnv, required: null });
+    if (!apiKey) {
+      if (loader.noKeyDebug) {
+        logger.debug(loader.noKeyDebug);
+      }
+      return { models: [], success: false };
+    }
+
+    return loadOpenAiCompatibleModels({
+      url: loader.url,
+      headers: { Authorization: `Bearer ${apiKey}` },
+      profile,
+      label: d.label,
+      notOkLog: loader.notOkLog,
+      catchLog: loader.catchLog,
+      dedupeById: loader.dedupeById,
+      mapper: loader.mapper
+        ? (id, item, provider) => {
+            const map = loader.mapper!;
+            return map(id, item, provider as LlmProvider);
+          }
+        : (id) => ({ id }),
+    });
+  };
+
+  return {
+    // Core LLM functions
+    createLlm,
+    getUsageReport: getDefaultUsageReport,
+    // default modelsInfo enrichment lookup; provider overrides (e.g. synthetic,
+    // zai-plan) spread after this and still win
+    getModelInfo: getDefaultModelInfo,
+
+    // Model discovery functions
+    loadModels,
+    hasEnvVars:
+      d.hasEnvVars === undefined
+        ? (() => {
+            const envKeys = d.hasEnvKeys ?? arrayify(d.apiKeyEnv);
+            return (settings: SettingsData): boolean =>
+              envKeys.length > 0 && envKeys.some((key) => !!getEffectiveEnvironmentVariable(key, settings, undefined)?.value);
+          })()
+        : d.hasEnvVars === false
+          ? (): boolean => false
+          : d.hasEnvVars,
+    getAiderMapping: d.aider
+      ? buildSimpleAiderMapping(d.aider)
+      : // unreachable: validated above that overrides supplies getAiderMapping
+        (_provider, modelId): AiderModelMapping => ({ modelName: modelId, environmentVariables: {} }),
+
+    ...d.overrides,
+  };
+};

--- a/src/main/models/providers/synthetic.ts
+++ b/src/main/models/providers/synthetic.ts
@@ -1,118 +1,37 @@
-import { Model, ModelInfo, ProviderProfile, SettingsData } from '@common/types';
-import { isSyntheticProvider, SyntheticProvider } from '@common/agent';
+import { isSyntheticProvider } from '@common/agent';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 
-import { getDefaultUsageReport } from './default';
+import { LlmProviderStrategy } from '@/models';
+import { createStrategyFromDescriptor } from '@/models/providers/strategy-factory';
+import { getModelInfoByPrefix } from '@/models/providers/shared';
 
-import type { LanguageModel } from 'ai';
+const SYNTHETIC_BASE_URL = 'https://api.synthetic.new/openai/v1';
 
-import { AiderModelMapping, LlmProviderStrategy, LoadModelsResponse } from '@/models';
-import logger from '@/logger';
-import { getEffectiveEnvironmentVariable } from '@/utils';
-
-const loadSyntheticModels = async (profile: ProviderProfile, settings: SettingsData): Promise<LoadModelsResponse> => {
-  if (!isSyntheticProvider(profile.provider)) {
-    return { models: [], success: false };
-  }
-
-  const provider = profile.provider as SyntheticProvider;
-  const apiKey = provider.apiKey || '';
-
-  const apiKeyEnv = getEffectiveEnvironmentVariable('SYNTHETIC_API_KEY', settings);
-
-  const effectiveApiKey = apiKey || apiKeyEnv?.value;
-
-  if (!effectiveApiKey) {
-    return { models: [], success: false };
-  }
-
-  try {
-    const response = await fetch('https://api.synthetic.new/openai/v1/models', {
-      headers: { Authorization: `Bearer ${effectiveApiKey}` },
-    });
-    if (!response.ok) {
-      const errorMsg = `Synthetic models API response failed: ${response.status} ${response.statusText} ${await response.text()}`;
-      logger.debug(errorMsg);
-      return { models: [], success: false, error: errorMsg };
-    }
-
-    const data = await response.json();
-    const models =
-      data.data?.map((model: { id: string }) => {
-        return {
-          id: model.id,
-          providerId: profile.id,
-        } satisfies Model;
-      }) || [];
-
-    logger.info(`Loaded ${models.length} Synthetic models for profile ${profile.id}`);
-    return { models, success: true };
-  } catch (error) {
-    const errorMsg = typeof error === 'string' ? error : error instanceof Error ? error.message : 'Unknown error loading Synthetic models';
-    logger.warn('Failed to fetch Synthetic models via API:', error);
-    return { models: [], success: false, error: errorMsg };
-  }
-};
-
-const hasSyntheticEnvVars = (): boolean => false;
-
-const getSyntheticAiderMapping = (provider: ProviderProfile, modelId: string, settings: SettingsData, projectDir: string): AiderModelMapping => {
-  const syntheticProvider = provider.provider as SyntheticProvider;
-  const envVars: Record<string, string> = {};
-
-  if (syntheticProvider.apiKey) {
-    envVars.OPENAI_API_KEY = syntheticProvider.apiKey;
-  } else {
-    const effectiveVar = getEffectiveEnvironmentVariable('SYNTHETIC_API_KEY', settings, projectDir);
-    if (effectiveVar) {
-      envVars.OPENAI_API_KEY = effectiveVar.value;
-    }
-  }
-
-  envVars.OPENAI_API_BASE = 'https://api.synthetic.new/openai/v1';
-
-  return {
-    modelName: `openai/${modelId}`,
-    environmentVariables: envVars,
-  };
-};
-
-const createSyntheticLlm = (profile: ProviderProfile, model: Model, settings: SettingsData, projectDir: string): LanguageModel => {
-  const provider = profile.provider as SyntheticProvider;
-  let apiKey = provider.apiKey;
-
-  if (!apiKey) {
-    const effectiveVar = getEffectiveEnvironmentVariable('SYNTHETIC_API_KEY', settings, projectDir);
-    if (effectiveVar) {
-      apiKey = effectiveVar.value;
-      logger.debug(`Loaded SYNTHETIC_API_KEY from ${effectiveVar.source}`);
-    }
-  }
-
-  if (!apiKey) {
-    throw new Error(`API key is required for ${provider.name}. Check Providers settings or Aider environment variables (SYNTHETIC_API_KEY).`);
-  }
-
-  const compatibleProvider = createOpenAICompatible({
-    name: provider.name,
-    apiKey,
-    baseURL: 'https://api.synthetic.new/openai/v1',
-    headers: profile.headers,
-  });
-  return compatibleProvider(model.id);
-};
-
-const getSyntheticModelInfo = (_provider: ProviderProfile, modelId: string, allModelInfos: Record<string, ModelInfo>): ModelInfo | undefined => {
-  const fullModelId = `synthetic/${modelId}`;
-  return allModelInfos[fullModelId];
-};
-
-export const syntheticProviderStrategy: LlmProviderStrategy = {
-  createLlm: createSyntheticLlm,
-  getUsageReport: getDefaultUsageReport,
-
-  loadModels: loadSyntheticModels,
-  hasEnvVars: hasSyntheticEnvVars,
-  getAiderMapping: getSyntheticAiderMapping,
-  getModelInfo: getSyntheticModelInfo,
-};
+export const syntheticProviderStrategy: LlmProviderStrategy = createStrategyFromDescriptor({
+  name: 'synthetic',
+  label: 'Synthetic',
+  sdkFactory: createOpenAICompatible,
+  apiKeyEnv: 'SYNTHETIC_API_KEY',
+  apiKeyRequired: (provider) => `API key is required for ${provider.name}. Check Providers settings or Aider environment variables (SYNTHETIC_API_KEY).`,
+  fixedBaseURL: SYNTHETIC_BASE_URL,
+  extraFactoryOptions: ({ provider }) => ({ name: provider.name }),
+  isProvider: isSyntheticProvider,
+  modelsLoader: {
+    type: 'openai-compatible',
+    url: `${SYNTHETIC_BASE_URL}/models`,
+    notOkLog: 'debug',
+    catchLog: 'warn',
+  },
+  // Synthetic is only configured via provider API keys; no Aider env var is checked
+  hasEnvVars: false,
+  aider: {
+    prefix: 'openai',
+    apiKeyEnv: 'OPENAI_API_KEY',
+    sourceEnvKey: 'SYNTHETIC_API_KEY',
+    readEnvFallback: true,
+    upstreamBaseUrl: SYNTHETIC_BASE_URL,
+  },
+  overrides: {
+    getModelInfo: getModelInfoByPrefix('synthetic'),
+  },
+});

--- a/src/main/models/providers/vertex-ai.ts
+++ b/src/main/models/providers/vertex-ai.ts
@@ -1,6 +1,6 @@
 import { v1beta1 } from '@google-cloud/aiplatform';
 import { GoogleAuth } from 'google-auth-library';
-import { Model, ModelInfo, ProviderProfile, Reasoning, SettingsData, UsageReportData } from '@common/types';
+import { Model, ProviderProfile, Reasoning, SettingsData, UsageReportData } from '@common/types';
 import { isVertexAiProvider, LlmProvider, VertexAiProvider } from '@common/agent';
 import { createVertex } from '@ai-sdk/google-vertex';
 
@@ -11,7 +11,8 @@ import { AiderModelMapping, LlmProviderStrategy, LoadModelsResponse } from '@/mo
 import logger from '@/logger';
 import { getEffectiveEnvironmentVariable } from '@/utils';
 import { Task } from '@/task/task';
-import { calculateCost } from '@/models/providers/default';
+import { getGoogleFamilyProviderOptions, getGoogleFamilyUsageReport } from '@/models/providers/google-family';
+import { getModelInfoByPrefix, mergeModelProps } from '@/models/providers/shared';
 
 export const loadVertexAIModels = async (profile: ProviderProfile, settings: SettingsData): Promise<LoadModelsResponse> => {
   if (!isVertexAiProvider(profile.provider)) {
@@ -20,8 +21,9 @@ export const loadVertexAIModels = async (profile: ProviderProfile, settings: Set
 
   const provider = profile.provider as VertexAiProvider;
 
-  const projectEnv = getEffectiveEnvironmentVariable('VERTEX_PROJECT', settings);
-  const locationEnv = getEffectiveEnvironmentVariable('VERTEX_LOCATION', settings);
+  // VERTEXAI_* is the spelling already used by createLlm and the Aider mapping.
+  const projectEnv = getEffectiveEnvironmentVariable('VERTEXAI_PROJECT', settings);
+  const locationEnv = getEffectiveEnvironmentVariable('VERTEXAI_LOCATION', settings);
   const credentialsEnv = getEffectiveEnvironmentVariable('GOOGLE_APPLICATION_CREDENTIALS', settings);
 
   const project = provider.project || projectEnv?.value || '';
@@ -161,84 +163,26 @@ export const createVertexAiLlm = (profile: ProviderProfile, model: Model, settin
   return vertexProvider(model.id);
 };
 
-type VertexGoogleMetadata = {
-  vertex: {
-    cachedContentTokenCount?: number;
-  };
-};
-
-const getVertexAiUsageReport = (
+export const getVertexAiUsageReport = (
   task: Task,
   provider: ProviderProfile,
   model: Model,
   usage: LanguageModelUsage,
   providerMetadata?: unknown,
-): UsageReportData => {
-  const totalSentTokens = usage.inputTokens || 0;
-  const receivedTokens = usage.outputTokens || 0;
-
-  // Extract cache read tokens from provider metadata
-  const { vertex } = (providerMetadata as VertexGoogleMetadata) || {};
-  const cacheReadTokens = vertex?.cachedContentTokenCount ?? usage.inputTokenDetails?.cacheReadTokens ?? 0;
-
-  // Calculate sentTokens after deducting cached tokens
-  const sentTokens = totalSentTokens - cacheReadTokens;
-
-  // Calculate cost internally with already deducted sentTokens
-  const messageCost = calculateCost(model, sentTokens, receivedTokens, cacheReadTokens);
-
-  return {
-    model: `${provider.id}/${model.id}`,
-    sentTokens,
-    receivedTokens,
-    cacheReadTokens,
-    messageCost,
-    agentTotalCost: task.task.agentTotalCost + messageCost,
-  };
-};
+): UsageReportData => getGoogleFamilyUsageReport('vertex', task, provider, model, usage, providerMetadata);
 
 export const getVertexAiProviderOptions = (llmProvider: LlmProvider, model: Model, reasoning?: Reasoning): SharedV4ProviderOptions | undefined => {
-  if (isVertexAiProvider(llmProvider)) {
-    const providerOverrides = model.providerOverrides as Partial<VertexAiProvider> | undefined;
-
-    // Use model-specific overrides, falling back to provider defaults
-    const includeThoughts = providerOverrides?.includeThoughts ?? llmProvider.includeThoughts;
-    const thinkingBudget = providerOverrides?.thinkingBudget ?? llmProvider.thinkingBudget;
-
-    // When the top-level reasoning parameter is set (not undefined or 'provider-default'),
-    // omit thinkingBudget from thinkingConfig so the AI SDK's portable reasoning takes effect.
-    // Keep includeThoughts if set so reasoning output is still returned.
-    if (reasoning && reasoning !== 'provider-default') {
-      return {
-        vertex: {
-          ...(includeThoughts && {
-            thinkingConfig: {
-              includeThoughts: true,
-            },
-          }),
-        },
-      };
-    }
-
-    return {
-      vertex: {
-        ...((includeThoughts || thinkingBudget) && {
-          thinkingConfig: {
-            includeThoughts: includeThoughts && (thinkingBudget ?? 0) > 0,
-            thinkingBudget,
-          },
-        }),
-      },
-    };
+  if (!isVertexAiProvider(llmProvider)) {
+    return undefined;
   }
 
-  return undefined;
+  // Use model-specific overrides, falling back to provider defaults
+  const overrides = mergeModelProps(model, llmProvider, ['includeThoughts', 'thinkingBudget']);
+
+  return getGoogleFamilyProviderOptions('vertex', overrides.includeThoughts, overrides.thinkingBudget, reasoning);
 };
 
-const getVertexAiModelInfo = (_provider: ProviderProfile, modelId: string, allModelInfos: Record<string, ModelInfo>): ModelInfo | undefined => {
-  const fullModelId = `google-vertex/${modelId}`;
-  return allModelInfos[fullModelId];
-};
+const getVertexAiModelInfo = getModelInfoByPrefix('google-vertex');
 
 // === Complete Strategy Implementation ===
 export const vertexAiProviderStrategy: LlmProviderStrategy = {

--- a/src/main/models/providers/zai-plan.ts
+++ b/src/main/models/providers/zai-plan.ts
@@ -1,193 +1,107 @@
-import { Model, ModelInfo, ProviderProfile, Reasoning, ReasoningEffort, SettingsData } from '@common/types';
-import { isZaiPlanProvider, LlmProvider, ZaiPlanProvider } from '@common/agent';
+import { isZaiPlanProvider, LlmProvider } from '@common/agent';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
-
-import { getDefaultUsageReport } from './default';
+import { Model, Reasoning, ReasoningEffort } from '@common/types';
 
 import type { SharedV4ProviderOptions } from '@ai-sdk/provider';
-import type { LanguageModel } from 'ai';
 
-import { AiderModelMapping, LlmProviderStrategy, LoadModelsResponse } from '@/models';
-import logger from '@/logger';
-import { getEffectiveEnvironmentVariable } from '@/utils';
+import { LlmProviderStrategy } from '@/models';
+import { createStrategyFromDescriptor } from '@/models/providers/strategy-factory';
+import { getModelInfoByPrefix, mergeModelProps } from '@/models/providers/shared';
 
-const loadZaiPlanModels = async (profile: ProviderProfile, settings: SettingsData): Promise<LoadModelsResponse> => {
-  if (!isZaiPlanProvider(profile.provider)) {
-    return { models: [], success: false };
-  }
-
-  const provider = profile.provider as ZaiPlanProvider;
-  const apiKey = provider.apiKey || '';
-
-  const apiKeyEnv = getEffectiveEnvironmentVariable('OPENAI_API_KEY', settings);
-
-  const effectiveApiKey = apiKey || apiKeyEnv?.value;
-
-  if (!effectiveApiKey) {
-    return { models: [], success: false };
-  }
-
-  try {
-    // ZAI uses specific endpoint for model discovery
-    const response = await fetch('https://api.z.ai/api/paas/v4/models', {
-      headers: { Authorization: `Bearer ${effectiveApiKey}` },
-    });
-    if (!response.ok) {
-      const errorMsg = `ZAI models API response failed: ${response.status} ${response.statusText} ${await response.text()}`;
-      logger.debug(errorMsg);
-      return { models: [], success: false, error: errorMsg };
-    }
-
-    const data = await response.json();
-    const models =
-      data.data?.map((model: { id: string }) => {
-        return {
-          id: model.id,
-          providerId: profile.id,
-          temperature: 0.7, // Default temperature for ZAI models
-        } satisfies Model;
-      }) || [];
-
-    logger.info(`Loaded ${models.length} ZAI models for profile ${profile.id}`);
-    return { models, success: true };
-  } catch (error) {
-    const errorMsg = typeof error === 'string' ? error : error instanceof Error ? error.message : 'Unknown error loading ZAI models';
-    logger.warn('Failed to fetch ZAI models via API:', error);
-    return { models: [], success: false, error: errorMsg };
-  }
-};
-
-const hasZaiPlanEnvVars = (): boolean => false;
-
-const getZaiPlanAiderMapping = (provider: ProviderProfile, modelId: string, settings: SettingsData, projectDir: string): AiderModelMapping => {
-  const zaiProvider = provider.provider as ZaiPlanProvider;
-  const envVars: Record<string, string> = {};
-
-  if (zaiProvider.apiKey) {
-    envVars.OPENAI_API_KEY = zaiProvider.apiKey;
-  } else {
-    const effectiveVar = getEffectiveEnvironmentVariable('ZAI_API_KEY', settings, projectDir);
-    if (effectiveVar) {
-      envVars.OPENAI_API_KEY = effectiveVar.value;
-    }
-  }
-
-  // Set the base URL for ZAI Plan
-  envVars.OPENAI_API_BASE = 'https://api.z.ai/api/coding/paas/v4';
-
-  // Use zai-plan prefix for ZAI providers
-  return {
-    modelName: `openai/${modelId}`,
-    environmentVariables: envVars,
-  };
-};
-
-// === LLM Creation Functions ===
-const createZaiPlanLlm = (profile: ProviderProfile, model: Model, settings: SettingsData, projectDir: string): LanguageModel => {
-  const provider = profile.provider as ZaiPlanProvider;
-  let apiKey = provider.apiKey;
-
-  if (!apiKey) {
-    const effectiveVar = getEffectiveEnvironmentVariable('ZAI_API_KEY', settings, projectDir);
-    if (effectiveVar) {
-      apiKey = effectiveVar.value;
-      logger.debug(`Loaded ZAI_API_KEY from ${effectiveVar.source}`);
-    }
-  }
-
-  if (!apiKey) {
-    throw new Error(`API key is required for ${provider.name}. Check Providers settings or Aider environment variables (ZAI_API_KEY).`);
-  }
-
-  // Use createOpenAICompatible to get a provider instance, then get the model
-  // ZAI uses specific base URL for chat completions
-  const compatibleProvider = createOpenAICompatible({
-    name: provider.name,
-    apiKey,
-    baseURL: 'https://api.z.ai/api/coding/paas/v4',
-    headers: profile.headers,
-  });
-  return compatibleProvider(model.id);
-};
-
-const getZaiPlanModelInfo = (_provider: ProviderProfile, modelId: string, allModelInfos: Record<string, ModelInfo>): ModelInfo | undefined => {
-  const fullModelId = `zai-coding-plan/${modelId}`;
-  return allModelInfos[fullModelId];
-};
+const ZAI_PLAN_BASE_URL = 'https://api.z.ai/api/coding/paas/v4';
 
 const getZaiPlanProviderOptions = (llmProvider: LlmProvider, model: Model, reasoning?: Reasoning): SharedV4ProviderOptions | undefined => {
-  if (isZaiPlanProvider(llmProvider)) {
-    const providerOverrides = model.providerOverrides as Partial<ZaiPlanProvider> | undefined;
-    const thinkingEnabled = providerOverrides?.thinkingEnabled ?? llmProvider.thinkingEnabled ?? true;
-    const reasoningEffort = providerOverrides?.reasoningEffort ?? llmProvider.reasoningEffort ?? ReasoningEffort.Max;
-    const toolCallStreamingDisabled = providerOverrides?.disableToolCallStreaming ?? llmProvider.disableToolCallStreaming ?? false;
+  if (!isZaiPlanProvider(llmProvider)) {
+    return undefined;
+  }
 
-    const toolStreamOption = toolCallStreamingDisabled ? {} : { tool_stream: true };
+  const overrides = mergeModelProps(model, llmProvider, ['thinkingEnabled', 'reasoningEffort', 'disableToolCallStreaming']);
+  const thinkingEnabled = overrides.thinkingEnabled ?? true;
+  const reasoningEffort = overrides.reasoningEffort ?? ReasoningEffort.Max;
+  const toolCallStreamingDisabled = overrides.disableToolCallStreaming ?? false;
 
-    // When the top-level reasoning parameter is set (not undefined or 'provider-default'),
-    // omit thinking and reasoningEffort so the AI SDK's portable reasoning takes effect.
-    // For 'none', explicitly disable thinking. Keep tool_stream if set.
-    if (reasoning && reasoning !== 'provider-default') {
-      if (reasoning === 'none') {
-        return {
-          zaiPlan: {
-            thinking: { type: 'disabled' },
-            ...toolStreamOption,
-          },
-        } as SharedV4ProviderOptions;
-      }
-      if (Object.keys(toolStreamOption).length > 0) {
-        return {
-          zaiPlan: toolStreamOption,
-        } as SharedV4ProviderOptions;
-      }
-      return undefined;
-    }
+  const toolStreamOption = toolCallStreamingDisabled ? {} : { tool_stream: true };
 
-    // Only disable thinking if explicitly set to false
-    if (thinkingEnabled === false) {
+  // When the top-level reasoning parameter is set (not undefined or 'provider-default'),
+  // omit thinking and reasoningEffort so the AI SDK's portable reasoning takes effect.
+  // For 'none', explicitly disable thinking. Keep tool_stream if set.
+  if (reasoning && reasoning !== 'provider-default') {
+    if (reasoning === 'none') {
       return {
         zaiPlan: {
-          thinking: {
-            type: 'disabled',
-          },
+          thinking: { type: 'disabled' },
           ...toolStreamOption,
         },
       } as SharedV4ProviderOptions;
     }
-
-    const mappedReasoningEffort = reasoningEffort === ReasoningEffort.None ? undefined : (reasoningEffort.toLowerCase() as 'max' | 'high');
-
-    if (mappedReasoningEffort) {
-      return {
-        zaiPlan: {
-          reasoningEffort: mappedReasoningEffort,
-          ...toolStreamOption,
-        },
-      } as SharedV4ProviderOptions;
-    }
-
     if (Object.keys(toolStreamOption).length > 0) {
       return {
         zaiPlan: toolStreamOption,
       } as SharedV4ProviderOptions;
     }
+    return undefined;
+  }
+
+  // Only disable thinking if explicitly set to false
+  if (thinkingEnabled === false) {
+    return {
+      zaiPlan: {
+        thinking: {
+          type: 'disabled',
+        },
+        ...toolStreamOption,
+      },
+    } as SharedV4ProviderOptions;
+  }
+
+  const mappedReasoningEffort = reasoningEffort === ReasoningEffort.None ? undefined : (reasoningEffort.toLowerCase() as 'max' | 'high');
+
+  if (mappedReasoningEffort) {
+    return {
+      zaiPlan: {
+        reasoningEffort: mappedReasoningEffort,
+        ...toolStreamOption,
+      },
+    } as SharedV4ProviderOptions;
+  }
+
+  if (Object.keys(toolStreamOption).length > 0) {
+    return {
+      zaiPlan: toolStreamOption,
+    } as SharedV4ProviderOptions;
   }
 
   return undefined;
 };
 
-// === Complete Strategy Implementation ===
-export const zaiPlanProviderStrategy: LlmProviderStrategy = {
-  // Core LLM functions
-  createLlm: createZaiPlanLlm,
-  getUsageReport: getDefaultUsageReport,
-
-  // Model discovery functions
-  loadModels: loadZaiPlanModels,
-  hasEnvVars: hasZaiPlanEnvVars,
-  getAiderMapping: getZaiPlanAiderMapping,
-  getModelInfo: getZaiPlanModelInfo,
-
-  getProviderOptions: getZaiPlanProviderOptions,
-};
+export const zaiPlanProviderStrategy: LlmProviderStrategy = createStrategyFromDescriptor({
+  name: 'zai-plan',
+  label: 'ZAI Plan',
+  sdkFactory: createOpenAICompatible,
+  apiKeyEnv: 'ZAI_API_KEY',
+  apiKeyRequired: (provider) => `API key is required for ${provider.name}. Check Providers settings or Aider environment variables (ZAI_API_KEY).`,
+  fixedBaseURL: ZAI_PLAN_BASE_URL,
+  extraFactoryOptions: ({ provider }) => ({ name: provider.name }),
+  isProvider: isZaiPlanProvider,
+  modelsLoader: {
+    type: 'openai-compatible',
+    // ZAI uses a specific endpoint (api/paas) for model discovery, different from chats (api/coding)
+    url: 'https://api.z.ai/api/paas/v4/models',
+    notOkLog: 'debug',
+    catchLog: 'warn',
+    mapper: (id) => ({ id, temperature: 0.7 }),
+  },
+  // only configured via provider API keys; no Aider env var is checked
+  hasEnvVars: false,
+  aider: {
+    prefix: 'openai',
+    apiKeyEnv: 'OPENAI_API_KEY',
+    sourceEnvKey: 'ZAI_API_KEY',
+    readEnvFallback: true,
+    upstreamBaseUrl: ZAI_PLAN_BASE_URL,
+  },
+  overrides: {
+    getModelInfo: getModelInfoByPrefix('zai-coding-plan'),
+    getProviderOptions: getZaiPlanProviderOptions,
+  },
+});

--- a/src/main/utils/open-url.ts
+++ b/src/main/utils/open-url.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execFileSync, spawnSync } from 'child_process';
 import { join } from 'path';
 import os from 'os';
 
@@ -6,6 +6,38 @@ import icon from '../../../resources/icon.png?asset';
 
 import { isElectron } from '@/app';
 import logger from '@/logger';
+
+/**
+ * Credential-like query parameters: names whose values must never reach the
+ * log files. Redaction is name-based (case-insensitive) and bounded to the
+ * `=`-terminated name, so ordinary parameters (e.g. `sort=key`, `q=auth`) are
+ * left untouched.
+ */
+const CREDENTIAL_QUERY_PARAMS = /([?&#])(token|key|auth|secret|password|passwd|api_?key|access_?token|refresh_?token|id_?token|client_?secret)=[^&#]*/gi;
+
+/**
+ * Redacts credentials (extension-provided URLs commonly carry unguessable auth
+ * tokens such as a `?token=...` review-server token): userinfo
+ * (`user:pass@host`, including the token-as-username basic-auth idiom) and
+ * credential-like query parameters in both the query string and `#` fragment,
+ * across repeated occurrences and any letter case, so they never reach the log
+ * files. The actual URL dispatch must always receive the raw, unmodified URL.
+ */
+export const redactTokenQueryParam = (url: string): string =>
+  url
+    // userinfo: keep the scheme, drop the credentials entirely.
+    .replace(/([a-z][a-z0-9+.-]*:\/\/)[^\s/?#@\]]*@/gi, '$1<hidden>@')
+    // credential-like query/fragment parameters: keep the name, hide the value.
+    .replace(CREDENTIAL_QUERY_PARAMS, '$1$2=<hidden>');
+
+/**
+ * Stringifies an error for logging with token-bearing URL fragments redacted.
+ * Child-process errors (e.g. a failed browser dispatch) embed the full command
+ * (program + arguments) including the raw URL, so success-path redaction alone
+ * is not enough on failure paths. Only the log string is redacted — rethrown
+ * errors and dispatched URLs always stay untouched.
+ */
+export const redactErrorForLog = (error: unknown): string => redactTokenQueryParam(error instanceof Error ? error.message : String(error));
 
 /**
  * Opens a URL either in external browser or a new BrowserWindow.
@@ -16,7 +48,7 @@ import logger from '@/logger';
  * @param title - Window title (only used when opening in a new window)
  */
 export const openUrl = async (url: string, target: 'external' | 'window' = 'window', title?: string): Promise<Electron.BrowserWindow | null> => {
-  logger.debug(`[openUrl] Opening URL: ${url} (position: ${target})`);
+  logger.debug(`[openUrl] Opening URL: ${redactTokenQueryParam(url)} (position: ${target})`);
 
   if (isElectron()) {
     const { shell, BrowserWindow } = await import('electron');
@@ -47,7 +79,9 @@ export const openUrl = async (url: string, target: 'external' | 'window' = 'wind
         await win.loadURL(loadUrl);
         return win;
       } catch (error) {
-        logger.error('[openUrl] Failed to create BrowserWindow:', error);
+        // The error message may embed the raw, token-bearing URL (e.g. from a
+        // failed loadURL) — redact only what reaches the log.
+        logger.error('[openUrl] Failed to create BrowserWindow:', redactErrorForLog(error));
         throw error;
       }
     } else {
@@ -64,32 +98,55 @@ export const openUrl = async (url: string, target: 'external' | 'window' = 'wind
 };
 
 /**
+ * Quotes a value for the `cmd.exe /c start "" <browser> <url>` command line.
+ * Each argument is embedded as one double-quoted string, so cmd metacharacters
+ * that appear inside a URL (`&`, `|`, `(`, `)`, `^`) stay literal arguments to
+ * `start` instead of command separators. Double quotes never occur in valid
+ * URLs and would break the quoting — they are stripped from the cmd-line value
+ * only. Residual cmd quirk: `%VAR%`-shaped spans inside a URL could be expanded
+ * as environment variables by cmd (documented platform limitation).
+ */
+const cmdQuote = (value: string): string => `"${value.replace(/"/g, '')}"`;
+
+/**
  * Opens a URL in the system's default browser using platform-specific commands.
  * Works in Node.js environments without Electron.
+ *
+ * Dispatch is argument-array based (`execFileSync` with no shell), so shells
+ * and shell-style substitution in the URL or browser path (`$(...)`,
+ * backticks, `;`, pipes) are never interpreted — the URL reaches the browser
+ * opener as a single raw argv element. The only exception is the Windows/WSL
+ * path: `cmd.exe /c start` is itself a shell, so its arguments are
+ * pre-quoted via cmdQuote (+ windowsVerbatimArguments, which joins the argv
+ * array verbatim) as defense in depth.
  */
 const openInExternalBrowser = (url: string): void => {
   try {
-    const browser = process.env.PLANNOTATOR_BROWSER || process.env.BROWSER;
+    const browser = process.env.AIDER_DESK_BROWSER || process.env.BROWSER;
     const platform = process.platform;
     const wsl = platform === 'linux' && os.release().toLowerCase().includes('microsoft');
 
-    if (browser) {
-      if (process.env.PLANNOTATOR_BROWSER && platform === 'darwin') {
-        execSync(`open -a ${JSON.stringify(browser)} ${JSON.stringify(url)}`, { stdio: 'ignore' });
-      } else if (platform === 'win32' || wsl) {
-        execSync(`cmd.exe /c start "" ${JSON.stringify(browser)} ${JSON.stringify(url)}`, { stdio: 'ignore' });
-      } else {
-        execSync(`${JSON.stringify(browser)} ${JSON.stringify(url)}`, { stdio: 'ignore' });
-      }
-    } else if (platform === 'win32' || wsl) {
-      execSync(`cmd.exe /c start "" ${JSON.stringify(url)}`, { stdio: 'ignore' });
+    if (platform === 'win32' || wsl) {
+      // `start` treats the first quoted argument as the window title, hence the
+      // empty `""` placeholder; the optional browser path follows second.
+      spawnSync('cmd.exe', ['/d', '/s', '/c', 'start', '', ...(browser ? [cmdQuote(browser)] : []), cmdQuote(url)], {
+        stdio: 'ignore',
+        windowsVerbatimArguments: true,
+      });
+    } else if (browser && process.env.AIDER_DESK_BROWSER && platform === 'darwin') {
+      execFileSync('open', ['-a', browser, url], { stdio: 'ignore' });
+    } else if (browser) {
+      // Browser binary and URL are separate argv entries — never a shell string.
+      execFileSync(browser, [url], { stdio: 'ignore' });
     } else if (platform === 'darwin') {
-      execSync(`open ${JSON.stringify(url)}`, { stdio: 'ignore' });
+      execFileSync('open', [url], { stdio: 'ignore' });
     } else {
-      execSync(`xdg-open ${JSON.stringify(url)}`, { stdio: 'ignore' });
+      execFileSync('xdg-open', [url], { stdio: 'ignore' });
     }
   } catch (error) {
-    logger.error('[openUrl] Failed to open URL in external browser:', error);
+    // Child-process errors embed the full command (including any token-bearing
+    // URL) in their message — redact only the log string, then rethrow unchanged.
+    logger.error('[openUrl] Failed to open URL in external browser:', redactErrorForLog(error));
     throw error;
   }
 };


### PR DESCRIPTION
## What

Extracts a shared kernel and descriptor-driven factory for the LLM provider system, collapsing ~50% of duplicated provider code, and carries the open-url security hardening that review turned up along the way.

## Why

- 28 provider strategies repeated the same credential resolution, model loading, and Aider mapping blocks with minor deltas.
- Extension provider strategies drifted from core strategies in signatures and defaults.
- Model metadata, pricing, and override semantics were inconsistent between providers.
- The shared open-url browser dispatch and extension-provided-URL logging had shell injection paths and token leakage.

## How

- `shared.ts`: credential resolution (explicit provider value vs env fallback), OpenAI-compatible model loader, static catalogs, Aider mapping builder, override merging, error normalization.
- `strategy-factory.ts`: descriptor-generated strategies for simple API-key and fixed-URL providers; bespoke providers compose the kernel, overrides win.
- `google-family.ts`: deduplicated Gemini/Vertex usage-report and thinking-option logic (metadata key parameterized).
- Extension strategy callbacks accept a trailing optional `profile` (backward-compatible); adapter passes it through.
- Unified env names: `ZAI_API_KEY`, `LMSTUDIO_API_BASE`, `VERTEXAI_*`.
- `open-url.ts`: shell-free arg-array browser dispatch, centralized token/credential redaction on success and error paths; the extension-specific browser override env var is generalized to `AIDER_DESK_BROWSER`.

## Behavior changes

- Deliberate env renames documented in CHANGELOG.md; `open-url`'s extension-specific browser override env var is additionally generalized to `AIDER_DESK_BROWSER`.
- Requesty cost helper kept intentionally (different cache-penalty defaults).
- Provider enrichment now prefers canonical provider id when profile id and name both match catalog entries.

## Tests

- New snapshot suites lock createLlm, aider mappings, model loaders, and provider pricing parity.
- Full node (1442 tests), web (251 tests), and extensions (133 tests) suites pass.
