### PR TITLE
feat: add copy task id to command palette

### DIFF
--- a/packages/common/src/locales/en.json
+++ b/packages/common/src/locales/en.json
@@ -31,6 +31,8 @@
     "exportTaskImage": "Export Task as Image",
     "exportTaskMarkdown": "Export Task as Markdown",
     "copyTaskMarkdown": "Copy Task as Markdown",
+    "copyTaskId": "Copy task id",
+    "copyTaskIdFailed": "Failed to copy task id",
     "interruptResponse": "Interrupt Response",
     "restartConnector": "Restart Aider Connector",
     "togglePin": "Toggle Pin",

--- a/packages/common/src/locales/ko.json
+++ b/packages/common/src/locales/ko.json
@@ -31,6 +31,8 @@
     "exportTaskImage": "작업을 이미지로 내보내기",
     "exportTaskMarkdown": "작업을 Markdown으로 내보내기",
     "copyTaskMarkdown": "작업을 Markdown으로 복사",
+    "copyTaskId": "작업 ID 복사",
+    "copyTaskIdFailed": "작업 ID 복사 실패",
     "interruptResponse": "응답 중단",
     "restartConnector": "Aider 커넥터 재시작",
     "togglePin": "고정 전환",

--- a/packages/common/src/locales/ru.json
+++ b/packages/common/src/locales/ru.json
@@ -31,6 +31,8 @@
     "exportTaskImage": "Экспортировать задачу как изображение",
     "exportTaskMarkdown": "Экспортировать задачу как Markdown",
     "copyTaskMarkdown": "Копировать задачу как Markdown",
+    "copyTaskId": "Копировать ID задачи",
+    "copyTaskIdFailed": "Не удалось скопировать ID задачи",
     "interruptResponse": "Прервать ответ",
     "restartConnector": "Перезапустить коннектор Aider",
     "togglePin": "Переключить закрепление",

--- a/packages/common/src/locales/zh.json
+++ b/packages/common/src/locales/zh.json
@@ -31,6 +31,8 @@
     "exportTaskImage": "导出任务为图片",
     "exportTaskMarkdown": "导出任务为Markdown",
     "copyTaskMarkdown": "复制任务为Markdown",
+    "copyTaskId": "复制任务 ID",
+    "copyTaskIdFailed": "复制任务 ID 失败",
     "interruptResponse": "中断响应",
     "restartConnector": "重启Aider连接器",
     "togglePin": "切换固定",

--- a/packages/common/src/ui-actions.ts
+++ b/packages/common/src/ui-actions.ts
@@ -37,6 +37,7 @@ export const UI_ACTIONS = [
   { id: 'task.exportImage', labelKey: 'uiActions.exportTaskImage' },
   { id: 'task.exportMarkdown', labelKey: 'uiActions.exportTaskMarkdown' },
   { id: 'task.copyMarkdown', labelKey: 'uiActions.copyTaskMarkdown' },
+  { id: 'task.copyId', labelKey: 'uiActions.copyTaskId' },
   { id: 'task.interrupt', labelKey: 'uiActions.interruptResponse' },
   { id: 'task.restartConnector', labelKey: 'uiActions.restartConnector' },
   { id: 'task.togglePin', labelKey: 'uiActions.togglePin' },

--- a/src/renderer/src/components/project/ProjectView.tsx
+++ b/src/renderer/src/components/project/ProjectView.tsx
@@ -32,7 +32,7 @@ import { useOverlayFocusRestore } from '@/hooks/useOverlayFocusRestore';
 import { useResponsive } from '@/hooks/useResponsive';
 import { useBooleanState } from '@/hooks/useBooleanState';
 import { showNotification } from '@/utils/browser-notifications';
-import { showErrorNotification, showInfoNotification } from '@/utils/notifications';
+import { showErrorNotification, showInfoNotification, showWarningNotification } from '@/utils/notifications';
 import { ExtensionsProvider } from '@/contexts/ExtensionsContext';
 import { FloatingExtensionPanels } from '@/components/extensions/FloatingExtensionPanels';
 import { useFileEditorStore } from '@/stores/fileEditorStore';
@@ -568,6 +568,20 @@ export const ProjectView = ({ projectDir, isProjectActive = false, initialTaskId
     [api, projectDir, t],
   );
 
+  const handleCopyTaskId = useCallback(
+    async (taskId: string) => {
+      try {
+        await api.writeToClipboard(taskId);
+        showInfoNotification(t('taskSidebar.taskIdCopied', { taskId }));
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error('Failed to copy task id:', error);
+        showWarningNotification(t('uiActions.copyTaskIdFailed'));
+      }
+    },
+    [api, t],
+  );
+
   const handleDuplicateTask = useCallback(
     async (taskId: string) => {
       try {
@@ -645,6 +659,11 @@ export const ProjectView = ({ projectDir, isProjectActive = false, initialTaskId
           void handleCopyTaskAsMarkdown(activeTaskId);
         }
       },
+      'task.copyId': () => {
+        if (activeTaskId) {
+          void handleCopyTaskId(activeTaskId);
+        }
+      },
       'task.interrupt': () => {
         if (activeTaskId) {
           void api.interruptResponse(projectDir, activeTaskId);
@@ -694,6 +713,7 @@ export const ProjectView = ({ projectDir, isProjectActive = false, initialTaskId
     handleExportTaskToImage,
     handleExportTaskToMarkdown,
     handleCopyTaskAsMarkdown,
+    handleCopyTaskId,
     api,
     handleUpdateOptimisticTaskState,
     optimisticTasks,


### PR DESCRIPTION
Adds a "Copy task id" command to the command palette, writing the active task.id to the clipboard via the IPC clipboard API. Shows a notification on success and a warning when copying fails.