### PR TITLE
fix(tps): improve streaming and subagent rates

### DIFF
--- a/packages/extensions/extensions/tps-counter/TPSCounter.jsx
+++ b/packages/extensions/extensions/tps-counter/TPSCounter.jsx
@@ -1,12 +1,33 @@
 ({ data }) => {
-  if (!data || data.messageCount === 0) return null;
+  if (!data || (data.messageCount === 0 && !data.isStreaming)) return null;
 
-  const { averageTps } = data;
+  const liveLabel = data.isStreaming ? 'Live tokens/s:' : 'Last tokens/s:';
+  const liveTps = Math.round(data.currentTps);
 
   return (
-    <div className="flex items-center gap-1 text-2xs mt-1 w-full justify-between">
-      <span>Avg. tokens/s:</span>
-      <span>{Math.round(averageTps)}</span>
+    <div className="flex flex-col gap-1 text-2xs mt-1 w-full">
+      <div className="flex items-center justify-between">
+        <span>{liveLabel}</span>
+        <span>{liveTps}</span>
+      </div>
+      {!data.isStreaming && (
+        <div className="flex items-center justify-between">
+          <span>Avg. tokens/s:</span>
+          <span>{Math.round(data.averageTps)}</span>
+        </div>
+      )}
+      {data.peakTps > 0 && (
+        <div className="flex items-center justify-between text-text-muted">
+          <span>Peak:</span>
+          <span>{Math.round(data.peakTps)}</span>
+        </div>
+      )}
+      {data.subagentCount > 0 && (
+        <div className="flex items-center justify-between text-text-muted">
+          <span>Subagents ({data.subagentCount}):</span>
+          <span>{Math.round(data.subagentTps)} tokens/s</span>
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/extensions/extensions/tps-counter/TPSMessageBar.jsx
+++ b/packages/extensions/extensions/tps-counter/TPSMessageBar.jsx
@@ -1,16 +1,19 @@
 ({ data, message }) => {
   if (!data || !message?.id) return null;
 
-  const messageTps = data[message.id];
+  const messageId = message.responseMessage?.id || message.id;
+  const messageTps = data[messageId];
 
   if (!messageTps) return null;
 
+  const label = messageTps.isStreaming ? 'Live' : 'TPS';
+
   return (
     <span
-      className="text-2xs mt-[4px] text-text-muted group-hover:text-text-secondary transition-colors"
-      title={`${messageTps.tokens} tokens in ${messageTps.duration.toFixed(2)}s`}
+      className="text-2xs mt-[4px] pl-2 border-l border-border-dark-light text-text-muted group-hover:text-text-secondary transition-colors"
+      title={`${messageTps.tokens} tokens in ${messageTps.duration.toFixed(2)}s; peak ${Math.round(messageTps.peakTps)} TPS`}
     >
-      {Math.round(messageTps.tps)} TPS
+      {label} {Math.round(messageTps.tps)} TPS
     </span>
   );
 };

--- a/packages/extensions/extensions/tps-counter/__tests__/tps-counter.test.ts
+++ b/packages/extensions/extensions/tps-counter/__tests__/tps-counter.test.ts
@@ -1,0 +1,129 @@
+import type { ExtensionContext, ResponseChunkEvent, ResponseCompletedEvent } from '@aiderdesk/extensions';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import TPSCounterExtension from '../index';
+
+const createContext = (taskId?: string) => ({
+  triggerUIDataRefresh: vi.fn(),
+  log: vi.fn(),
+  getTaskContext: taskId ? () => ({ data: { id: taskId } }) : () => null,
+  getProjectContext: () => ({
+    getTasks: async () => [
+      { id: 'parent', parentId: null },
+      { id: 'child', parentId: 'parent' },
+    ],
+  }),
+}) as unknown as ExtensionContext;
+
+const createChunk = (messageId: string, chunk: string, reasoning?: string, taskId = 'task-1'): ResponseChunkEvent => ({
+  chunk: {
+    messageId,
+    baseDir: '/tmp/project',
+    taskId,
+    chunk,
+    reasoning,
+  },
+});
+
+const createCompletion = (messageId: string, receivedTokens?: number, taskId = 'task-1'): ResponseCompletedEvent => ({
+  response: {
+    type: 'response-completed',
+    messageId,
+    baseDir: '/tmp/project',
+    taskId,
+    content: 'completed response',
+    usageReport: receivedTokens === undefined
+      ? undefined
+      : { model: 'test-model', sentTokens: 1, receivedTokens, messageCost: 0 },
+  },
+});
+
+describe('TPSCounterExtension', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('updates live TPS from streamed chunks and throttles refreshes', async () => {
+    vi.spyOn(Date, 'now')
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(1_050)
+      .mockReturnValueOnce(1_200);
+    const extension = new TPSCounterExtension();
+    const context = createContext();
+
+    await extension.onResponseChunk(createChunk('message-1', '12345678'), context);
+    await extension.onResponseChunk(createChunk('message-1', '12345678'), context);
+
+    const data = await extension.getUIExtensionData('tps-counter', context) as {
+      currentTps: number;
+      currentTokens: number;
+      isStreaming: boolean;
+    };
+
+    expect(data.currentTokens).toBe(4);
+    expect(data.currentTps).toBeGreaterThan(0);
+    expect(data.currentTps).toBeLessThanOrEqual(4);
+    expect(data.isStreaming).toBe(true);
+    expect(context.triggerUIDataRefresh).toHaveBeenCalledTimes(4);
+  });
+
+  it('uses provider usage when available and streamed tokens as fallback', async () => {
+    vi.spyOn(Date, 'now')
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(2_000)
+      .mockReturnValueOnce(2_000)
+      .mockReturnValueOnce(3_000)
+      .mockReturnValueOnce(3_000)
+      .mockReturnValueOnce(4_000)
+      .mockReturnValueOnce(4_000);
+    const extension = new TPSCounterExtension();
+    const context = createContext();
+
+    await extension.onResponseChunk(createChunk('reported', '1234'), context);
+    await extension.onResponseCompleted(createCompletion('reported', 20), context);
+    await extension.onResponseChunk(createChunk('fallback', '12345678'), context);
+    await extension.onResponseCompleted(createCompletion('fallback'), context);
+
+    const data = await extension.getUIExtensionData('tps-counter', context) as {
+      totalTokens: number;
+      messageCount: number;
+      isStreaming: boolean;
+    };
+    const messages = await extension.getUIExtensionData('tps-counter-message-bar', context) as Record<string, { tokens: number }>;
+
+    expect(data.totalTokens).toBe(22);
+    expect(data.messageCount).toBe(2);
+    expect(data.isStreaming).toBe(false);
+    expect(messages.reported.tokens).toBe(20);
+    expect(messages.fallback.tokens).toBe(2);
+  });
+
+  it('keeps parent TPS separate and exposes active subagent TPS on the parent dashboard', async () => {
+    let now = 1_000;
+    vi.spyOn(Date, 'now').mockImplementation(() => now);
+    const extension = new TPSCounterExtension();
+    const parentContext = createContext('parent');
+
+    await extension.onResponseChunk(createChunk('parent-message', '12345678', undefined, 'parent'), parentContext);
+    now = 2_000;
+    await extension.onResponseCompleted(createCompletion('parent-message', 4, 'parent'), parentContext);
+    now = 3_000;
+    await extension.onResponseChunk(createChunk('child-message', '12345678', undefined, 'child'), parentContext);
+    now = 4_000;
+    await extension.onResponseChunk(createChunk('child-message', '12345678', undefined, 'child'), parentContext);
+
+    const data = await extension.getUIExtensionData('tps-counter', parentContext) as {
+      currentTps: number;
+      subagentTps: number;
+      subagentCount: number;
+      isStreaming: boolean;
+    };
+
+    expect(data.currentTps).toBe(0);
+    expect(data.subagentTps).toBeGreaterThan(0);
+    expect(data.subagentCount).toBe(1);
+    expect(data.isStreaming).toBe(false);
+  });
+});

--- a/packages/extensions/extensions/tps-counter/index.ts
+++ b/packages/extensions/extensions/tps-counter/index.ts
@@ -8,15 +8,23 @@ interface TPSData {
   currentTokens: number;
   currentDuration: number;
   averageTps: number;
+  peakTps: number;
   totalTokens: number;
   totalDuration: number;
   messageCount: number;
+  isStreaming: boolean;
+  subagentTps: number;
+  subagentPeakTps: number;
+  subagentCount: number;
 }
 
 interface MessageTPSData {
+  taskId: string;
   tps: number;
+  peakTps: number;
   tokens: number;
   duration: number;
+  isStreaming: boolean;
 }
 
 interface Settings {
@@ -24,27 +32,44 @@ interface Settings {
   messageBarEnabled: boolean;
 }
 
+const REFRESH_INTERVAL_MS = 100;
+const MIN_RATE_WINDOW_SECONDS = 1;
+const CHARS_PER_TOKEN = 4;
+
+const emptyData = (): TPSData => ({
+  currentTps: 0,
+  currentTokens: 0,
+  currentDuration: 0,
+  averageTps: 0,
+  peakTps: 0,
+  totalTokens: 0,
+  totalDuration: 0,
+  messageCount: 0,
+  isStreaming: false,
+  subagentTps: 0,
+  subagentPeakTps: 0,
+  subagentCount: 0,
+});
+
 export default class TPSCounterExtension implements Extension {
   static metadata = {
     name: 'TPS Counter',
-    version: '1.1.1',
-    description: 'Displays tokens per second for agent responses',
+    version: '1.2.0',
+    description: 'Displays real-time and completed-response tokens per second',
     author: 'wladimiiir',
     iconUrl: 'https://raw.githubusercontent.com/hotovo/aider-desk/refs/heads/main/packages/extensions/extensions/tps-counter/icon.png',
     capabilities: ['metrics'],
   };
 
   private messageStartTimes: Map<string, number> = new Map();
+  private messageTokenCounts: Map<string, number> = new Map();
+  private messagePeakTps: Map<string, number> = new Map();
+  private messageLastRefreshTimes: Map<string, number> = new Map();
   private messageTpsData: Map<string, MessageTPSData> = new Map();
-  private currentData: TPSData = {
-    currentTps: 0,
-    currentTokens: 0,
-    currentDuration: 0,
-    averageTps: 0,
-    totalTokens: 0,
-    totalDuration: 0,
-    messageCount: 0,
-  };
+  private taskData: Map<string, TPSData> = new Map();
+  private activeMessageIds: Map<string, Set<string>> = new Map();
+  private messageTaskIds: Map<string, string> = new Map();
+  private currentData: TPSData = emptyData();
   private settings: Settings = { usageInfoEnabled: true, messageBarEnabled: true };
   private settingsPath = join(__dirname, 'settings.json');
 
@@ -68,6 +93,38 @@ export default class TPSCounterExtension implements Extension {
     }
   }
 
+  private estimateTokens(text: string | undefined, reasoning: string | undefined): number {
+    const characterCount = (text?.length ?? 0) + (reasoning?.length ?? 0);
+    return characterCount > 0 ? Math.max(1, Math.ceil(characterCount / CHARS_PER_TOKEN)) : 0;
+  }
+
+  private getTaskData(taskId: string): TPSData {
+    const existing = this.taskData.get(taskId);
+    if (existing) return existing;
+    const data = emptyData();
+    this.taskData.set(taskId, data);
+    return data;
+  }
+
+  private getLiveData(messageId: string, now: number): Omit<MessageTPSData, 'taskId'> {
+    const startedAt = this.messageStartTimes.get(messageId) ?? now;
+    const duration = Math.max(0, (now - startedAt) / 1000);
+    const tokens = this.messageTokenCounts.get(messageId) ?? 0;
+    const tps = tokens / Math.max(duration, MIN_RATE_WINDOW_SECONDS);
+    const peakTps = Math.max(this.messagePeakTps.get(messageId) ?? 0, tps);
+    this.messagePeakTps.set(messageId, peakTps);
+    return { tps, peakTps, tokens, duration, isStreaming: true };
+  }
+
+  private refreshUI(messageId: string, context: ExtensionContext, force = false): void {
+    const now = Date.now();
+    const lastRefresh = this.messageLastRefreshTimes.get(messageId) ?? 0;
+    if (!force && now - lastRefresh < REFRESH_INTERVAL_MS) return;
+    this.messageLastRefreshTimes.set(messageId, now);
+    context.triggerUIDataRefresh('tps-counter');
+    context.triggerUIDataRefresh('tps-counter-message-bar');
+  }
+
   async onLoad(context: ExtensionContext): Promise<void> {
     this.settings = this.loadSettings();
     context.log('TPS Counter extension loaded', 'info');
@@ -75,64 +132,134 @@ export default class TPSCounterExtension implements Extension {
 
   async onUnload(): Promise<void> {
     this.messageStartTimes.clear();
+    this.messageTokenCounts.clear();
+    this.messagePeakTps.clear();
+    this.messageLastRefreshTimes.clear();
     this.messageTpsData.clear();
-    this.currentData = {
-      currentTps: 0,
-      currentTokens: 0,
-      currentDuration: 0,
-      averageTps: 0,
-      totalTokens: 0,
-      totalDuration: 0,
-      messageCount: 0,
-    };
+    this.taskData.clear();
+    this.activeMessageIds.clear();
+    this.messageTaskIds.clear();
+    this.currentData = emptyData();
   }
 
-  async onResponseChunk(event: ResponseChunkEvent, _context: ExtensionContext): Promise<void> {
+  async onResponseChunk(event: ResponseChunkEvent, context: ExtensionContext): Promise<void> {
     const messageId = event.chunk.messageId;
+    const now = Date.now();
 
     if (!this.messageStartTimes.has(messageId)) {
-      this.messageStartTimes.set(messageId, Date.now());
+      this.messageStartTimes.set(messageId, now);
     }
+
+    const tokenIncrement = this.estimateTokens(event.chunk.chunk, event.chunk.reasoning);
+    this.messageTokenCounts.set(messageId, (this.messageTokenCounts.get(messageId) ?? 0) + tokenIncrement);
+
+    const taskId = event.chunk.taskId;
+    const taskData = this.getTaskData(taskId);
+    const liveData = this.getLiveData(messageId, now);
+    this.messageTaskIds.set(messageId, taskId);
+    this.messageTpsData.set(messageId, { taskId, ...liveData });
+    const activeMessages = this.activeMessageIds.get(taskId) ?? new Set<string>();
+    activeMessages.add(messageId);
+    this.activeMessageIds.set(taskId, activeMessages);
+    taskData.currentTps = liveData.tps;
+    taskData.currentTokens = liveData.tokens;
+    taskData.currentDuration = liveData.duration;
+    taskData.peakTps = Math.max(taskData.peakTps, liveData.peakTps);
+    taskData.isStreaming = true;
+    this.refreshUI(messageId, context);
   }
 
   async onResponseCompleted(event: ResponseCompletedEvent, context: ExtensionContext): Promise<void> {
     const messageId = event.response.messageId;
-    context.log(`[TPS] onResponseCompleted - messageId: ${messageId}`, 'debug');
     const startTime = this.messageStartTimes.get(messageId);
+    if (!startTime) return;
 
-    if (!startTime || !event.response.usageReport) {
-      context.log(`[TPS] onResponseCompleted - skipping (no startTime or usageReport)`, 'debug');
-      return;
-    }
-
+    const taskId = this.messageTaskIds.get(messageId) ?? event.response.promptContext?.id ?? 'unknown';
+    const taskData = this.getTaskData(taskId);
     const endTime = Date.now();
-    const durationMs = endTime - startTime;
-    const durationSeconds = durationMs / 1000;
+    const durationSeconds = Math.max(0, (endTime - startTime) / 1000);
+    const streamedTokens = this.messageTokenCounts.get(messageId) ?? 0;
+    const reportedTokens = event.response.usageReport?.receivedTokens ?? 0;
+    const totalTokens = reportedTokens > 0 ? reportedTokens : streamedTokens;
+    const currentTps = totalTokens / Math.max(durationSeconds, MIN_RATE_WINDOW_SECONDS);
+    const peakTps = Math.max(this.messagePeakTps.get(messageId) ?? 0, currentTps);
 
-    const receivedTokens = event.response.usageReport.receivedTokens || 0;
-    const totalTokens = receivedTokens;
-    const currentTps = durationSeconds > 0 ? totalTokens / durationSeconds : 0;
-
-    this.currentData.totalTokens += totalTokens;
-    this.currentData.totalDuration += durationSeconds;
-    this.currentData.messageCount += 1;
-
-    this.currentData.currentTps = currentTps;
-    this.currentData.currentTokens = totalTokens;
-    this.currentData.currentDuration = durationSeconds;
-    this.currentData.averageTps = this.currentData.totalDuration > 0 ? this.currentData.totalTokens / this.currentData.totalDuration : 0;
+    taskData.totalTokens += totalTokens;
+    taskData.totalDuration += durationSeconds;
+    taskData.messageCount += 1;
+    taskData.currentTps = currentTps;
+    taskData.currentTokens = totalTokens;
+    taskData.currentDuration = durationSeconds;
+    taskData.peakTps = Math.max(taskData.peakTps, peakTps);
+    taskData.averageTps = taskData.totalDuration > 0 ? taskData.totalTokens / taskData.totalDuration : 0;
+    const activeMessages = this.activeMessageIds.get(taskId);
+    activeMessages?.delete(messageId);
+    taskData.isStreaming = (activeMessages?.size ?? 0) > 0;
 
     this.messageTpsData.set(messageId, {
+      taskId,
       tps: currentTps,
+      peakTps,
       tokens: totalTokens,
       duration: durationSeconds,
+      isStreaming: false,
     });
 
-    context.log(`[TPS] messageTpsData keys after update: ${JSON.stringify([...this.messageTpsData.keys()])}`, 'debug');
-
     this.messageStartTimes.delete(messageId);
-    context.triggerUIDataRefresh('tps-counter');
-    context.triggerUIDataRefresh('tps-counter-message-bar');
+    this.messageTokenCounts.delete(messageId);
+    this.messagePeakTps.delete(messageId);
+    this.messageLastRefreshTimes.delete(messageId);
+    this.refreshUI(messageId, context, true);
+  }
+
+  private aggregateTaskData(taskIds: string[]): TPSData {
+    const result = emptyData();
+    for (const taskId of taskIds) {
+      const data = this.taskData.get(taskId);
+      if (!data) continue;
+      result.totalTokens += data.totalTokens;
+      result.totalDuration += data.totalDuration;
+      result.messageCount += data.messageCount;
+      result.currentTps += data.isStreaming ? data.currentTps : 0;
+      result.currentTokens += data.isStreaming ? data.currentTokens : 0;
+      result.currentDuration = Math.max(result.currentDuration, data.isStreaming ? data.currentDuration : 0);
+      result.peakTps = Math.max(result.peakTps, data.peakTps);
+      result.isStreaming ||= data.isStreaming;
+    }
+    result.averageTps = result.totalDuration > 0 ? result.totalTokens / result.totalDuration : 0;
+    return result;
+  }
+
+  private async getDashboardData(context: ExtensionContext): Promise<TPSData> {
+    const taskContext = context.getTaskContext();
+    if (!taskContext) return this.aggregateTaskData([...this.taskData.keys()]);
+
+    let tasks: Array<{ id: string; parentId?: string | null }> = [];
+    try {
+      const projectContext = context.getProjectContext() as unknown as { getTasks: () => Promise<Array<{ id: string; parentId?: string | null }>> };
+      tasks = await projectContext.getTasks();
+    } catch {
+      return this.aggregateTaskData([taskContext.data.id]);
+    }
+
+    const descendantIds = new Set<string>();
+    const collectDescendants = (parentId: string) => {
+      for (const task of tasks) {
+        if (task.parentId === parentId && !descendantIds.has(task.id)) {
+          descendantIds.add(task.id);
+          collectDescendants(task.id);
+        }
+      }
+    };
+    collectDescendants(taskContext.data.id);
+
+    const result = this.aggregateTaskData([taskContext.data.id]);
+    const activeSubagentIds = [...descendantIds].filter((taskId) => this.taskData.get(taskId)?.isStreaming);
+    const subagents = this.aggregateTaskData(activeSubagentIds);
+    result.subagentTps = subagents.currentTps;
+    result.subagentPeakTps = subagents.peakTps;
+    result.subagentCount = activeSubagentIds.length;
+    return result;
   }
 
   getUIComponents(_context: ExtensionContext): UIComponentDefinition[] {
@@ -140,38 +267,20 @@ export default class TPSCounterExtension implements Extension {
 
     if (this.settings.usageInfoEnabled) {
       const jsx = readFileSync(join(__dirname, './TPSCounter.jsx'), 'utf-8');
-      components.push({
-        id: 'tps-counter',
-        placement: 'task-usage-info-bottom',
-        jsx,
-        loadData: true,
-      });
+      components.push({ id: 'tps-counter', placement: 'task-usage-info-bottom', jsx, loadData: true });
     }
 
     if (this.settings.messageBarEnabled) {
       const messageBarJsx = readFileSync(join(__dirname, './TPSMessageBar.jsx'), 'utf-8');
-      components.push({
-        id: 'tps-counter-message-bar',
-        placement: 'task-message-bar',
-        jsx: messageBarJsx,
-        loadData: true,
-      });
+      components.push({ id: 'tps-counter-message-bar', placement: 'task-message-bar', jsx: messageBarJsx, loadData: true });
     }
 
     return components;
   }
 
-  async getUIExtensionData(componentId: string, context: ExtensionContext): Promise<unknown> {
-    if (componentId === 'tps-counter') {
-      return this.currentData;
-    }
-
-    if (componentId === 'tps-counter-message-bar') {
-      const data = Object.fromEntries(this.messageTpsData);
-      context.log(`[TPS] getUIExtensionData - returning keys: ${JSON.stringify(Object.keys(data))}`, 'debug');
-      return data;
-    }
-
+  async getUIExtensionData(componentId: string, _context: ExtensionContext): Promise<unknown> {
+    if (componentId === 'tps-counter') return this.getDashboardData(_context);
+    if (componentId === 'tps-counter-message-bar') return Object.fromEntries(this.messageTpsData);
     return undefined;
   }
 
@@ -184,9 +293,7 @@ export default class TPSCounterExtension implements Extension {
           this.settings.usageInfoEnabled = !this.settings.usageInfoEnabled;
           this.saveSettings();
           const taskContext = context.getTaskContext();
-          if (taskContext) {
-            taskContext.addLogMessage('info', `TPS usage info display ${this.settings.usageInfoEnabled ? 'enabled' : 'disabled'}`);
-          }
+          if (taskContext) taskContext.addLogMessage('info', `TPS usage info display ${this.settings.usageInfoEnabled ? 'enabled' : 'disabled'}`);
           context.triggerUIComponentsReload();
         },
       },
@@ -197,9 +304,7 @@ export default class TPSCounterExtension implements Extension {
           this.settings.messageBarEnabled = !this.settings.messageBarEnabled;
           this.saveSettings();
           const taskContext = context.getTaskContext();
-          if (taskContext) {
-            taskContext.addLogMessage('info', `TPS message bar display ${this.settings.messageBarEnabled ? 'enabled' : 'disabled'}`);
-          }
+          if (taskContext) taskContext.addLogMessage('info', `TPS message bar display ${this.settings.messageBarEnabled ? 'enabled' : 'disabled'}`);
           context.triggerUIComponentsReload();
         },
       },


### PR DESCRIPTION
Adds real-time per-message TPS beside token and cost usage.

Scopes dashboard metrics by task hierarchy and shows active descendant subagent throughput separately from the parent rate.

Uses provider usage when available, streamed-token fallback otherwise, and prevents unrealistic early-window TPS spikes.

Adds focused regression coverage for streaming, fallback usage, grouped messages, and parent/subagent behavior.

Focused tests pass: 3 tests.
